### PR TITLE
Misc edits to `explain_prediction` documentation

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -231,8 +231,6 @@ Regressors are components that output a predicted target value.
 Prediction Explanations
 ========================
 
-XGBoost models and CatBoost multiclass classifiers are not currently supported.
-
 .. autosummary::
     :toctree: generated
     :nosignatures:

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -189,7 +189,7 @@
    "source": [
     "The interpretation of the table is the same for regression problems - but the SHAP value now corresponds to the change in the estimated value of the dependent variable rather than a change in probability. For multiclass classification problems, a table will be output for each possible class.\n",
     "\n",
-    "This functionality is currently not **supported** for **XGBoost** models or **CatBoost multiclass** classifiers."
+    "This functionality is currently **not supported** for **XGBoost** models or **CatBoost multiclass** classifiers."
    ]
   }
  ],

--- a/evalml/pipelines/prediction_explanations/__init__.py
+++ b/evalml/pipelines/prediction_explanations/__init__.py
@@ -1,2 +1,2 @@
 # flake8:noqa
-from ._explainers import _explain_prediction as explain_prediction
+from .explainers import explain_prediction

--- a/evalml/pipelines/prediction_explanations/explainers.py
+++ b/evalml/pipelines/prediction_explanations/explainers.py
@@ -9,8 +9,10 @@ from evalml.pipelines.prediction_explanations._user_interface import (
 )
 
 
-def _explain_prediction(pipeline, input_features, top_k=3, training_data=None, include_shap_values=False):
+def explain_prediction(pipeline, input_features, top_k=3, training_data=None, include_shap_values=False):
     """Creates table summarizing the top_k positive and top_k negative contributing features to the prediction of a single datapoint.
+
+    XGBoost models and CatBoost multiclass classifiers are not currently supported.
 
     Arguments:
         pipeline (PipelineBase): Fitted pipeline whose predictions we want to explain with SHAP.

--- a/evalml/tests/pipeline_tests/explanations_tests/test_explainers.py
+++ b/evalml/tests/pipeline_tests/explanations_tests/test_explainers.py
@@ -4,8 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from evalml.pipelines.prediction_explanations._explainers import (
-    _explain_prediction
+from evalml.pipelines.prediction_explanations.explainers import (
+    explain_prediction
 )
 
 test_features = [5, [1], np.ones((1, 15)), pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).iloc[0],
@@ -13,19 +13,19 @@ test_features = [5, [1], np.ones((1, 15)), pd.DataFrame({"a": [1, 2, 3], "b": [1
 
 
 @pytest.mark.parametrize("test_features", test_features)
-@patch("evalml.pipelines.prediction_explanations._explainers._compute_shap_values")
-@patch("evalml.pipelines.prediction_explanations._explainers._normalize_shap_values")
+@patch("evalml.pipelines.prediction_explanations.explainers._compute_shap_values")
+@patch("evalml.pipelines.prediction_explanations.explainers._normalize_shap_values")
 def test_explain_prediction_value_error(mock_normalize_shap_values, mock_compute_shap_values, test_features):
     with pytest.raises(ValueError, match="features must be stored in a dataframe of one row."):
-        _explain_prediction(None, input_features=test_features, training_data=None)
+        explain_prediction(None, input_features=test_features, training_data=None)
 
 
-@patch("evalml.pipelines.prediction_explanations._explainers._compute_shap_values", return_value={"a": [1], "b": [-2],
-                                                                                                  "c": [-0.25], "d": [2]})
-@patch("evalml.pipelines.prediction_explanations._explainers._normalize_shap_values", return_value={"a": [0.5],
-                                                                                                    "b": [-0.75],
-                                                                                                    "c": [-0.25],
-                                                                                                    "d": [0.75]})
+@patch("evalml.pipelines.prediction_explanations.explainers._compute_shap_values", return_value={"a": [1], "b": [-2],
+                                                                                                 "c": [-0.25], "d": [2]})
+@patch("evalml.pipelines.prediction_explanations.explainers._normalize_shap_values", return_value={"a": [0.5],
+                                                                                                   "b": [-0.75],
+                                                                                                   "c": [-0.25],
+                                                                                                   "d": [0.75]})
 def test_explain_prediction_runs(mock_normalize_shap_values, mock_compute_shap_values):
 
     answer = """Feature Name   Contribution to Prediction
@@ -37,7 +37,7 @@ def test_explain_prediction_runs(mock_normalize_shap_values, mock_compute_shap_v
 
     pipeline = MagicMock()
     features = pd.DataFrame({"a": [1], "b": [2]})
-    table = _explain_prediction(pipeline, features).splitlines()
+    table = explain_prediction(pipeline, features).splitlines()
 
     assert len(table) == len(answer)
     for row, row_answer in zip(table, answer):


### PR DESCRIPTION
# Pull Request Description

1. Adds a sentence to the api reference/User Guide about how XGBoost and CatBoost are not fully supported.
2. Moves a paragraph of the explaining predictions section of the user guide below the code block.

### Change to API Reference
![image](https://user-images.githubusercontent.com/41651716/88821342-8bd96f00-d190-11ea-871b-52e181518f77.png)


### Change to Model Understanding Tutorial
![image](https://user-images.githubusercontent.com/41651716/88821458-b0cde200-d190-11ea-9fc2-b36a61f8327a.png)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
