### PR TITLE
Update default objectives for automl

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,7 +8,7 @@ Changelog
     * Fixes
         * Removed direct access to `cls.component_graph` :pr:`595`
     * Changes
-        * Updated default objectives for classification (log loss) and regression (MSE) :pr:`613`
+        * Updated default objective for binary/multiseries classification to log loss :pr:`613`
     * Documentation Changes
         * Fixed some sphinx warnings :pr:`593`
         * Fixed docstring for AutoClassificationSearch with correct command :pr:`599`

--- a/evalml/automl/auto_regression_search.py
+++ b/evalml/automl/auto_regression_search.py
@@ -73,7 +73,7 @@ class AutoRegressionSearch(AutoBase):
 
         """
         if objective is None:
-            objective = "mse"
+            objective = "R2"
 
         problem_type = ProblemTypes.REGRESSION
 


### PR DESCRIPTION
**Classification**
We definitely shouldn't be using precision to rank the leaderboard for classification problems. If you just favor precision you'll end up with trivial models. I think log loss is a much better default to use. It works with predicted probabilities so it won't depend on the threshold value we choose. (We could decide to change this once we merge #346 which will add threshold tuning for binary classification).

**Regression**
For regression, R2 is fine, but I'd rather use MAE or MSE because my opinion is those are more standard. MAE in particular is in the original units of the target value, which is a nice property. But MSE is better at penalizing large errors.

It's worth noting these settings don't affect how each model's optimizer is working, but they do affect a) how the models are ranked and b) how the next set of pipeline parameters is chosen.