### PR TITLE
Clean up deps: remove 'plots' option from scikit-optimize, move category_encoders

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -5,5 +5,4 @@ scikit-learn>=0.21.3,!=0.22
 scikit-optimize
 tqdm>=4.33.0
 colorama
-category_encoders>=2.0.0
 cloudpickle>=0.2.2

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,7 +19,7 @@ Changelog
         * Added functionality to override component hyperparemeters and made pipelines take hyperparemeters from components :pr:`516`
         * Allow numpy.random.RandomState for random_state parameters :pr:`556`
     * Fixes
-        * Removed unused dependency `matplotlib` :pr:`572`
+        * Removed unused dependency `matplotlib`, and move `category_encoders` to test reqs :pr:`572`
     * Changes
         * Undo version cap in XGBoost placed in :pr:`402` and allowed all released of XGBoost :pr:`407`
         * Support pandas 1.0.0 :pr:`486`

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,5 @@ pytest-cov==2.6.1
 nbval==0.9.3
 graphviz>=0.13
 codecov==2.0.15
+category_encoders>=2.0.0
 requirements-parser>=0.2.0


### PR DESCRIPTION
Have core deps install scikit-optimize but not the 'plots' option (i.e. [matplotlib](https://github.com/scikit-optimize/scikit-optimize/blob/master/setup.py#L50)). Actually I'm not sure we need matplotlib at all.