### PR TITLE
Parameter validation for both PipelineBase and ComponentBase

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -28,6 +28,7 @@ Release Notes
         * Added "Feature Value" column to prediction explanation reports. :pr:`1064`
         * Added LightGBM classification estimator :pr:`1082`, :pr:`1114`
         * Added `max_batches` parameter to AutoMLSearch :pr:`1087`
+        * Added parameter validation for PipelineBase and hyperparameter validation for ComponentBase :pr:``
     * Fixes
         * Updated TextFeaturizer component to no longer require an internet connection to run :pr:`1022`
         * Fixed non-deterministic element of TextFeaturizer transformations :pr:`1022`

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -24,6 +24,7 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
         self._component_obj = component_obj
         self._parameters = parameters or {}
         self._is_fitted = False
+        self.validate_parameters(parameters)
 
     @property
     @classmethod
@@ -64,6 +65,23 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
             cls._default_parameters = cls().parameters
 
         return cls._default_parameters
+
+    def validate_parameters(self, parameters, err_annotation=""):
+        """Determines if the parameters passed in are in the hyperparameter ranges allowed.
+
+            Arguments:
+                parameters (dict): dictionary of parameters passed in for this component
+                err_annotation (str): string to display if error comes up.
+        """
+        if parameters:
+            try:
+                hyperparams = self.hyperparameter_ranges
+                for parameter, parameter_value in self.parameters.items():
+                    if parameter in hyperparams.keys():
+                        if parameter_value not in hyperparams[parameter]:
+                            raise ValueError("{}{} = {} not in hyperparameter range of {}".format(err_annotation, parameter, parameter_value, hyperparams[parameter]))
+            except AttributeError:
+                pass
 
     def clone(self, random_state=0):
         """Constructs a new component with the same parameters

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -69,6 +69,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
 
         self._validate_estimator_problem_type()
         self._is_fitted = False
+        self._validate_parameters(parameters)
 
     @classproperty
     def name(cls):
@@ -468,3 +469,14 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             A new instance of this pipeline with identical parameters and components
         """
         return self.__class__(self.parameters, random_state=random_state)
+
+    def _validate_parameters(self, parameters):
+        err_annotation = 'Error in {}:'.format(self.name)
+        # check to make sure all parameters passed in are in component_graph
+        diff = set.difference(set(parameters.keys()), {c.name for c in self.component_graph})
+        if len(diff) > 0:
+            raise ValueError("{} Extra components found: {}".format(err_annotation, str(diff)))
+        # validate all components that are passed in through parameters
+        for component in self.component_graph:
+            if component.name in parameters.keys():
+                component.validate_parameters(parameters[component.name], err_annotation=err_annotation)

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -769,3 +769,17 @@ def test_serialization_protocol(mock_cloudpickle_dump, tmpdir):
     component.save(path, pickle_protocol=42)
     assert len(mock_cloudpickle_dump.call_args_list) == 1
     assert mock_cloudpickle_dump.call_args_list[0][1]['protocol'] == 42
+
+
+def test_transformer_params():
+    OneHotEncoder(top_n=0, drop=None, handle_unknown="ignore", handle_missing="error", categories=None)
+
+    with pytest.raises(ValueError, match="percent_features = -0.5 not in hyperparameter range"):
+        RFClassifierSelectFromModel(percent_features=-0.5)
+
+
+def test_estimator_param_out_of_range():
+    with pytest.raises(ValueError, match="penalty = l4 not in hyperparameter range"):
+        LogisticRegressionClassifier(penalty="l4", C=1.0, n_jobs=-1, random_state=0)
+
+    RandomForestClassifier(n_estimators=10, max_depth=2)


### PR DESCRIPTION
fix #454 

Create validations for `PipelineBase` to ensure parameters are valid and parameter args are valid. Create validation for `ComponentBase` to ensure all parameters are in the hyperparameter range. 