### PR TITLE
v0.6.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 ---------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+**v0.6.0 Dec. 16, 2019**
+    * Enhancements
         * Added ability to create a plot of feature importances :pr:`133`
         * Add early stopping to AutoML using patience and tolerance parameters :pr:`241`
         * Added ROC and confusion matrix metrics and plot for classification problems and introduce PipelineSearchPlots class :pr:`242`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -27,4 +27,4 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='evalml',
-    version='0.5.2',
+    version='0.6.0',
     author='Feature Labs, Inc.',
     author_email='support@featurelabs.com',
     url='http://www.featurelabs.com/',


### PR DESCRIPTION

## v0.6.0 (Dec. 16, 2019)

#### Enhancements
- Added ability to create a plot of feature importances #133 
- Add early stopping to AutoML using patience and tolerance parameters #241
- Added ROC and confusion matrix metrics and plot for classification problems and introduce PipelineSearchPlots class #242
- Enhanced AutoML results with search order #260

#### Fixes
- Lower botocore requirement #235
- Fixed decision_function calculation for FraudCost objective #254
- Fixed return value of Recall metrics #264

#### Changes
- Renamed automl classes to AutoRegressionSearch and AutoClassificationSearch #287
- Updating demo datasets to retain column names #223
- Moving pipeline visualization to PipelinePlots class #228
- Standarizing inputs as pd.Dataframe / pd.Series #130
- Enforcing that pipelines must have an estimator as last component #277
- Added ipywidgets as a dependency in requirements.txt #278

#### Documentation Changes
- Adding class properties to API reference #244
- Fix and filter FutureWarnings from scikit-learn #249, #257
- Adding Linear Regression to API reference and cleaning up some Sphinx warnings #227

#### Testing Changes
- Added support for testing on Windows with CircleCI #226
- Added support for doctests #233
        

#### Breaking Changes

- The ``fit()`` method for ``AutoClassifier`` and ``AutoRegressor`` has been renamed to ``search()``. 
- ``AutoClassifier`` has been renamed to ``AutoClassificationSearch``
- ``AutoRegressor`` has been renamed to ``AutoRegressionSearch``
- ``AutoClassificationSearch.results`` and ``AutoRegressionSearch.results`` now is a dictionary with ``pipeline_results`` and ``search_order`` keys. ``pipeline_results`` can be used to access a dictionary that is identical to the old ``.results`` dictionary. Whereas,``search_order`` returns a list of the search order in terms of pipeline id. 
-  Pipelines now require an estimator as the last component in `component_list`. Slicing pipelines now throws an NotImplementedError to avoid returning Pipelines without an estimator.

