### PR TITLE
Dependency check: update expected catboost version

### DIFF
--- a/evalml/tests/latest_dependency_versions.txt
+++ b/evalml/tests/latest_dependency_versions.txt
@@ -1,4 +1,4 @@
-catboost==0.22
+catboost==0.23
 cloudpickle==1.3.0
 numpy==1.18.3
 pandas==1.0.3


### PR DESCRIPTION
Putting this up now to get things green rather than waiting for the bot.