### PR TITLE
CI job to check that all test dirs are included in package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,6 @@ jobs:
           source test_python/bin/activate
           make -C docs/ html
       - run: ls docs/build/html
-
   check_dependencies_updated_linux:
     parameters:
       python_version:
@@ -249,7 +248,6 @@ jobs:
           when: on_fail
       - store_artifacts:
           path: /tmp/dependencies_updated_artifacts
-
 
 workflows:
   version: 2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,7 +20,7 @@ Release Notes
         * Update setup.py URL to point to the github repo :pr:`1037`
     * Testing Changes
         * Refactor CircleCI tests to use matrix jobs (:pr:`1043`)
-        * Added CI job to check that all test directories are included in package :pr:`1054`
+        * Added a test to check that all test directories are included in evalml package :pr:`1054`
 
 
 .. warning::


### PR DESCRIPTION
### Pull Request Description

Closes #1031 . The new job should is called `check_all_test_dirs_included`. I tested it locally and by creating two dummy PRs and seeing if the CI job passes/fails as it should.

#1055 should fail the new check because the new test directory does not have an init file.
#1056 should pass the new check.


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
