### PR TITLE
Release v0.9.0 Apr. 27, 2020

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 ---------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.9.0 Apr. 27, 2020**
+    * Enhancements
         * Added accuracy as an standard objective :pr:`624`
         * Added verbose parameter to load_fraud :pr:`560`
         * Added Balanced Accuracy metric for binary, multiclass :pr:`612` :pr:`661`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -28,4 +28,4 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-__version__ = '0.8.0'
+__version__ = '0.9.0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='evalml',
-    version='0.8.0',
+    version='0.9.0',
     author='Feature Labs, Inc.',
     author_email='support@featurelabs.com',
     url='http://www.featurelabs.com/',


### PR DESCRIPTION
## v0.9.0 Apr. 27, 2020
#### Enhancements
- Added accuracy as an standard objective :pr:`624`
- Added verbose parameter to load_fraud :pr:`560`
- Added Balanced Accuracy metric for binary, multiclass :pr:`612` :pr:`661`
- Added XGBoost regressor and XGBoost regression pipeline :pr:`666`
- Added Accuracy metric for multiclass :pr:`672`
- Added objective name in `AutoBase.describe_pipeline` :pr:`686`

#### Fixes
- Removed direct access to `cls.component_graph` :pr:`595`
- Add testing files to .gitignore :pr:`625`
- Remove circular dependencies from `Makefile` :pr:`637`
- Add error case for `normalize_confusion_matrix()` :pr:`640`
- Fixed XGBoostClassifier and XGBoostRegressor bug with feature names that contain [, ], or < :pr:`659`
- Update make_pipeline_graph to not accidentally create empty file when testing if path is valid :pr:`649`
- Fix pip installation warning about docsutils version, from boto dependency :pr:`664`
- Removed zero division warning for F1/precision/recall metrics :pr:`671`
- Fixed `summary` for pipelines without estimators :pr:`707`

#### Changes
- Updated default objective for binary/multiseries classification to log loss :pr:`613`
- Created classification and regression pipeline subclasses and removed objective as an attribute of pipeline classes :pr:`405`
- Changed the output of `score` to return one dictionary :pr:`429`
- Created binary and multiclass objective subclasses :pr:`504`
- Updated objectives API :pr:`445`
- Removed call to `get_plot_data` from AutoML :pr:`615`
- Set `raise_error` to default to True for AutoML classes :pr:`638`
- Remove unnecessary "u" prefixes on some unicode strings :pr:`641`
- Changed one-hot encoder to return uint8 dtypes instead of ints :pr:`653`
- Pipeline `_name` field changed to `custom_name` :pr:`650`
- Removed `graphs.py` and moved methods into `PipelineBase` :pr:`657`, :pr:`665`
- Remove s3fs as a dev dependency :pr:`664`
- Changed requirements-parser to be a core dependency :pr:`673`
- Replace `supported_problem_types` field on pipelines with `problem_type` attribute on base classes :pr:`678`
- Changed AutoML to only show best results for a given pipeline template in `rankings`, added `full_rankings` property to show all :pr:`682`
- Update `ModelFamily` values: don't list xgboost/catboost as classifiers now that we have regression pipelines for them :pr:`677`
- Changed AutoML's `describe_pipeline` to get problem type from pipeline instead :pr:`685`
- Standardize `import_or_raise` error messages :pr:`683`
- Updated argument order of objectives to align with sklearn's :pr:`698`
- Renamed `pipeline.feature_importance_graph` to `pipeline.graph_feature_importances` :pr:`700`
- Moved ROC and confusion matrix methods to `evalml.pipelines.plot_utils` :pr:`704`
- Renamed `MultiClassificationObjective` to `MulticlassClassificationObjective`, to align with pipeline naming scheme :pr:`715`

#### Documentation Changes
- Fixed some sphinx warnings :pr:`593`
- Fixed docstring for AutoClassificationSearch with correct command :pr:`599`
- Limit readthedocs formats to pdf, not htmlzip and epub :pr:`594` :pr:`600`
- Clean up objectives API documentation :pr:`605`
- Fixed function on Exploring search results page :pr:`604`
- Update release process doc :pr:`567`
- AutoClassificationSearch and AutoRegressionSearch show inherited methods in API reference :pr:`651`
- Fixed improperly formatted code in breaking changes for changelog :pr:`655`
- Added configuration to treat Sphinx warnings as errors :pr:`660`
- Removed separate plotting section for pipelines in API reference :pr:`657`, :pr:`665`
- Have leads example notebook load S3 files using https, so we can delete s3fs dev dependency :pr:`664`
- Categorized components in API reference and added descriptions for each category :pr:`663`
- Fixed Sphinx warnings about BalancedAccuracy objective :pr:`669`
- Updated API reference to include missing components and clean up pipeline docstrings :pr:`689`
- Reorganize API ref, and clarify pipeline sub-titles :pr:`688`
- Add and update preprocessing utils in API reference :pr:`687`
- Added inheritance diagrams to API reference :pr:`695`
- Documented which default objective AutoML optimizes for :pr:`699`
- Create seperate install page :pr:`701`
- Include more utils in API ref, like `import_or_raise` :pr:`704`
- Add more color to pipeline documentation :pr:`705`

#### Testing Changes
- Matched install commands of `check_latest_dependencies` test and it's GitHub action :pr:`578`
- Added Github app to auto assign PR author as assignee :pr:`477`
- Removed unneeded conda installation of xgboost in windows checkin tests :pr:`618`
- Update graph tests to always use tmpfile dir :pr:`649`
- Changelog checkin test workaround for release PRs: If 'future release' section is empty of PR refs, pass check :pr:`658`

#### Breaking Changes

- Pipelines will now no longer take an objective parameter during instantiation, and will no longer have an objective attribute.
- `fit()` and `predict()` now use an optional `objective` parameter, which is only used in binary classification pipelines to fit for a specific objective.
- `score()` will now use a required `objectives` parameter that is used to determine all the objectives to score on. This differs from the previous behavior, where the pipeline's objective was scored on regardless.
- `score()` will now return one dictionary of all objective scores.
- `ROC` and `ConfusionMatrix` plot methods via `Auto(*).plot` have been removed by :pr:`615` and are replaced by `roc_curve` and `confusion_matrix` in `evamlm.pipelines.plot_utils` in :pr:`704`
- `normalize_confusion_matrix` has been moved to `evalml.pipelines.plot_utils` :pr:`704`
- Pipelines `_name` field changed to `custom_name`
- Pipelines `supported_problem_types` field is removed because it is no longer necessary :pr:`678`
- Updated argument order of objectives' `objective_function` to align with sklearn :pr:`698`
- `pipeline.feature_importance_graph` has been renamed to `pipeline.graph_feature_importances` in :pr:`700`
- Removed unsupported `MSLE` objective :pr:`704`
