### PR TITLE
WIP: Custom Pipelines Implementation (Remove static pipelines and reading in yaml)

### DIFF
--- a/evalml/pipelines/__init__.py
+++ b/evalml/pipelines/__init__.py
@@ -19,7 +19,12 @@ from .components import (
 )
 
 from .pipeline_base import PipelineBase
-
+from .classification import (
+    LogisticRegressionPipeline,
+    RFClassificationPipeline,
+    XGBoostPipeline
+)
+from .regression import LinearRegressionPipeline, RFRegressionPipeline
 from .utils import (
     get_component_lists,
     list_model_types,

--- a/evalml/pipelines/classification/__init__.py
+++ b/evalml/pipelines/classification/__init__.py
@@ -1,0 +1,4 @@
+# flake8:noqa
+from .logistic_regression import LogisticRegressionPipeline
+from .random_forest import RFClassificationPipeline
+from .xgboost import XGBoostPipeline

--- a/evalml/pipelines/classification/logistic_regression.py
+++ b/evalml/pipelines/classification/logistic_regression.py
@@ -1,0 +1,40 @@
+from skopt.space import Real
+
+from evalml.model_types import ModelTypes
+from evalml.pipelines import PipelineBase
+from evalml.pipelines.components import (
+    LogisticRegressionClassifier,
+    OneHotEncoder,
+    SimpleImputer,
+    StandardScaler
+)
+from evalml.problem_types import ProblemTypes
+
+
+class LogisticRegressionPipeline(PipelineBase):
+    """Logistic Regression Pipeline for both binary and multiclass classification"""
+    name = "Logistic Regression Classifier w/ One Hot Encoder + Simple Imputer + Standard Scaler"
+    model_type = ModelTypes.LINEAR_MODEL
+    problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
+
+    hyperparameters = {
+        "penalty": ["l2"],
+        "C": Real(.01, 10),
+        "impute_strategy": ["mean", "median", "most_frequent"],
+    }
+
+    def __init__(self, objective, penalty, C, impute_strategy,
+                 number_features, n_jobs=-1, random_state=0):
+
+        imputer = SimpleImputer(impute_strategy=impute_strategy)
+        enc = OneHotEncoder()
+        scaler = StandardScaler()
+        estimator = LogisticRegressionClassifier(random_state=random_state,
+                                                 penalty=penalty,
+                                                 C=C,
+                                                 n_jobs=-1)
+
+        super().__init__(objective=objective,
+                         component_list=[enc, imputer, scaler, estimator],
+                         n_jobs=n_jobs,
+                         random_state=random_state)

--- a/evalml/pipelines/classification/random_forest.py
+++ b/evalml/pipelines/classification/random_forest.py
@@ -1,0 +1,48 @@
+import numpy as np
+from skopt.space import Integer, Real
+
+from evalml.model_types import ModelTypes
+from evalml.pipelines import PipelineBase
+from evalml.pipelines.components import (
+    OneHotEncoder,
+    RandomForestClassifier,
+    RFClassifierSelectFromModel,
+    SimpleImputer
+)
+from evalml.problem_types import ProblemTypes
+
+
+class RFClassificationPipeline(PipelineBase):
+    """Random Forest Pipeline for both binary and multiclass classification"""
+    name = "Random Forest Classifier w/ One Hot Encoder + Simple Imputer + RF Classifier Select From Model"
+    model_type = ModelTypes.RANDOM_FOREST
+    problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
+
+    hyperparameters = {
+        "n_estimators": Integer(10, 1000),
+        "max_depth": Integer(1, 32),
+        "impute_strategy": ["mean", "median", "most_frequent"],
+        "percent_features": Real(.01, 1)
+    }
+
+    def __init__(self, objective, n_estimators, max_depth, impute_strategy,
+                 percent_features, number_features, n_jobs=-1, random_state=0):
+
+        imputer = SimpleImputer(impute_strategy=impute_strategy)
+        enc = OneHotEncoder()
+        estimator = RandomForestClassifier(n_estimators=n_estimators,
+                                           max_depth=max_depth,
+                                           n_jobs=n_jobs,
+                                           random_state=random_state)
+        feature_selection = RFClassifierSelectFromModel(n_estimators=n_estimators,
+                                                        max_depth=max_depth,
+                                                        number_features=number_features,
+                                                        percent_features=percent_features,
+                                                        threshold=-np.inf,
+                                                        n_jobs=n_jobs,
+                                                        random_state=random_state)
+
+        super().__init__(objective=objective,
+                         component_list=[enc, imputer, feature_selection, estimator],
+                         n_jobs=n_jobs,
+                         random_state=random_state)

--- a/evalml/pipelines/classification/xgboost.py
+++ b/evalml/pipelines/classification/xgboost.py
@@ -1,0 +1,49 @@
+import numpy as np
+from skopt.space import Integer, Real
+
+from evalml.model_types import ModelTypes
+from evalml.pipelines import PipelineBase
+from evalml.pipelines.components import (
+    OneHotEncoder,
+    RFClassifierSelectFromModel,
+    SimpleImputer,
+    XGBoostClassifier
+)
+from evalml.problem_types import ProblemTypes
+
+
+class XGBoostPipeline(PipelineBase):
+    """XGBoost Pipeline for both binary and multiclass classification"""
+    name = "XGBoost Classifier w/ One Hot Encoder + Simple Imputer + RF Classifier Select From Model"
+    model_type = ModelTypes.XGBOOST
+    problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
+
+    hyperparameters = {
+        "eta": Real(0, 1),
+        "min_child_weight": Real(1, 10),
+        "max_depth": Integer(1, 20),
+        "impute_strategy": ["mean", "median", "most_frequent"],
+        "percent_features": Real(.01, 1)
+    }
+
+    def __init__(self, objective, eta, min_child_weight, max_depth, impute_strategy,
+                 percent_features, number_features, n_estimators=10, n_jobs=-1, random_state=0):
+
+        imputer = SimpleImputer(impute_strategy=impute_strategy)
+        enc = OneHotEncoder()
+        feature_selection = RFClassifierSelectFromModel(n_estimators=n_estimators,
+                                                        max_depth=max_depth,
+                                                        number_features=number_features,
+                                                        percent_features=percent_features,
+                                                        threshold=-np.inf,
+                                                        n_jobs=n_jobs,
+                                                        random_state=random_state)
+        estimator = XGBoostClassifier(random_state=random_state,
+                                      eta=eta,
+                                      max_depth=max_depth,
+                                      min_child_weight=min_child_weight)
+
+        super().__init__(objective=objective,
+                         component_list=[enc, imputer, feature_selection, estimator],
+                         n_jobs=n_jobs,
+                         random_state=random_state)

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -16,7 +16,7 @@ class PipelineBase:
     # Necessary for "Plotting" documentation, since Sphinx does not work well with instance attributes.
     plot = PipelinePlots
 
-    def __init__(self, objective, component_list, n_jobs=-1, random_state=0, **kwargs):
+    def __init__(self, objective, component_list, n_jobs, random_state, **kwargs):
         """Machine learning pipeline made out of transformers and a estimator.
 
         Arguments:

--- a/evalml/pipelines/regression/__init__.py
+++ b/evalml/pipelines/regression/__init__.py
@@ -1,0 +1,3 @@
+# flake8:noqa
+from .linear_regression import LinearRegressionPipeline
+from .random_forest import RFRegressionPipeline

--- a/evalml/pipelines/regression/linear_regression.py
+++ b/evalml/pipelines/regression/linear_regression.py
@@ -1,0 +1,36 @@
+from evalml.model_types import ModelTypes
+from evalml.pipelines import PipelineBase
+from evalml.pipelines.components import (
+    LinearRegressor,
+    OneHotEncoder,
+    SimpleImputer,
+    StandardScaler
+)
+from evalml.problem_types import ProblemTypes
+
+
+class LinearRegressionPipeline(PipelineBase):
+    """Linear Regression Pipeline for regression problems"""
+    name = "Linear Regressor w/ One Hot Encoder + Simple Imputer + Standard Scaler"
+    model_type = ModelTypes.LINEAR_MODEL
+    problem_types = [ProblemTypes.REGRESSION]
+
+    hyperparameters = {
+        'impute_strategy': ['most_frequent', 'mean', 'median'],
+        'normalize': [False, True],
+        'fit_intercept': [False, True]
+    }
+
+    def __init__(self, objective, random_state, number_features, impute_strategy, normalize=False, fit_intercept=True, n_jobs=-1):
+
+        imputer = SimpleImputer(impute_strategy=impute_strategy)
+        enc = OneHotEncoder()
+        scaler = StandardScaler()
+        estimator = LinearRegressor(normalize=normalize,
+                                    fit_intercept=fit_intercept,
+                                    n_jobs=-1)
+
+        super().__init__(objective=objective,
+                         component_list=[enc, imputer, scaler, estimator],
+                         n_jobs=n_jobs,
+                         random_state=random_state)

--- a/evalml/pipelines/regression/random_forest.py
+++ b/evalml/pipelines/regression/random_forest.py
@@ -1,0 +1,48 @@
+import numpy as np
+from skopt.space import Integer, Real
+
+from evalml.model_types import ModelTypes
+from evalml.pipelines import PipelineBase
+from evalml.pipelines.components import (
+    OneHotEncoder,
+    RandomForestRegressor,
+    RFRegressorSelectFromModel,
+    SimpleImputer
+)
+from evalml.problem_types import ProblemTypes
+
+
+class RFRegressionPipeline(PipelineBase):
+    """Random Forest Pipeline for regression problems"""
+    name = "Random Forest Regressor w/ One Hot Encoder + Simple Imputer + RF Regressor Select From Model"
+    model_type = ModelTypes.RANDOM_FOREST
+    problem_types = [ProblemTypes.REGRESSION]
+
+    hyperparameters = {
+        "n_estimators": Integer(10, 1000),
+        "max_depth": Integer(1, 32),
+        "impute_strategy": ["mean", "median", "most_frequent"],
+        "percent_features": Real(.01, 1)
+    }
+
+    def __init__(self, objective, n_estimators, max_depth, impute_strategy, percent_features,
+                 number_features, n_jobs=-1, random_state=0):
+
+        imputer = SimpleImputer(impute_strategy=impute_strategy)
+        enc = OneHotEncoder()
+        feature_selection = RFRegressorSelectFromModel(n_estimators=n_estimators,
+                                                       max_depth=max_depth,
+                                                       number_features=number_features,
+                                                       percent_features=percent_features,
+                                                       threshold=-np.inf,
+                                                       n_jobs=n_jobs,
+                                                       random_state=random_state)
+        estimator = RandomForestRegressor(random_state=random_state,
+                                          n_estimators=n_estimators,
+                                          max_depth=max_depth,
+                                          n_jobs=n_jobs)
+
+        super().__init__(objective=objective,
+                         component_list=[enc, imputer, feature_selection, estimator],
+                         n_jobs=n_jobs,
+                         random_state=random_state)

--- a/evalml/tests/automl_tests/test_pipeline_search_plots.py
+++ b/evalml/tests/automl_tests/test_pipeline_search_plots.py
@@ -10,7 +10,7 @@ from evalml.automl.pipeline_search_plots import (
     PipelineSearchPlots,
     SearchIterationPlot
 )
-from evalml.pipelines import PipelineBase
+from evalml.pipelines import LogisticRegressionPipeline
 from evalml.problem_types import ProblemTypes
 
 
@@ -26,8 +26,8 @@ def test_generate_roc(X_y):
             self.problem_type = ProblemTypes.BINARY
 
         def search(self):
-            pipeline = PipelineBase(objective="ROC", component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"], 
-                                        penalty='l2', C=0.5, impute_strategy='mean', number_features=len(X[0]), random_state=1)
+            pipeline = LogisticRegressionPipeline(objective="ROC", penalty='l2', C=0.5,
+                                                  impute_strategy='mean', number_features=len(X[0]), random_state=1)
             cv = StratifiedKFold(n_splits=5, random_state=0)
             cv_data = []
             for train, test in cv.split(X, y):
@@ -102,8 +102,8 @@ def test_generate_confusion_matrix(X_y):
             self.problem_type = ProblemTypes.BINARY
 
         def search(self):
-            pipeline = PipelineBase(objective="confusion_matrix", component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                        penalty='l2', C=0.5, impute_strategy='mean', number_features=len(X[0]), random_state=1)
+            pipeline = LogisticRegressionPipeline(objective="confusion_matrix", penalty='l2', C=0.5,
+                                                  impute_strategy='mean', number_features=len(X[0]), random_state=1)
             cv = StratifiedKFold(n_splits=5, random_state=0)
             cv_data = []
             for train, test in cv.split(X, y):

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pytest
 from sklearn import datasets
 
-from evalml.pipelines import PipelineBase
 
 @pytest.fixture
 def X_y():

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -5,7 +5,7 @@ from evalml.objectives import (
     get_objective,
     get_objectives
 )
-from evalml.pipelines import PipelineBase
+from evalml.pipelines import LogisticRegressionPipeline
 from evalml.problem_types import ProblemTypes
 
 
@@ -23,8 +23,7 @@ def test_get_objectives_types():
 def test_binary_average(X_y):
     X, y = X_y
 
-    pipeline = PipelineBase(objective=Precision(), component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean', number_features=0)
+    pipeline = LogisticRegressionPipeline(objective=Precision(), penalty='l2', C=1.0, impute_strategy='mean', number_features=0)
     pipeline.fit(X, y)
     y_pred = pipeline.predict(X)
 

--- a/evalml/tests/pipeline_tests/test_linear_regression.py
+++ b/evalml/tests/pipeline_tests/test_linear_regression.py
@@ -1,0 +1,63 @@
+import category_encoders as ce
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from evalml.objectives import R2
+from evalml.pipelines import LinearRegressionPipeline
+
+
+def test_lr_init(X_y_categorical_regression):
+    X, y = X_y_categorical_regression
+
+    objective = R2()
+    clf = LinearRegressionPipeline(objective=objective, number_features=len(X.columns), random_state=2, impute_strategy='mean', normalize=True, fit_intercept=True, n_jobs=-1)
+    expected_parameters = {'impute_strategy': 'mean', 'fit_intercept': True, 'normalize': True}
+    assert clf.parameters == expected_parameters
+    assert clf.random_state == 2
+
+
+def test_linear_regression(X_y_categorical_regression):
+    X, y = X_y_categorical_regression
+    enc = ce.OneHotEncoder(use_cat_names=True, return_df=True)
+    imputer = SimpleImputer(strategy='mean')
+    scaler = StandardScaler()
+    estimator = LinearRegression(normalize=False, fit_intercept=True, n_jobs=-1)
+    sk_pipeline = Pipeline([("encoder", enc),
+                            ("imputer", imputer),
+                            ("scaler", scaler),
+                            ("estimator", estimator)])
+    sk_pipeline.fit(X, y)
+    sk_score = sk_pipeline.score(X, y)
+
+    objective = R2()
+    clf = LinearRegressionPipeline(objective=objective,
+                                   number_features=len(X.columns),
+                                   impute_strategy='mean',
+                                   normalize=False,
+                                   fit_intercept=True,
+                                   random_state=0,
+                                   n_jobs=-1)
+    clf.fit(X, y)
+    clf_score = clf.score(X, y)
+    y_pred = clf.predict(X)
+
+    np.testing.assert_almost_equal(y_pred, sk_pipeline.predict(X), decimal=5)
+    np.testing.assert_almost_equal(sk_score, clf_score[0], decimal=5)
+    assert not clf.feature_importances.isnull().all().all()
+
+
+def test_lr_input_feature_names(X_y):
+    X, y = X_y
+    # create a list of column names
+    col_names = ["col_{}".format(i) for i in range(len(X[0]))]
+    X = pd.DataFrame(X, columns=col_names)
+    objective = R2()
+    clf = LinearRegressionPipeline(objective=objective, number_features=len(X.columns), random_state=0, impute_strategy='mean', normalize=False, fit_intercept=True, n_jobs=-1)
+    clf.fit(X, y)
+    assert len(clf.feature_importances) == len(X.columns)
+    assert not clf.feature_importances.isnull().all().all()
+    assert ("col_" in col_name for col_name in clf.feature_importances["feature"])

--- a/evalml/tests/pipeline_tests/test_logistic_regression.py
+++ b/evalml/tests/pipeline_tests/test_logistic_regression.py
@@ -1,0 +1,63 @@
+import category_encoders as ce
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline as SKPipeline
+from sklearn.preprocessing import StandardScaler as SkScaler
+
+from evalml.objectives import PrecisionMicro
+from evalml.pipelines import LogisticRegressionPipeline
+
+
+def test_lor_init(X_y):
+    X, y = X_y
+
+    objective = PrecisionMicro()
+    clf = LogisticRegressionPipeline(objective=objective, penalty='l2', C=0.5, impute_strategy='mean', number_features=len(X[0]), random_state=1)
+    expected_parameters = {'impute_strategy': 'mean', 'penalty': 'l2', 'C': 0.5}
+    assert clf.parameters == expected_parameters
+    assert clf.random_state == 1
+
+
+def test_lor_multi(X_y_multi):
+    X, y = X_y_multi
+    imputer = SimpleImputer(strategy='mean')
+    enc = ce.OneHotEncoder(use_cat_names=True, return_df=True)
+    scaler = SkScaler()
+    estimator = LogisticRegression(random_state=0,
+                                   penalty='l2',
+                                   C=1.0,
+                                   multi_class='auto',
+                                   solver="lbfgs",
+                                   n_jobs=-1)
+    sk_pipeline = SKPipeline([("encoder", enc),
+                              ("imputer", imputer),
+                              ("scaler", scaler),
+                              ("estimator", estimator)])
+    sk_pipeline.fit(X, y)
+    sk_score = sk_pipeline.score(X, y)
+
+    objective = PrecisionMicro()
+    clf = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
+    clf.fit(X, y)
+    clf_score = clf.score(X, y)
+    y_pred = clf.predict(X)
+    assert((y_pred == sk_pipeline.predict(X)).all())
+    assert (sk_score == clf_score[0])
+    assert len(np.unique(y_pred)) == 3
+    assert len(clf.feature_importances) == len(X[0])
+    assert not clf.feature_importances.isnull().all().all()
+
+
+def test_lor_input_feature_names(X_y):
+    X, y = X_y
+    # create a list of column names
+    col_names = ["col_{}".format(i) for i in range(len(X[0]))]
+    X = pd.DataFrame(X, columns=col_names)
+    objective = PrecisionMicro()
+    clf = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X.columns), random_state=0)
+    clf.fit(X, y)
+    assert len(clf.feature_importances) == len(X.columns)
+    assert not clf.feature_importances.isnull().all().all()
+    assert ("col_" in col_name for col_name in clf.feature_importances["feature"])

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -4,7 +4,7 @@ import pytest
 
 from evalml.model_types import ModelTypes
 from evalml.objectives import FraudCost, Precision
-from evalml.pipelines import PipelineBase
+from evalml.pipelines import LogisticRegressionPipeline, PipelineBase
 from evalml.pipelines.components import (
     ComponentTypes,
     Estimator,
@@ -44,8 +44,7 @@ def test_serialization(X_y, tmpdir):
     path = os.path.join(str(tmpdir), 'pipe.pkl')
     objective = Precision()
 
-    pipeline = PipelineBase(objective=objective, component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    pipeline = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]))
     pipeline.fit(X, y)
     save_pipeline(pipeline, path)
     assert pipeline.score(X, y) == load_pipeline(path).score(X, y)
@@ -57,8 +56,7 @@ def pickled_pipeline_path(X_y, tmpdir):
     path = os.path.join(str(tmpdir), 'pickled_pipe.pkl')
     MockPrecision = type('MockPrecision', (Precision,), {})
     objective = MockPrecision()
-    pipeline = PipelineBase(objective=objective, component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    pipeline = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]))
     pipeline.fit(X, y)
     save_pipeline(pipeline, path)
     return path
@@ -70,8 +68,7 @@ def test_load_pickled_pipeline_with_custom_objective(X_y, pickled_pipeline_path)
     with pytest.raises(NameError):
         MockPrecision()  # noqa: F821: ignore flake8's "undefined name" error
     objective = Precision()
-    pipeline = PipelineBase(objective=objective, component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    pipeline = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]))
     pipeline.fit(X, y)
     assert load_pipeline(pickled_pipeline_path).score(X, y) == pipeline.score(X, y)
 
@@ -85,12 +82,10 @@ def test_reproducibility(X_y):
         amount_col=10
     )
 
-    clf = PipelineBase(objective=objective, component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    clf = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
     clf.fit(X, y)
 
-    clf_1 = PipelineBase(objective=objective, component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    clf_1 = LogisticRegressionPipeline(objective=objective, penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
     clf_1.fit(X, y)
 
     assert clf_1.score(X, y) == clf.score(X, y)
@@ -98,8 +93,7 @@ def test_reproducibility(X_y):
 
 def test_indexing(X_y):
     X, y = X_y
-    clf = PipelineBase(objective='recall', component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    clf = LogisticRegressionPipeline(objective='recall', penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
     clf.fit(X, y)
 
     assert isinstance(clf[0], OneHotEncoder)
@@ -116,15 +110,13 @@ def test_indexing(X_y):
 
 def test_describe(X_y):
     X, y = X_y
-    lrp = PipelineBase(objective='recall', component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    lrp = LogisticRegressionPipeline(objective='recall', penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
     assert lrp.describe(True) == {'C': 1.0, 'impute_strategy': 'mean', 'penalty': 'l2'}
 
 
 def test_name(X_y):
     X, y = X_y
-    clf = PipelineBase(objective='recall', component_list=["One Hot Encoder", "Simple Imputer", "Standard Scaler", "Logistic Regression Classifier"],
-                                penalty='l2', C=1.0, impute_strategy='mean')
+    clf = LogisticRegressionPipeline(objective='recall', penalty='l2', C=1.0, impute_strategy='mean', number_features=len(X[0]), random_state=0)
     assert clf.name == 'Logistic Regression Classifier w/ One Hot Encoder + Simple Imputer + Standard Scaler'
 
 

--- a/evalml/tests/pipeline_tests/test_rf.py
+++ b/evalml/tests/pipeline_tests/test_rf.py
@@ -1,0 +1,67 @@
+import category_encoders as ce
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.feature_selection import SelectFromModel
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+
+from evalml.objectives import PrecisionMicro
+from evalml.pipelines import RFClassificationPipeline
+
+
+def test_rf_init(X_y):
+    X, y = X_y
+
+    objective = PrecisionMicro()
+    clf = RFClassificationPipeline(objective=objective, n_estimators=20, max_depth=5, impute_strategy='mean', percent_features=1.0, number_features=len(X[0]), random_state=2)
+    expected_parameters = {'impute_strategy': 'mean', 'percent_features': 1.0,
+                           'threshold': -np.inf, 'n_estimators': 20, 'max_depth': 5}
+    assert clf.parameters == expected_parameters
+    assert clf.random_state == 2
+
+
+def test_rf_multi(X_y_multi):
+    X, y = X_y_multi
+
+    # create sklearn pipeline
+    imputer = SimpleImputer(strategy='mean')
+    enc = ce.OneHotEncoder(use_cat_names=True, return_df=True)
+    estimator = RandomForestClassifier(random_state=0,
+                                       n_estimators=10,
+                                       max_depth=3,
+                                       n_jobs=-1)
+    feature_selection = SelectFromModel(estimator=estimator,
+                                        max_features=max(1, int(1 * len(X[0]))),
+                                        threshold=-np.inf)
+    sk_pipeline = Pipeline([("encoder", enc),
+                            ("imputer", imputer),
+                            ("feature_selection", feature_selection),
+                            ("estimator", estimator)])
+    sk_pipeline.fit(X, y)
+    sk_score = sk_pipeline.score(X, y)
+
+    objective = PrecisionMicro()
+    clf = RFClassificationPipeline(objective=objective, n_estimators=10, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=len(X[0]))
+    clf.fit(X, y)
+    clf_score = clf.score(X, y)
+    y_pred = clf.predict(X)
+
+    assert((y_pred == sk_pipeline.predict(X)).all())
+    assert (sk_score == clf_score[0])
+    assert len(np.unique(y_pred)) == 3
+    assert len(clf.feature_importances) == len(X[0])
+    assert not clf.feature_importances.isnull().all().all()
+
+
+def test_rf_input_feature_names(X_y):
+    X, y = X_y
+    # create a list of column names
+    col_names = ["col_{}".format(i) for i in range(len(X[0]))]
+    X = pd.DataFrame(X, columns=col_names)
+    objective = PrecisionMicro()
+    clf = RFClassificationPipeline(objective=objective, n_estimators=10, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=len(X.columns))
+    clf.fit(X, y)
+    assert len(clf.feature_importances) == len(X.columns)
+    assert not clf.feature_importances.isnull().all().all()
+    assert ("col_" in col_name for col_name in clf.feature_importances["feature"])

--- a/evalml/tests/pipeline_tests/test_rf_regression.py
+++ b/evalml/tests/pipeline_tests/test_rf_regression.py
@@ -1,0 +1,63 @@
+import category_encoders as ce
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.feature_selection import SelectFromModel
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+
+from evalml.objectives import R2
+from evalml.pipelines import RFRegressionPipeline
+
+
+def test_rf_init(X_y_reg):
+    X, y = X_y_reg
+
+    objective = R2()
+    clf = RFRegressionPipeline(objective=objective, n_estimators=20, max_depth=5, impute_strategy='mean', percent_features=1.0, number_features=len(X[0]), random_state=2)
+    expected_parameters = {'impute_strategy': 'mean', 'percent_features': 1.0,
+                           'threshold': -np.inf, 'n_estimators': 20, 'max_depth': 5}
+    assert clf.parameters == expected_parameters
+    assert clf.random_state == 2
+
+
+def test_rf_regression(X_y_categorical_regression):
+    X, y = X_y_categorical_regression
+
+    imputer = SimpleImputer(strategy='mean')
+    enc = ce.OneHotEncoder(use_cat_names=True, return_df=True)
+    estimator = RandomForestRegressor(random_state=0,
+                                      n_estimators=10,
+                                      max_depth=3,
+                                      n_jobs=-1)
+    feature_selection = SelectFromModel(estimator=estimator,
+                                        max_features=max(1, int(1 * X.shape[1])),
+                                        threshold=-np.inf)
+    sk_pipeline = Pipeline([("encoder", enc),
+                            ("imputer", imputer),
+                            ("feature_selection", feature_selection),
+                            ("estimator", estimator)])
+    sk_pipeline.fit(X, y)
+    sk_score = sk_pipeline.score(X, y)
+
+    objective = R2()
+    clf = RFRegressionPipeline(objective=objective, n_estimators=10, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=X.shape[1])
+    clf.fit(X, y)
+    clf_score = clf.score(X, y)
+    y_pred = clf.predict(X)
+
+    np.testing.assert_almost_equal(y_pred, sk_pipeline.predict(X), decimal=5)
+    np.testing.assert_almost_equal(sk_score, clf_score[0], decimal=5)
+
+
+def test_rfr_input_feature_names(X_y_reg):
+    X, y = X_y_reg
+    # create a list of column names
+    col_names = ["col_{}".format(i) for i in range(len(X[0]))]
+    X = pd.DataFrame(X, columns=col_names)
+    objective = R2()
+    clf = RFRegressionPipeline(objective=objective, n_estimators=10, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=len(X.columns))
+    clf.fit(X, y)
+    assert len(clf.feature_importances) == len(X.columns)
+    assert not clf.feature_importances.isnull().all().all()
+    assert ("col_" in col_name for col_name in clf.feature_importances["feature"])

--- a/evalml/tests/pipeline_tests/test_xgboost.py
+++ b/evalml/tests/pipeline_tests/test_xgboost.py
@@ -1,0 +1,69 @@
+import category_encoders as ce
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier as SKRandomForestClassifier
+from sklearn.feature_selection import SelectFromModel
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+from xgboost import XGBClassifier
+
+from evalml.objectives import PrecisionMicro
+from evalml.pipelines import XGBoostPipeline
+
+
+def test_xg_init(X_y):
+    X, y = X_y
+
+    objective = PrecisionMicro()
+    clf = XGBoostPipeline(objective=objective, eta=0.2, min_child_weight=3, max_depth=5, impute_strategy='median',
+                          percent_features=1.0, number_features=len(X[0]), random_state=1)
+    expected_parameters = {'impute_strategy': 'median', 'percent_features': 1.0, 'threshold': -np.inf,
+                           'eta': 0.2, 'max_depth': 5, 'min_child_weight': 3}
+    assert clf.parameters == expected_parameters
+    assert clf.random_state == 1
+
+
+def test_xg_multi(X_y_multi):
+    X, y = X_y_multi
+
+    imputer = SimpleImputer(strategy='mean')
+    enc = ce.OneHotEncoder(use_cat_names=True, return_df=True)
+    estimator = XGBClassifier(random_state=0,
+                              eta=0.1,
+                              max_depth=3,
+                              min_child_weight=1)
+    rf_estimator = SKRandomForestClassifier(random_state=0, n_estimators=10, max_depth=3)
+    feature_selection = SelectFromModel(estimator=rf_estimator,
+                                        max_features=max(1, int(1 * len(X[0]))),
+                                        threshold=-np.inf)
+    sk_pipeline = Pipeline([("encoder", enc),
+                            ("imputer", imputer),
+                            ("feature_selection", feature_selection),
+                            ("estimator", estimator)])
+    sk_pipeline.fit(X, y)
+    sk_score = sk_pipeline.score(X, y)
+
+    objective = PrecisionMicro()
+    clf = XGBoostPipeline(objective=objective, eta=0.1, min_child_weight=1, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=len(X[0]))
+    clf.fit(X, y)
+    clf_score = clf.score(X, y)
+    y_pred = clf.predict(X)
+
+    assert((y_pred == sk_pipeline.predict(X)).all())
+    assert (sk_score == clf_score[0])
+    assert len(np.unique(y_pred)) == 3
+    assert len(clf.feature_importances) == len(X[0])
+    assert not clf.feature_importances.isnull().all().all()
+
+
+def test_xg_input_feature_names(X_y):
+    X, y = X_y
+    # create a list of column names
+    col_names = ["col_{}".format(i) for i in range(len(X[0]))]
+    X = pd.DataFrame(X, columns=col_names)
+    objective = PrecisionMicro()
+    clf = XGBoostPipeline(objective=objective, eta=0.1, min_child_weight=1, max_depth=3, impute_strategy='mean', percent_features=1.0, number_features=len(X.columns))
+    clf.fit(X, y)
+    assert len(clf.feature_importances) == len(X.columns)
+    assert not clf.feature_importances.isnull().all().all()
+    assert ("col_" in col_name for col_name in clf.feature_importances["feature"])


### PR DESCRIPTION
First initial pass on refactoring so that all pipelines are generated through `PipelineBase` and you only need component lists to define pipelines.

- [x] Register New Pipeline
- [ ] Remove static pipelines and tests
- [x] change name generation in `PipelineBase` to class method that takes in component_list
- [x] rename `possible_component_lists` etc.
- [x] error handling in `_instantiate_components`
- [x] write tests
- [ ] review API reference and docs
- [ ] ????

**Pros:**
- Centralizes pipelines to using `PipelineBase to initialize`
- Easy to configure new pipelines using `.yaml` or through component lists
- Can set environment variable to load multiple new pipelines
- Component lists allow for specific names or types of components
- Removes all static pipelines and uses AutoBase to retrieve annotated information from components
- Allows users to pass in wtv arguments they want to their pipelines and components
- Allows for easier implementation of component based optimization.

**Cons:**
- Instead of modularizing responsibility adds more into AutoBase and `PipelineBase`
-  Users don't have static pipelines to look to in API (maybe we can just add section on docs)
- Our default pipelines become more ambiguous

**More thoughts:**
If static pipelines and tests are removed how can we replace the tests? Should we keep static pipelines for users that want to use them? **We can just refactor and remove the bloat.** If these changes are made it removes the ambiguity of default pipelines but makes adding new pipelines a slightly longer process. 

What is the deal with 3.5 parallelization and circleci tests failing? Even without removing static pipelines it shows up intermittently. Removing static pipelines seemed to make the process worse. Maybe this is something worth investigating before this PR should be merged in. Please refer to the log [here](https://app.circleci.com/jobs/github/FeatureLabs/evalml/9049/parallel-runs/0/steps/0-104).
