### PR TITLE
Delete s3fs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,4 +8,3 @@ Sphinx==2.0.1; python_version>'3.4'
 sphinx_rtd_theme==0.4.3
 nbconvert==5.5.0
 nbsphinx==0.4.2
-s3fs>=0.3.0


### PR DESCRIPTION
Fixes #592 

I don't think we need this anymore! It's causing a `boto` install warning.

```
s3fs==0.4.0
  - boto3 [required: >=1.9.91, installed: 1.12.15]
    - botocore [required: >=1.15.15,<1.16.0, installed: 1.15.15]
      - docutils [required: >=0.10,<0.16, installed: 0.16]
      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.5]
      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
        - six [required: >=1.5, installed: 1.14.0]
      - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.5]
    - s3transfer [required: >=0.3.0,<0.4.0, installed: 0.3.3]
      - botocore [required: >=1.12.36,<2.0a.0, installed: 1.15.15]
        - docutils [required: >=0.10,<0.16, installed: 0.16]
        - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.5]
        - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
          - six [required: >=1.5, installed: 1.14.0]
        - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
  - botocore [required: >=1.12.91, installed: 1.15.15]
    - docutils [required: >=0.10,<0.16, installed: 0.16]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.5]
    - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.1]
      - six [required: >=1.5, installed: 1.14.0]
    - urllib3 [required: >=1.20,<1.26, installed: 1.25.8]
  - fsspec [required: >=0.6.0, installed: 0.6.2]
```