### PR TITLE
Hide features with zero importance in plot by default

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Changelog
         * Remove unused parameter ObjectiveBase.fit_needs_proba :pr:`320`
         * Remove extraneous parameter component_type from all components :pr:`361`
         * Remove unused rankings.csv file :pr:`397`
+        * Changed plot.feature_importance to show only non-zero feature importances by default, added optional parameter to show all :pr:`413`
     * Documentation Changes
         * Update release.md with instructions to release to internal license key :pr:`354`
     * Testing Changes

--- a/evalml/pipelines/pipeline_plots.py
+++ b/evalml/pipelines/pipeline_plots.py
@@ -74,14 +74,24 @@ class PipelinePlots:
 
         return graph
 
-    def feature_importances(self):
+    def feature_importances(self, show_all_features=False):
+        """Create and return a plot of the pipeline's feature importances
+
+        Arguments:
+            show_all_features (bool, optional) : If true, plot features with an importance value of zero. Defaults to False.
+
+        Returns:
+            plotly.Figure, a bar graph showing features and their importances
+
+        """
         import plotly.graph_objects as go
 
         feat_imp = self.pipeline.feature_importances
         feat_imp['importance'] = abs(feat_imp['importance'])
 
-        # Remove features with zero importance
-        feat_imp = feat_imp[feat_imp['importance'] != 0]
+        if not show_all_features:
+            # Remove features with zero importance
+            feat_imp = feat_imp[feat_imp['importance'] != 0]
 
         # List is reversed to go from ascending order to descending order
         feat_imp = feat_imp.iloc[::-1]

--- a/evalml/tests/pipeline_tests/test_pipelines_plots.py
+++ b/evalml/tests/pipeline_tests/test_pipelines_plots.py
@@ -43,7 +43,7 @@ def test_feature_importance_plot(X_y):
     assert isinstance(clf.plot.feature_importances(), go.Figure)
 
 
-def test_feature_importance_plot_hides_zero_value_features(X_y):
+def test_feature_importance_plot_show_all_features(X_y):
 
     class MockPipeline(PipelineBase):
         name = "Mock Pipeline"
@@ -71,3 +71,7 @@ def test_feature_importance_plot_hides_zero_value_features(X_y):
 
     data = figure.data[0]
     assert (np.all(data['x']))
+
+    figure = clf.plot.feature_importances(show_all_features=True)
+    data = figure.data[0]
+    assert (np.any(data['x'] == 0.0))


### PR DESCRIPTION
Closes #411. Introduces a new `show_all_features` flag which, if `True`, will plot all features including those with an importance equal to zero. Defaults to False.
![image](https://user-images.githubusercontent.com/5422235/75192834-0e15c100-5723-11ea-9ec6-3d7bc8c6cf35.png)
