### PR TITLE
Fix for 's' units when setting string max_time

### DIFF
--- a/evalml/tests/automl_tests/test_autoclassifier.py
+++ b/evalml/tests/automl_tests/test_autoclassifier.py
@@ -264,6 +264,9 @@ def test_max_time_units():
     min_max_time = AutoClassifier(objective='F1', max_time='30 mins')
     assert min_max_time.max_time == 1800
 
+    min_max_time = AutoClassifier(objective='F1', max_time='30 s')
+    assert min_max_time.max_time == 30
+
     with pytest.raises(AssertionError, match="Invalid unit. Units must be hours, mins, or seconds. Received 'year'"):
         AutoClassifier(objective='F1', max_time='30 years')
 

--- a/evalml/utils/convert_time.py
+++ b/evalml/utils/convert_time.py
@@ -3,7 +3,7 @@ def convert_to_seconds(input_str):
     minutes = {'m', 'minute', 'min'}
     seconds = {'s', 'second', 'sec'}
     value, unit = input_str.split()
-    if unit[-1] == 's':
+    if unit[-1] == 's' and len(unit) != 1:
         unit = unit[:-1]
     if unit in seconds:
         return float(value)


### PR DESCRIPTION
Per Angela's comment on PR #125, this allows 's' units to be used for `max_time` 