### PR TITLE
Added notebooks as tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ lint-fix:
 .PHONY: test
 test:
 	pytest evalml/tests --cov=evalml
+	pytest --nbval-lax --ignore=docs/source/demos/fraud.ipynb docs/source/
 
 .PHONY: installdeps
 installdeps:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest==4.4.1
 pytest-xdist==1.26.1
 pytest-cov==2.6.1
+nbval==0.9.3


### PR DESCRIPTION
Adds running doc source notebooks as tests excluding the Fraud notebook as it takes too long.