### PR TITLE
Revert "Add python-dateutil to requirements" and switch to botocore

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 **Future Releases**
     * Enhancements
     * Fixes
+        * Lower botocore requirement :pr:`235`
     * Changes
         * Updating demo datasets to retain column names :pr:`223`
     * Documentation Changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+botocore<=1.13.8
+boto3<=1.10.8
 scipy>=1.2.1
 scikit-learn>=0.21.3
 dask[complete]>=2.1.0


### PR DESCRIPTION
Reverts FeatureLabs/evalml#234


```bash
(test1) RM-MB-114:evalml jeremy.shih$ pip install -r requirements.txt
Collecting botocore<=1.13.8 (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/34/f7/fce50110ae94feed24b5b2796cb2bd376345ceb480b9d4090e10be75d959/botocore-1.13.8-py2.py3-none-any.whl (5.3MB)
    100% |████████████████████████████████| 5.3MB 8.6MB/s
Collecting boto3<=1.10.8 (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/ea/be/ce6320d0341936efd97990f62b33aa2717513c12b16a8a2ed4301214e65a/boto3-1.10.8-py2.py3-none-any.whl (128kB)
    100% |████████████████████████████████| 133kB 31.8MB/s
Collecting scipy>=1.2.1 (from -r requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/c8/40/c7d54f604f41656be3eb8b8bd7d073050e3da08b5b0d32bba8c8c7023210/scipy-1.3.2-cp37-cp37m-macosx_10_6_intel.whl
Collecting scikit-learn>=0.21.3 (from -r requirements.txt (line 4))
  Using cached https://files.pythonhosted.org/packages/e9/57/8a9889d49d0d77905af5a7524fb2b468d2ef5fc723684f51f5ca63efed0d/scikit_learn-0.21.3-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting dask[complete]>=2.1.0 (from -r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/16/c6/d833bb656823031161f7fa085050dafc0f11949334a3c34d4a9392c54f46/dask-2.8.0-py3-none-any.whl
Collecting numpy>=1.16.4 (from -r requirements.txt (line 6))
  Using cached https://files.pythonhosted.org/packages/60/9a/a6b3168f2194fb468dcc4cf54c8344d1f514935006c3347ede198e968cb0/numpy-1.17.4-cp37-cp37m-macosx_10_9_x86_64.whl
Collecting pandas>=0.25.0 (from -r requirements.txt (line 7))
  Using cached https://files.pythonhosted.org/packages/16/b5/bab3477466a4d9e705d40829ac65683155e7977acbc07f05b06fabded1be/pandas-0.25.3-cp37-cp37m-macosx_10_9_x86_64.whl
Collecting xgboost>=0.82 (from -r requirements.txt (line 8))
Collecting tqdm>=4.33.0 (from -r requirements.txt (line 9))
  Using cached https://files.pythonhosted.org/packages/b9/08/8505f192efc72bfafec79655e1d8351d219e2b80b0dec4ae71f50934c17a/tqdm-4.38.0-py2.py3-none-any.whl
Collecting scikit-optimize[plots] (from -r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/f4/44/60f82c97d1caa98752c7da2c1681cab5c7a390a0fdd3a55fac672b321cac/scikit_optimize-0.5.2-py2.py3-none-any.whl
Collecting colorama (from -r requirements.txt (line 11))
  Using cached https://files.pythonhosted.org/packages/4f/a6/728666f39bfff1719fc94c481890b2106837da9318031f71a8424b662e12/colorama-0.4.1-py2.py3-none-any.whl
Collecting s3fs==0.2.2 (from -r requirements.txt (line 12))
Collecting joblib>=0.10.3 (from -r requirements.txt (line 13))
  Using cached https://files.pythonhosted.org/packages/8f/42/155696f85f344c066e17af287359c9786b436b1bf86029bb3411283274f3/joblib-0.14.0-py2.py3-none-any.whl
Collecting category_encoders>=2.0.0 (from -r requirements.txt (line 14))
  Using cached https://files.pythonhosted.org/packages/a0/52/c54191ad3782de633ea3d6ee3bb2837bda0cf3bc97644bb6375cf14150a0/category_encoders-2.1.0-py2.py3-none-any.whl
Collecting cloudpickle>=0.2.2 (from -r requirements.txt (line 15))
  Using cached https://files.pythonhosted.org/packages/c1/49/334e279caa3231255725c8e860fa93e72083567625573421db8875846c14/cloudpickle-1.2.2-py2.py3-none-any.whl
Collecting jmespath<1.0.0,>=0.7.1 (from botocore<=1.13.8->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/83/94/7179c3832a6d45b266ddb2aac329e101367fbdb11f425f13771d27f225bb/jmespath-0.9.4-py2.py3-none-any.whl
Collecting urllib3<1.26,>=1.20; python_version >= "3.4" (from botocore<=1.13.8->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/b4/40/a9837291310ee1ccc242ceb6ebfd9eb21539649f193a7c8c86ba15b98539/urllib3-1.25.7-py2.py3-none-any.whl
Collecting docutils<0.16,>=0.10 (from botocore<=1.13.8->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl
Collecting python-dateutil<3.0.0,>=2.1; python_version >= "2.7" (from botocore<=1.13.8->-r requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
Collecting s3transfer<0.3.0,>=0.2.0 (from boto3<=1.10.8->-r requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/16/8a/1fc3dba0c4923c2a76e1ff0d52b305c44606da63f718d14d3231e21c51b0/s3transfer-0.2.1-py2.py3-none-any.whl
Collecting distributed>=2.0; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Downloading https://files.pythonhosted.org/packages/4e/90/9f4f4c8a21818666d85dfe1b1f267776788929749cf6c49bad087cb94679/distributed-2.8.0-py3-none-any.whl (567kB)
    100% |████████████████████████████████| 573kB 24.5MB/s
Collecting toolz>=0.7.3; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
Collecting partd>=0.3.10; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/8b/17/09c352519da1db31634979c3aa9126078e9ece0f561c5f641e0649b78905/partd-1.0.0-py2.py3-none-any.whl
Collecting fsspec>=0.6.0; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/4f/d9/40c970ef234cd3054c9cd6c087b92f24ea5b1209c87dcb931e28a72dbc29/fsspec-0.6.0-py3-none-any.whl
Collecting PyYaml; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
Collecting bokeh>=1.0.0; extra == "complete" (from dask[complete]>=2.1.0->-r requirements.txt (line 5))
Collecting pytz>=2017.2 (from pandas>=0.25.0->-r requirements.txt (line 7))
  Using cached https://files.pythonhosted.org/packages/e7/f9/f0b53f88060247251bf481fa6ea62cd0d25bf1b11a87888e53ce5b7c8ad2/pytz-2019.3-py2.py3-none-any.whl
Collecting matplotlib; extra == "plots" (from scikit-optimize[plots]->-r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/c3/8b/af9e0984f5c0df06d3fab0bf396eb09cbf05f8452de4e9502b182f59c33b/matplotlib-3.1.1-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting six>=1.12.0 (from s3fs==0.2.2->-r requirements.txt (line 12))
  Using cached https://files.pythonhosted.org/packages/65/26/32b8464df2a97e6dd1b656ed26b2c194606c16fe163c695a992b36c11cdf/six-1.13.0-py2.py3-none-any.whl
Collecting statsmodels>=0.6.1 (from category_encoders>=2.0.0->-r requirements.txt (line 14))
  Using cached https://files.pythonhosted.org/packages/b5/b8/50f9b86bbd87b1de961f439c2b93dfc41dd0cb9d65f6b7d824b287b50b21/statsmodels-0.10.1-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting patsy>=0.4.1 (from category_encoders>=2.0.0->-r requirements.txt (line 14))
  Using cached https://files.pythonhosted.org/packages/ea/0c/5f61f1a3d4385d6bf83b83ea495068857ff8dfb89e74824c6e9eb63286d8/patsy-0.5.1-py2.py3-none-any.whl
Collecting click>=6.6 (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl
Collecting zict>=0.1.3 (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/64/b4/a904be4184814adb9dfc2e679c4e611392080a32726a657a34cab93b38c2/zict-1.0.0-py2.py3-none-any.whl
Collecting sortedcontainers!=2.0.0,!=2.0.1 (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/13/f3/cf85f7c3a2dbd1a515d51e1f1676d971abe41bba6f4ab5443240d9a78e5b/sortedcontainers-2.1.0-py2.py3-none-any.whl
Collecting msgpack (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/68/a6/18d0f681fa650a3ff10caf72cd04db1c602ebd74a3db25dc6d918b9943d7/msgpack-0.6.2-cp37-cp37m-macosx_10_14_x86_64.whl
Collecting psutil>=5.0 (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/03/9a/95c4b3d0424426e5fd94b5302ff74cea44d5d4f53466e1228ac8e73e14b4/psutil-5.6.5.tar.gz
Collecting tornado>=5 (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
Collecting tblib (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/6d/b1/32dd1c3e6f68856d9596abc649eae40ca914192b3f0f39fce91cf6747d90/tblib-1.5.0-py2.py3-none-any.whl
Collecting locket (from partd>=0.3.10; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
Collecting pillow>=4.0 (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/85/28/2c72ba965b52884a0bd71e419761fc162763dc2e5d9bec2f3b1949f7272a/Pillow-6.2.1-cp37-cp37m-macosx_10_6_intel.whl
Collecting packaging>=16.8 (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/cf/94/9672c2d4b126e74c4496c6b3c58a8b51d6419267be9e70660ba23374c875/packaging-19.2-py2.py3-none-any.whl
Collecting Jinja2>=2.7 (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/65/e0/eb35e762802015cab1ccee04e8a277b03f1d8e53da3ec3106882ec42558b/Jinja2-2.10.3-py2.py3-none-any.whl
Collecting cycler>=0.10 (from matplotlib; extra == "plots"->scikit-optimize[plots]->-r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/f7/d2/e07d3ebb2bd7af696440ce7e754c59dd546ffe1bbe732c8ab68b9c834e61/cycler-0.10.0-py2.py3-none-any.whl
Collecting kiwisolver>=1.0.1 (from matplotlib; extra == "plots"->scikit-optimize[plots]->-r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/df/93/8bc9b52a8846be2b9572aa0a7c881930939b06e4abe1162da6a0430b794f/kiwisolver-1.1.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 (from matplotlib; extra == "plots"->scikit-optimize[plots]->-r requirements.txt (line 10))
  Using cached https://files.pythonhosted.org/packages/c0/0c/fc2e007d9a992d997f04a80125b0f183da7fb554f1de701bbb70a8e7d479/pyparsing-2.4.5-py2.py3-none-any.whl
Collecting heapdict (from zict>=0.1.3->distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/b6/9d/cd4777dbcf3bef9d9627e0fe4bc43d2e294b1baeb01d0422399d5e9de319/HeapDict-1.0.1-py3-none-any.whl
Collecting MarkupSafe>=0.23 (from Jinja2>=2.7->bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->-r requirements.txt (line 5))
  Using cached https://files.pythonhosted.org/packages/ce/c6/f000f1af136ef74e4a95e33785921c73595c5390403f102e9b231b065b7a/MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl
Requirement already satisfied: setuptools in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from kiwisolver>=1.0.1->matplotlib; extra == "plots"->scikit-optimize[plots]->-r requirements.txt (line 10)) (40.8.0)
Installing collected packages: jmespath, urllib3, docutils, six, python-dateutil, botocore, s3transfer, boto3, numpy, scipy, joblib, scikit-learn, cloudpickle, click, heapdict, zict, sortedcontainers, PyYaml, msgpack, psutil, tornado, tblib, toolz, distributed, pytz, pandas, locket, partd, fsspec, pillow, pyparsing, packaging, MarkupSafe, Jinja2, bokeh, dask, xgboost, tqdm, cycler, kiwisolver, matplotlib, scikit-optimize, colorama, s3fs, patsy, statsmodels, category-encoders
  Running setup.py install for psutil ... done
Successfully installed Jinja2-2.10.3 MarkupSafe-1.1.1 PyYaml-5.1.2 bokeh-1.4.0 boto3-1.10.8 botocore-1.13.8 category-encoders-2.1.0 click-7.0 cloudpickle-1.2.2 colorama-0.4.1 cycler-0.10.0 dask-2.8.0 distributed-2.8.0 docutils-0.15.2 fsspec-0.6.0 heapdict-1.0.1 jmespath-0.9.4 joblib-0.14.0 kiwisolver-1.1.0 locket-0.2.0 matplotlib-3.1.1 msgpack-0.6.2 numpy-1.17.4 packaging-19.2 pandas-0.25.3 partd-1.0.0 patsy-0.5.1 pillow-6.2.1 psutil-5.6.5 pyparsing-2.4.5 python-dateutil-2.8.1 pytz-2019.3 s3fs-0.2.2 s3transfer-0.2.1 scikit-learn-0.21.3 scikit-optimize-0.5.2 scipy-1.3.2 six-1.13.0 sortedcontainers-2.1.0 statsmodels-0.10.1 tblib-1.5.0 toolz-0.10.0 tornado-6.0.3 tqdm-4.38.0 urllib3-1.25.7 xgboost-0.90 zict-1.0.0
You are using pip version 19.0.3, however version 19.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(test1) RM-MB-114:evalml jeremy.shih$ pip install -e .
Obtaining file:///Users/jeremy.shih/Documents/evalml
Requirement already satisfied: botocore<=1.13.8 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (1.13.8)
Requirement already satisfied: boto3<=1.10.8 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (1.10.8)
Requirement already satisfied: scipy>=1.2.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (1.3.2)
Requirement already satisfied: scikit-learn>=0.21.3 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.21.3)
Requirement already satisfied: dask[complete]>=2.1.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (2.8.0)
Requirement already satisfied: numpy>=1.16.4 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (1.17.4)
Requirement already satisfied: pandas>=0.25.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.25.3)
Requirement already satisfied: xgboost>=0.82 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.90)
Requirement already satisfied: tqdm>=4.33.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (4.38.0)
Requirement already satisfied: scikit-optimize[plots] in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.5.2)
Requirement already satisfied: colorama in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.4.1)
Requirement already satisfied: s3fs==0.2.2 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.2.2)
Requirement already satisfied: joblib>=0.10.3 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (0.14.0)
Requirement already satisfied: category_encoders>=2.0.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (2.1.0)
Requirement already satisfied: cloudpickle>=0.2.2 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from evalml==0.5.2) (1.2.2)
Requirement already satisfied: urllib3<1.26,>=1.20; python_version >= "3.4" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from botocore<=1.13.8->evalml==0.5.2) (1.25.7)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from botocore<=1.13.8->evalml==0.5.2) (0.9.4)
Requirement already satisfied: docutils<0.16,>=0.10 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from botocore<=1.13.8->evalml==0.5.2) (0.15.2)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1; python_version >= "2.7" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from botocore<=1.13.8->evalml==0.5.2) (2.8.1)
Requirement already satisfied: s3transfer<0.3.0,>=0.2.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from boto3<=1.10.8->evalml==0.5.2) (0.2.1)
Requirement already satisfied: toolz>=0.7.3; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (0.10.0)
Requirement already satisfied: distributed>=2.0; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (2.8.0)
Requirement already satisfied: bokeh>=1.0.0; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (1.4.0)
Requirement already satisfied: fsspec>=0.6.0; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (0.6.0)
Requirement already satisfied: partd>=0.3.10; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (1.0.0)
Requirement already satisfied: PyYaml; extra == "complete" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from dask[complete]>=2.1.0->evalml==0.5.2) (5.1.2)
Requirement already satisfied: pytz>=2017.2 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from pandas>=0.25.0->evalml==0.5.2) (2019.3)
Requirement already satisfied: matplotlib; extra == "plots" in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from scikit-optimize[plots]->evalml==0.5.2) (3.1.1)
Requirement already satisfied: six>=1.12.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from s3fs==0.2.2->evalml==0.5.2) (1.13.0)
Requirement already satisfied: patsy>=0.4.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from category_encoders>=2.0.0->evalml==0.5.2) (0.5.1)
Requirement already satisfied: statsmodels>=0.6.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from category_encoders>=2.0.0->evalml==0.5.2) (0.10.1)
Requirement already satisfied: sortedcontainers!=2.0.0,!=2.0.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (2.1.0)
Requirement already satisfied: zict>=0.1.3 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (1.0.0)
Requirement already satisfied: tornado>=5 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (6.0.3)
Requirement already satisfied: tblib in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (1.5.0)
Requirement already satisfied: msgpack in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (0.6.2)
Requirement already satisfied: click>=6.6 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (7.0)
Requirement already satisfied: psutil>=5.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (5.6.5)
Requirement already satisfied: pillow>=4.0 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (6.2.1)
Requirement already satisfied: packaging>=16.8 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (19.2)
Requirement already satisfied: Jinja2>=2.7 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (2.10.3)
Requirement already satisfied: locket in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from partd>=0.3.10; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (0.2.0)
Requirement already satisfied: kiwisolver>=1.0.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from matplotlib; extra == "plots"->scikit-optimize[plots]->evalml==0.5.2) (1.1.0)
Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from matplotlib; extra == "plots"->scikit-optimize[plots]->evalml==0.5.2) (2.4.5)
Requirement already satisfied: cycler>=0.10 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from matplotlib; extra == "plots"->scikit-optimize[plots]->evalml==0.5.2) (0.10.0)
Requirement already satisfied: heapdict in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from zict>=0.1.3->distributed>=2.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (1.0.1)
Requirement already satisfied: MarkupSafe>=0.23 in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from Jinja2>=2.7->bokeh>=1.0.0; extra == "complete"->dask[complete]>=2.1.0->evalml==0.5.2) (1.1.1)
Requirement already satisfied: setuptools in /Users/jeremy.shih/.pyenv/versions/3.7.4/envs/test1/lib/python3.7/site-packages (from kiwisolver>=1.0.1->matplotlib; extra == "plots"->scikit-optimize[plots]->evalml==0.5.2) (40.8.0)
Installing collected packages: evalml
  Running setup.py develop for evalml
Successfully installed evalml```