### PR TITLE
Release v0.11.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.11.0 June 30, 2020**
+    * Enhancements
         * Added multiclass support for ROC curve graphing :pr:`832`
         * Added preprocessing component to drop features whose percentage of NaN values exceeds a specified threshold :pr:`834`
         * Added data check to check for problematic target labels :pr:`814`
@@ -52,11 +60,11 @@ Changelog
     **Breaking Changes**
         * Pipelines' static ``component_graph`` field must contain either ``ComponentBase`` subclasses or ``str``, instead of ``ComponentBase`` subclass instances :pr:`850`
         * Rename ``handle_component`` to ``handle_component_class``. Now standardizes to ``ComponentBase`` subclasses instead of ``ComponentBase`` subclass instances :pr:`850`
-        * Renamed `automl` `cv` argument to `data_split` :pr:`877`
-        * Pipelines' and classifiers' `feature_importances` is renamed `feature_importance`, `graph_feature_importances` is renamed `graph_feature_importance` :pr:`883`
-        * Passing data_checks=None to automl search will not perform any data checks as opposed to default checks. :pr:`892`
+        * Renamed automl's ``cv`` argument to ``data_split`` :pr:`877`
+        * Pipelines' and classifiers' ``feature_importances`` is renamed `feature_importance`, `graph_feature_importances` is renamed `graph_feature_importance` :pr:`883`
+        * Passing ``data_checks=None`` to automl search will not perform any data checks as opposed to default checks. :pr:`892`
         * Pipelines to search for in AutoML are now determined automatically, rather than using the statically-defined pipeline classes. :pr:`870`
-        * Updated `AutoSearchBase.get_pipelines` to return an untrained pipeline instance, instead of one which happened to be trained on the final cross-validation fold :pr:`876`
+        * Updated ``AutoSearchBase.get_pipelines`` to return an untrained pipeline instance, instead of one which happened to be trained on the final cross-validation fold :pr:`876`
 
 
 **v0.10.0 May 29, 2020**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -28,4 +28,4 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-__version__ = '0.10.0'
+__version__ = '0.11.0'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='evalml',
-    version='0.10.0',
+    version='0.11.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     url='https://www.alteryx.com/innovation-labs',


### PR DESCRIPTION

# v0.11.0 June 30, 2020
### Enhancements

 - Added multiclass support for ROC curve graphing #832
 - Added preprocessing component to drop features whose percentage of NaN values exceeds a specified threshold #834
 - Added data check to check for problematic target labels #814
 - Added PerColumnImputer that allows imputation strategies per column #824
 - Added transformer to drop specific columns #827
 - Added support for `categories`, `handle_error`, and `drop` parameters in `OneHotEncoder` #830 #897
 - Added preprocessing component to handle DateTime columns featurization #838
 - Added ability to clone pipelines and components #842
 - Define getter method for component `parameters` #847
 - Added utility methods to calculate and graph permutation importances #860, #880
 - Added new utility functions necessary for generating dynamic preprocessing pipelines #852
 - Added kwargs to all components #863
 - Updated `AutoSearchBase` to use dynamically generated preprocessing pipelines #870
 - Added SelectColumns transformer #873
 - Added ability to evaluate additional pipelines for automl search #874
 - Added `default_parameters` class property to components and pipelines #879
 - Added better support for disabling data checks in automl search #892
 - Added ability to save and load AutoML objects to file #888
 - Updated `AutoSearchBase.get_pipelines` to return an untrained pipeline instance #876
 - Saved learned binary classification thresholds in automl results cv data dict #876

### Fixes
 - Fixed bug where SimpleImputer cannot handle dropped columns #846
 - Fixed bug where PerColumnImputer cannot handle dropped columns #855
 - Enforce requirement that builtin components save all inputted values in their parameters dict #847
 - Don't list base classes in `all_components` output #847
 - Standardize all components to output pandas data structures, and accept either pandas or numpy #853
 - Fixed rankings and full_rankings error when search has not been run #894

### Changes
 - Update `all_pipelines` and `all_components` to try initializing pipelines/components, and on failure exclude them #849
 - Refactor `handle_components` to `handle_components_class`, standardize to `ComponentBase` subclass instead of instance #850
 - Refactor "blacklist"/"whitelist" to "allow"/"exclude" lists #854
 - Replaced `AutoClassificationSearch` and `AutoRegressionSearch` with `AutoMLSearch` #871
 - Renamed feature_importances and permutation_importances methods to use singular names (feature_importance and permutation_importance) #883
 - Updated `automl` default data splitter to train/validation split for large datasets #877
 - Added open source license, update some repo metadata #887

### Documentation Changes
 - Fix some typos and update the EvalML logo #872

### Testing Changes
 - Update the changelog check job to expect the new branching pattern for the deps update bot #836
 - Check that all components output pandas datastructures, and can accept either pandas or numpy #853
 - Replaced `AutoClassificationSearch` and `AutoRegressionSearch` with `AutoMLSearch` #871

### Breaking Changes
 - Pipelines' static ``component_graph`` field must contain either ``ComponentBase`` subclasses or ``str``, instead of ``ComponentBase`` subclass instances #850
 - Rename ``handle_component`` to ``handle_component_class``. Now standardizes to ``ComponentBase`` subclasses instead of ``ComponentBase`` subclass instances #850
 - Renamed automl's ``cv`` argument to ``data_split`` #877
 - Pipelines' and classifiers' ``feature_importances`` is renamed `feature_importance`, `graph_feature_importances` is renamed `graph_feature_importance` #883
 - Passing ``data_checks=None`` to automl search will not perform any data checks as opposed to default checks. #892
 - Pipelines to search for in AutoML are now determined automatically, rather than using the statically - defined pipeline classes. #870
 - Updated ``AutoSearchBase.get_pipelines`` to return an untrained pipeline instance, instead of one which happened to be trained on the final cross - validation fold #876
