### PR TITLE
v0.8.0 Mar. 31, 2020

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 ---------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.8.0 Mar. 31, 2020**
+    * Enhancements
         * Add normalization option and information to confusion matrix :pr:`484`
         * Add util function to drop rows with NaN values :pr:`487`
         * Renamed `PipelineBase.name` as `PipelineBase.summary` and redefined `PipelineBase.name` as class property :pr:`491`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -27,4 +27,4 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='evalml',
-    version='0.7.0',
+    version='0.8.0',
     author='Feature Labs, Inc.',
     author_email='support@featurelabs.com',
     url='http://www.featurelabs.com/',


### PR DESCRIPTION
## v0.8.0 Mar. 31, 2020
####  Enhancements
- Add normalization option and information to confusion matrix :pr:`484`
- Add util function to drop rows with NaN values :pr:`487`
- Renamed `PipelineBase.name` as `PipelineBase.summary` and redefined `PipelineBase.name` as class property :pr:`491`
- Added access to parameters in Pipelines with `PipelineBase.parameters` (used to be return of `PipelineBase.describe`) :pr:`501`
- Added `fill_value` parameter for SimpleImputer :pr:`509`
- Added functionality to override component hyperparemeters and made pipelines take hyperparemeters from components :pr:`516`
- Allow numpy.random.RandomState for random_state parameters :pr:`530`

#### Fixes

#### Changes
- Undo version cap in XGBoost placed in :pr:`402` and allowed all released of XGBoost :pr:`407`
- Support pandas 1.0.0 :pr:`486`
- Made all references to the logger static :pr:`503`
- Refactored `model_type` parameter for components and pipelines to `model_family` :pr:`507`
- Refactored `problem_types` for pipelines and components into `supported_problem_types` :pr:`515`
- Moved `pipelines/utils.save_pipeline` and `pipelines/utils.load_pipeline` to `PipelineBase.save` and `PipelineBase.load` :pr:`526`
- Limit number of categories encoded by OneHotEncoder :pr:`517`

#### Documentation Changes
- Updated API reference to remove PipelinePlot and added moved PipelineBase plotting methods :pr:`483`
- Add code style and github issue guides :pr:`463` :pr:`512`
- Updated API reference for to surface class variables for pipelines and components :pr:`537`

#### Testing Changes
- Added automated dependency check PR :pr:`482`, :pr:`505`
- Updated automated dependency check comment :pr:`497`
- Have build_docs job use python executor, so that env vars are set properly :pr:`547`

#### Breaking Changes

- `AutoClassificationSearch` and `AutoRegressionSearch`'s `model_types` parameter has been refactored into `allowed_model_families`
- `ModelTypes` enum has been changed to `ModelFamily`
- Components and Pipelines now have a `model_family` field instead of `model_type`
- `get_pipelines` utility function now accepts `model_families` as an argument instead of `model_types`
- `PipelineBase.name` no longer returns structure of pipeline and has been replaced by `PipelineBase.summary`
- `PipelineBase.problem_types` and `Estimator.problem_types` has been renamed to `supported_problem_types`
- `pipelines/utils.save_pipeline` and `pipelines/utils.load_pipeline` moved to `PipelineBase.save` and `PipelineBase.load`

--

Closes #532 