### PR TITLE
Parametrizing DataChecks

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Added LightGBM to AutoMLSearch :pr:`1199`
         * Updates scikit-learn and scikit-optimize to use latest versions - 0.23.2 and 0.8.1 respectively :pr:`1141`
         * Add `ProblemTypes.all_problem_types` helper to get list of supported problem types :pr:`1219`
+        * `DataChecks` can now be parametrized by passing a list of `DataCheck` classes and a parameter dictionary :pr:`1167`
     * Fixes
         * Updated GitHub URL after migration to Alteryx GitHub org :pr:`1207`
         * Changed Problem Type enum to be more similar to the string name :pr:`1208`
@@ -21,6 +22,11 @@ Release Notes
         * Add pipeline properties to API reference :pr:`1209`
         * Improved description of `max_iterations` in documentation :pr:`1212`
     * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+        * DefaultDataChecks now accepts a problem_type parameter that must be specified :pr:`1167`
 
 
 **v0.13.2 Sep. 17, 2020**

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -301,7 +301,7 @@ class AutoMLSearch:
 
         return search_desc + rankings_desc
 
-    def _validate_data_checks(self, data_checks, params):
+    def _validate_data_checks(self, data_checks):
         """Validate data_checks parameter.
 
         Arguments:
@@ -314,7 +314,7 @@ class AutoMLSearch:
         if isinstance(data_checks, DataChecks):
             return data_checks
         elif isinstance(data_checks, list):
-            return DataChecks(data_checks, data_check_params=params)
+            return DataChecks(data_checks)
         elif isinstance(data_checks, str):
             if data_checks == "auto":
                 return DefaultDataChecks(problem_type=self.problem_type)
@@ -326,7 +326,7 @@ class AutoMLSearch:
         elif data_checks is None:
             return EmptyDataChecks()
         else:
-            return DataChecks(data_checks, data_check_params=params)
+            return DataChecks(data_checks)
 
     def _handle_keyboard_interrupt(self, pipeline, current_batch_pipelines):
         """Presents a prompt to the user asking if they want to stop the search.
@@ -354,11 +354,10 @@ class AutoMLSearch:
             else:
                 leading_char = ""
 
-    def search(self, X, y, data_checks="auto", data_check_params=None, show_iteration_plot=True, feature_types=None):
+    def search(self, X, y, data_checks="auto", show_iteration_plot=True, feature_types=None):
         """Find the best pipeline for the data set.
 
         Arguments:
-            data_check_params:
             X (pd.DataFrame): the input training data of shape [n_samples, n_features]
 
             y (pd.Series): the target training data of length [n_samples]
@@ -402,7 +401,7 @@ class AutoMLSearch:
 
         self.data_split = self.data_split or default_data_split
 
-        data_checks = self._validate_data_checks(data_checks, data_check_params)
+        data_checks = self._validate_data_checks(data_checks)
         data_check_results = data_checks.validate(X, y)
 
         if len(data_check_results) > 0:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -301,8 +301,7 @@ class AutoMLSearch:
 
         return search_desc + rankings_desc
 
-    @staticmethod
-    def _validate_data_checks(data_checks):
+    def _validate_data_checks(self, data_checks, params):
         """Validate data_checks parameter.
 
         Arguments:
@@ -315,10 +314,11 @@ class AutoMLSearch:
         if isinstance(data_checks, DataChecks):
             return data_checks
         elif isinstance(data_checks, list):
-            return DataChecks(data_checks)
+            return DataChecks(data_checks, data_check_params=params)
         elif isinstance(data_checks, str):
             if data_checks == "auto":
-                return DefaultDataChecks()
+                return DataChecks(DefaultDataChecks,
+                                  data_check_params={"InvalidTargetDataCheck": {"problem_type": self.problem_type}})
             elif data_checks == "disabled":
                 return EmptyDataChecks()
             else:
@@ -327,7 +327,7 @@ class AutoMLSearch:
         elif data_checks is None:
             return EmptyDataChecks()
         else:
-            return DataChecks(data_checks)
+            return DataChecks(data_checks, data_check_params=params)
 
     def _handle_keyboard_interrupt(self, pipeline, current_batch_pipelines):
         """Presents a prompt to the user asking if they want to stop the search.
@@ -355,10 +355,11 @@ class AutoMLSearch:
             else:
                 leading_char = ""
 
-    def search(self, X, y, data_checks="auto", feature_types=None, show_iteration_plot=True):
+    def search(self, X, y, data_checks="auto", data_check_params=None, show_iteration_plot=True, feature_types=None):
         """Find the best pipeline for the data set.
 
         Arguments:
+            data_check_params:
             X (pd.DataFrame): the input training data of shape [n_samples, n_features]
 
             y (pd.Series): the target training data of length [n_samples]
@@ -402,7 +403,7 @@ class AutoMLSearch:
 
         self.data_split = self.data_split or default_data_split
 
-        data_checks = self._validate_data_checks(data_checks)
+        data_checks = self._validate_data_checks(data_checks, data_check_params)
         data_check_results = data_checks.validate(X, y)
 
         if len(data_check_results) > 0:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -317,8 +317,7 @@ class AutoMLSearch:
             return DataChecks(data_checks, data_check_params=params)
         elif isinstance(data_checks, str):
             if data_checks == "auto":
-                return DataChecks(DefaultDataChecks,
-                                  data_check_params={"InvalidTargetDataCheck": {"problem_type": self.problem_type}})
+                return DefaultDataChecks(problem_type=self.problem_type)
             elif data_checks == "disabled":
                 return EmptyDataChecks()
             else:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -354,7 +354,7 @@ class AutoMLSearch:
             else:
                 leading_char = ""
 
-    def search(self, X, y, data_checks="auto", show_iteration_plot=True, feature_types=None):
+    def search(self, X, y, data_checks="auto", feature_types=None, show_iteration_plot=True):
         """Find the best pipeline for the data set.
 
         Arguments:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -17,7 +17,12 @@ from .pipeline_search_plots import PipelineSearchPlots
 
 from evalml.automl.automl_algorithm import IterativeAlgorithm
 from evalml.automl.data_splitters import TrainingValidationSplit
-from evalml.data_checks import DataChecks, DefaultDataChecks, EmptyDataChecks
+from evalml.data_checks import (
+    AutoMLDataChecks,
+    DataChecks,
+    DefaultDataChecks,
+    EmptyDataChecks
+)
 from evalml.data_checks.data_check_message_type import DataCheckMessageType
 from evalml.exceptions import (
     AutoMLSearchException,
@@ -314,7 +319,7 @@ class AutoMLSearch:
         if isinstance(data_checks, DataChecks):
             return data_checks
         elif isinstance(data_checks, list):
-            return DataChecks(data_checks)
+            return AutoMLDataChecks(data_checks)
         elif isinstance(data_checks, str):
             if data_checks == "auto":
                 return DefaultDataChecks(problem_type=self.problem_type)

--- a/evalml/data_checks/__init__.py
+++ b/evalml/data_checks/__init__.py
@@ -1,6 +1,6 @@
 # flake8:noqas
 from .data_check import DataCheck
-from .data_checks import DataChecks
+from .data_checks import AutoMLDataChecks, DataChecks
 from .data_check_message import DataCheckMessage, DataCheckWarning, DataCheckError
 from .data_check_message_type import DataCheckMessageType
 from .default_data_checks import DefaultDataChecks

--- a/evalml/data_checks/class_imbalance_data_check.py
+++ b/evalml/data_checks/class_imbalance_data_check.py
@@ -7,16 +7,25 @@ from .data_check_message import DataCheckWarning
 class ClassImbalanceDataCheck(DataCheck):
     """Checks if any target labels are imbalanced beyond a threshold. Use for classification problems"""
 
-    def validate(self, X, y, threshold=0.10):
+    def __init__(self, threshold=0.1):
+        """Check if any of the features are likely to be ID columns.
+
+        Arguments:
+            threshold (float): The minimum threshold allowed for class imbalance before a warning is raised.
+                A perfectly balanced dataset would have a threshold of (1/n_classes), ie 0.50 for binary classes.
+                Defaults to 0.10
+        """
+        if threshold <= 0 or threshold > 0.5:
+            raise ValueError("Provided threshold {} is not within the range (0, 0.5]".format(threshold))
+        self.threshold = threshold
+
+    def validate(self, X, y):
         """Checks if any target labels are imbalanced beyond a threshold for binary and multiclass problems
         Ignores nan values in target labels if they appear
 
         Arguments:
             X (pd.DataFrame, pd.Series, np.array, list): Features. Ignored.
             y: Target labels to check for imbalanced data.
-            threshold (float, optional): The minimum threshold allowed for class imbalance before a warning is raised.
-                                        A perfectly balanced dataset would have a threshold of (1/n_classes), ie 0.50 for binary classes.
-                                        Defaults to 0.10
 
         Returns:
             list (DataCheckWarning): list with DataCheckWarnings if imbalance in classes is less than the threshold.
@@ -24,20 +33,16 @@ class ClassImbalanceDataCheck(DataCheck):
         Example:
             >>> X = pd.DataFrame({})
             >>> y = pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-            >>> threshold = 0.10
-            >>> target_check = ClassImbalanceDataCheck()
-            >>> assert target_check.validate(X, y, threshold) == [DataCheckWarning("The following labels fall below 10% of the target: [0]", "ClassImbalanceDataCheck")]
+            >>> target_check = ClassImbalanceDataCheck(threshold=0.10)
+            >>> assert target_check.validate(X, y) == [DataCheckWarning("The following labels fall below 10% of the target: [0]", "ClassImbalanceDataCheck")]
         """
-        if threshold <= 0 or threshold > 0.5:
-            raise ValueError("Provided threshold {} is not within the range (0, 0.5]".format(threshold))
-
         if not isinstance(y, pd.Series):
             y = pd.Series(y)
         messages = []
         counts = y.value_counts(normalize=True)
-        below_threshold = counts.where(counts < threshold).dropna()
+        below_threshold = counts.where(counts < self.threshold).dropna()
         # if there are items that occur less than the threshold, add them to the list of messages
         if len(below_threshold):
             warning_msg = "The following labels fall below {:.0f}% of the target: {}"
-            messages.append(DataCheckWarning(warning_msg.format(threshold * 100, below_threshold.index.tolist()), self.name))
+            messages.append(DataCheckWarning(warning_msg.format(self.threshold * 100, below_threshold.index.tolist()), self.name))
         return messages

--- a/evalml/data_checks/data_checks.py
+++ b/evalml/data_checks/data_checks.py
@@ -1,6 +1,7 @@
 import inspect
-import warnings
+
 from .data_check import DataCheck
+
 from evalml.exceptions import DataCheckInitError
 
 
@@ -54,8 +55,8 @@ def init_data_checks_from_params(data_check_classes, params):
     data_check_instances = []
     for extraneous_class in set(params.keys()).difference([c.name for c in data_check_classes]):
         raise DataCheckInitError(f"Class {extraneous_class} was provided in params dictionary but it does not match any name in "
-                                  "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
-                                  "attribute of a corresponding DataCheck class.")
+                                 "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
+                                 "attribute of a corresponding DataCheck class.")
 
     for data_check_class in data_check_classes:
         class_params = params.get(data_check_class.name, {})
@@ -66,4 +67,3 @@ def init_data_checks_from_params(data_check_classes, params):
         except TypeError as e:
             raise DataCheckInitError(f"Encountered the following error while initializing {data_check_class.name}: {e}")
     return data_check_instances
-

--- a/evalml/data_checks/data_checks.py
+++ b/evalml/data_checks/data_checks.py
@@ -5,8 +5,60 @@ from .data_check import DataCheck
 from evalml.exceptions import DataCheckInitError
 
 
+def _has_defaults_for_all_args(init):
+    """Tests whether the init method has defaults for all arguments."""
+    signature = inspect.getfullargspec(init)
+    n_default_args = 0 if not signature.defaults else len(signature.defaults)
+    n_args = len(signature.args) - 1 if 'self' in signature.args else len(signature.args)
+    return n_args == n_default_args
+
+
 class DataChecks:
     """A collection of data checks."""
+
+    @staticmethod
+    def _validate_data_checks(data_check_classes, params):
+        """Inits a DataChecks instance from a list of DataCheck classes and corresponding params."""
+        if not isinstance(data_check_classes, list):
+            raise ValueError(f"Parameter data_checks must be a list. Received {type(data_check_classes).__name__}.")
+        if not all(inspect.isclass(check) and issubclass(check, DataCheck) for check in data_check_classes):
+            raise ValueError("All elements of parameter data_checks must be an instance of DataCheck "
+                             "or a DataCheck class with any desired parameters specified in the "
+                             "data_check_params dictionary.")
+        params = params or dict()
+        if not isinstance(params, dict):
+            raise ValueError(f"Params must be a dictionary. Received {params}")
+        in_params = set(params.keys())
+        in_classes = set([c.name for c in data_check_classes])
+        name_to_class = {c.name: c for c in data_check_classes}
+        extraneous = in_params.difference(in_classes)
+        missing = in_classes.difference(in_params)
+        for extraneous_class in extraneous:
+            raise DataCheckInitError(
+                f"Class {extraneous_class} was provided in params dictionary but it does not match any name "
+                "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
+                "attribute of a corresponding DataCheck class.")
+        for missing_class_name in missing:
+            if not _has_defaults_for_all_args(name_to_class[missing_class_name]):
+                raise DataCheckInitError(
+                    f"Class {missing_class_name} was provided in the data_checks_classes list but it does not have "
+                    "an entry in the parameters dictionary.")
+
+    @staticmethod
+    def _init_data_checks(data_check_classes, params):
+        data_check_instances = []
+
+        for data_check_class in data_check_classes:
+            class_params = params.get(data_check_class.name, {})
+            if not isinstance(class_params, dict):
+                raise DataCheckInitError(
+                    f"Parameters for {data_check_class.name} were not in a dictionary. Received {class_params}.")
+            try:
+                data_check_instances.append(data_check_class(**class_params))
+            except TypeError as e:
+                raise DataCheckInitError(
+                    f"Encountered the following error while initializing {data_check_class.name}: {e}")
+        return data_check_instances
 
     def __init__(self, data_checks=None, data_check_params=None):
         """
@@ -15,17 +67,9 @@ class DataChecks:
         Arguments:
             data_checks (list (DataCheck)): List of DataCheck objects
         """
-        if not isinstance(data_checks, list):
-            raise ValueError(f"Parameter data_checks must be a list. Received {type(data_checks).__name__}.")
-        if all(inspect.isclass(check) and issubclass(check, DataCheck) for check in data_checks):
-            data_check_instances = init_data_checks_from_params(data_checks, data_check_params)
-        elif all(isinstance(check, DataCheck) for check in data_checks):
-            data_check_instances = data_checks
-        else:
-            raise ValueError("All elements of parameter data_checks must be an instance of DataCheck "
-                             "or a DataCheck class with any desired parameters specified in the "
-                             "data_check_params dictionary.")
-
+        data_check_params = data_check_params or dict()
+        self._validate_data_checks(data_checks, data_check_params)
+        data_check_instances = self._init_data_checks(data_checks, data_check_params)
         self.data_checks = data_check_instances
 
     def validate(self, X, y=None):
@@ -47,23 +91,9 @@ class DataChecks:
         return messages
 
 
-def init_data_checks_from_params(data_check_classes, params):
-    """Inits a DataChecks instance from a list of DataCheck classes and corresponding params."""
-    params = params or dict()
-    if not isinstance(params, dict):
-        raise ValueError(f"Params must be a dictionary. Received {params}")
-    data_check_instances = []
-    for extraneous_class in set(params.keys()).difference([c.name for c in data_check_classes]):
-        raise DataCheckInitError(f"Class {extraneous_class} was provided in params dictionary but it does not match any name in "
-                                 "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
-                                 "attribute of a corresponding DataCheck class.")
+class AutoMLDataChecks(DataChecks):
 
-    for data_check_class in data_check_classes:
-        class_params = params.get(data_check_class.name, {})
-        if not isinstance(class_params, dict):
-            raise DataCheckInitError(f"Parameters for {data_check_class.name} were not in a dictionary. Received {class_params}.")
-        try:
-            data_check_instances.append(data_check_class(**class_params))
-        except TypeError as e:
-            raise DataCheckInitError(f"Encountered the following error while initializing {data_check_class.name}: {e}")
-    return data_check_instances
+    def __init__(self, data_check_instances):
+        if not all(isinstance(check, DataCheck) for check in data_check_instances):
+            raise ValueError("All elements of parameter data_checks must be an instance of DataCheck.")
+        self.data_checks = data_check_instances

--- a/evalml/data_checks/data_checks.py
+++ b/evalml/data_checks/data_checks.py
@@ -49,11 +49,13 @@ class DataChecks:
 def init_data_checks_from_params(data_check_classes, params):
     """Inits a DataChecks instance from a list of DataCheck classes and corresponding params."""
     params = params or dict()
+    if not isinstance(params, dict):
+        raise ValueError(f"Params must be a dictionary. Received {params}")
     data_check_instances = []
     for extraneous_class in set(params.keys()).difference([c.name for c in data_check_classes]):
-        warnings.warn(f"Class {extraneous_class} was provided in params dictionary but it does not match any name in "
-                      "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
-                      "attribute of a corresponding DataCheck class.")
+        raise DataCheckInitError(f"Class {extraneous_class} was provided in params dictionary but it does not match any name in "
+                                  "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
+                                  "attribute of a corresponding DataCheck class.")
 
     for data_check_class in data_check_classes:
         class_params = params.get(data_check_class.name, {})

--- a/evalml/data_checks/data_checks.py
+++ b/evalml/data_checks/data_checks.py
@@ -1,10 +1,13 @@
+import inspect
+import warnings
 from .data_check import DataCheck
+from evalml.exceptions import DataCheckInitError
 
 
 class DataChecks:
     """A collection of data checks."""
 
-    def __init__(self, data_checks=None):
+    def __init__(self, data_checks=None, data_check_params=None):
         """
         A collection of data checks.
 
@@ -13,10 +16,16 @@ class DataChecks:
         """
         if not isinstance(data_checks, list):
             raise ValueError(f"Parameter data_checks must be a list. Received {type(data_checks).__name__}.")
-        if not all(isinstance(check, DataCheck) for check in data_checks):
-            raise ValueError("All elements of parameter data_checks must be an instance of DataCheck.")
+        if all(inspect.isclass(check) and issubclass(check, DataCheck) for check in data_checks):
+            data_check_instances = init_data_checks_from_params(data_checks, data_check_params)
+        elif all(isinstance(check, DataCheck) for check in data_checks):
+            data_check_instances = data_checks
+        else:
+            raise ValueError("All elements of parameter data_checks must be an instance of DataCheck "
+                             "or a DataCheck class with any desired parameters specified in the "
+                             "data_check_params dictionary.")
 
-        self.data_checks = data_checks
+        self.data_checks = data_check_instances
 
     def validate(self, X, y=None):
         """
@@ -35,3 +44,24 @@ class DataChecks:
             messages_new = data_check.validate(X, y)
             messages.extend(messages_new)
         return messages
+
+
+def init_data_checks_from_params(data_check_classes, params):
+    """Inits a DataChecks instance from a list of DataCheck classes and corresponding params."""
+    params = params or dict()
+    data_check_instances = []
+    for extraneous_class in set(params.keys()).difference([c.name for c in data_check_classes]):
+        warnings.warn(f"Class {extraneous_class} was provided in params dictionary but it does not match any name in "
+                      "in the data_check_classes list. Make sure every key of the params dictionary matches the name"
+                      "attribute of a corresponding DataCheck class.")
+
+    for data_check_class in data_check_classes:
+        class_params = params.get(data_check_class.name, {})
+        if not isinstance(class_params, dict):
+            raise DataCheckInitError(f"Parameters for {data_check_class.name} were not in a dictionary. Received {class_params}.")
+        try:
+            data_check_instances.append(data_check_class(**class_params))
+        except TypeError as e:
+            raise DataCheckInitError(f"Encountered the following error while initializing {data_check_class.name}: {e}")
+    return data_check_instances
+

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -5,14 +5,14 @@ from .invalid_targets_data_check import InvalidTargetDataCheck
 from .label_leakage_data_check import LabelLeakageDataCheck
 from .no_variance_data_check import NoVarianceDataCheck
 
-_default_data_checks_classes = [HighlyNullDataCheck, IDColumnsDataCheck,
-                                LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck]
-
 
 class DefaultDataChecks(DataChecks):
     """A collection of basic data checks that is used by AutoML by default.
     Includes HighlyNullDataCheck, IDColumnsDataCheck, LabelLeakageDataCheck, InvalidTargetDataCheck,
     and NoVarianceDataCheck."""
+
+    _DEFAULT_DATA_CHECK_CLASSES = [HighlyNullDataCheck, IDColumnsDataCheck,
+                                   LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck]
 
     def __init__(self, problem_type):
         """
@@ -20,5 +20,5 @@ class DefaultDataChecks(DataChecks):
         Arguments:
             problem_type (str): The problem type that is being validated. Can be regression, binary, or multiclass.
         """
-        super().__init__(_default_data_checks_classes,
+        super().__init__(self._DEFAULT_DATA_CHECK_CLASSES,
                          data_check_params={"InvalidTargetDataCheck": {"problem_type": problem_type}})

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -18,7 +18,7 @@ class DefaultDataChecks(DataChecks):
         """
         A collection of basic data checks.
         Arguments:
-            problem_type (str): The problem type that is being validated. Can be regression,
+            problem_type (str): The problem type that is being validated. Can be regression, binary, or multiclass.
         """
         super().__init__(_default_data_checks_classes,
                          data_check_params={"InvalidTargetDataCheck": {"problem_type": problem_type}})

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -5,7 +5,6 @@ from .invalid_targets_data_check import InvalidTargetDataCheck
 from .label_leakage_data_check import LabelLeakageDataCheck
 from .no_variance_data_check import NoVarianceDataCheck
 
-
 _default_data_checks_classes = [HighlyNullDataCheck, IDColumnsDataCheck,
                                 LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck]
 

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -1,3 +1,4 @@
+from .data_checks import DataChecks
 from .highly_null_data_check import HighlyNullDataCheck
 from .id_columns_data_check import IDColumnsDataCheck
 from .invalid_targets_data_check import InvalidTargetDataCheck
@@ -5,6 +6,17 @@ from .label_leakage_data_check import LabelLeakageDataCheck
 from .no_variance_data_check import NoVarianceDataCheck
 
 
-DefaultDataChecks = [HighlyNullDataCheck, IDColumnsDataCheck,
-                     LabelLeakageDataCheck, InvalidTargetDataCheck,
-                     NoVarianceDataCheck]
+class DefaultDataChecks(DataChecks):
+    """A collection of basic data checks that is used by AutoML by default.
+    Includes HighlyNullDataCheck, IDColumnsDataCheck, LabelLeakageDataCheck, InvalidTargetDataCheck,
+    and NoVarianceDataCheck."""
+
+    def __init__(self, problem_type):
+        """
+        A collection of basic data checks.
+        Arguments:
+            problem_type (str): The problem type that is being validated. Can be regression,
+        """
+        super().__init__([HighlyNullDataCheck, IDColumnsDataCheck,
+                          LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck],
+                         data_check_params={"InvalidTargetDataCheck": {"problem_type": problem_type}})

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -6,6 +6,10 @@ from .label_leakage_data_check import LabelLeakageDataCheck
 from .no_variance_data_check import NoVarianceDataCheck
 
 
+_default_data_checks_classes = [HighlyNullDataCheck, IDColumnsDataCheck,
+                                LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck]
+
+
 class DefaultDataChecks(DataChecks):
     """A collection of basic data checks that is used by AutoML by default.
     Includes HighlyNullDataCheck, IDColumnsDataCheck, LabelLeakageDataCheck, InvalidTargetDataCheck,
@@ -17,6 +21,5 @@ class DefaultDataChecks(DataChecks):
         Arguments:
             problem_type (str): The problem type that is being validated. Can be regression,
         """
-        super().__init__([HighlyNullDataCheck, IDColumnsDataCheck,
-                          LabelLeakageDataCheck, InvalidTargetDataCheck, NoVarianceDataCheck],
+        super().__init__(_default_data_checks_classes,
                          data_check_params={"InvalidTargetDataCheck": {"problem_type": problem_type}})

--- a/evalml/data_checks/default_data_checks.py
+++ b/evalml/data_checks/default_data_checks.py
@@ -1,4 +1,3 @@
-from .data_checks import DataChecks
 from .highly_null_data_check import HighlyNullDataCheck
 from .id_columns_data_check import IDColumnsDataCheck
 from .invalid_targets_data_check import InvalidTargetDataCheck
@@ -6,19 +5,6 @@ from .label_leakage_data_check import LabelLeakageDataCheck
 from .no_variance_data_check import NoVarianceDataCheck
 
 
-class DefaultDataChecks(DataChecks):
-    """A collection of basic data checks that is used by AutoML by default.
-
-    Includes HighlyNullDataCheck, IDColumnsDataCheck, LabelLeakageDataCheck, InvalidTargetDataCheck,
-    and NoVarianceDataCheck."""
-
-    def __init__(self, data_checks=None):
-        """
-        A collection of basic data checks.
-
-        Arguments:
-            data_checks (list (DataCheck)): Ignored.
-        """
-        self.data_checks = [HighlyNullDataCheck(), IDColumnsDataCheck(),
-                            LabelLeakageDataCheck(), InvalidTargetDataCheck(),
-                            NoVarianceDataCheck()]
+DefaultDataChecks = [HighlyNullDataCheck, IDColumnsDataCheck,
+                     LabelLeakageDataCheck, InvalidTargetDataCheck,
+                     NoVarianceDataCheck]

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -7,13 +7,14 @@ from evalml.utils.gen_utils import (
     categorical_dtypes,
     numeric_and_boolean_dtypes
 )
+from evalml.problem_types import handle_problem_types, ProblemTypes
 
 
 class InvalidTargetDataCheck(DataCheck):
     """Checks if the target data contains missing or invalid values."""
 
     def __init__(self, problem_type):
-        self.problem_type = problem_type
+        self.problem_type = handle_problem_types(problem_type)
 
     def validate(self, X, y):
         """Checks if the target data contains missing or invalid values.
@@ -43,6 +44,10 @@ class InvalidTargetDataCheck(DataCheck):
             messages.append(DataCheckError("Target is unsupported {} type. Valid target types include: {}".format(y.dtype, ", ".join(valid_target_types)), self.name))
 
         value_counts = y.value_counts()
+
+        if self.problem_type == ProblemTypes.BINARY and len(value_counts) != 2:
+            messages.append(DataCheckError("Target does not have two unique values which is not supported for binary classification", self.name))
+
         if len(value_counts) == 2 and y.dtype in numeric_and_boolean_dtypes:
             unique_values = value_counts.index.tolist()
             if set(unique_values) != set([0, 1]):

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -12,6 +12,9 @@ from evalml.utils.gen_utils import (
 class InvalidTargetDataCheck(DataCheck):
     """Checks if the target data contains missing or invalid values."""
 
+    def __init__(self, problem_type):
+        self.problem_type = problem_type
+
     def validate(self, X, y):
         """Checks if the target data contains missing or invalid values.
 
@@ -25,7 +28,7 @@ class InvalidTargetDataCheck(DataCheck):
         Example:
             >>> X = pd.DataFrame({})
             >>> y = pd.Series([0, 1, None, None])
-            >>> target_check = InvalidTargetDataCheck()
+            >>> target_check = InvalidTargetDataCheck('binary')
             >>> assert target_check.validate(X, y) == [DataCheckError("2 row(s) (50.0%) of target values are null", "InvalidTargetDataCheck")]
         """
         if not isinstance(y, pd.Series):

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -3,11 +3,11 @@ import pandas as pd
 from .data_check import DataCheck
 from .data_check_message import DataCheckError
 
+from evalml.problem_types import ProblemTypes, handle_problem_types
 from evalml.utils.gen_utils import (
     categorical_dtypes,
     numeric_and_boolean_dtypes
 )
-from evalml.problem_types import handle_problem_types, ProblemTypes
 
 
 class InvalidTargetDataCheck(DataCheck):

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -61,3 +61,7 @@ class PipelineScoreError(Exception):
 
         self.message = message
         super().__init__(message)
+
+
+class DataCheckInitError(Exception):
+    """Exception raised when a data check can't init with the parameters given."""

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -64,4 +64,4 @@ class PipelineScoreError(Exception):
 
 
 class DataCheckInitError(Exception):
-    """Exception raised when a data check can't init with the parameters given."""
+    """Exception raised when a data check can't initialize with the parameters given."""

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -317,7 +317,7 @@ def test_automl_empty_data_checks(mock_fit, mock_score):
     assert automl.data_check_results is None
 
 
-@patch('evalml.data_checks.DefaultDataChecks.validate')
+@patch('evalml.data_checks.DataChecks.validate')
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 def test_automl_default_data_checks(mock_fit, mock_score, mock_validate, X_y_binary, caplog):

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -317,7 +317,7 @@ def test_automl_empty_data_checks(mock_fit, mock_score):
     assert automl.data_check_results is None
 
 
-@patch('evalml.data_checks.DataChecks.validate')
+@patch('evalml.data_checks.DefaultDataChecks.validate')
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 def test_automl_default_data_checks(mock_fit, mock_score, mock_validate, X_y_binary, caplog):

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -338,6 +338,7 @@ class MockDataCheckErrorAndWarning(DataCheck):
     def validate(self, X, y):
         return [DataCheckError("error one", self.name), DataCheckWarning("warning one", self.name)]
 
+
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog):
@@ -366,6 +367,7 @@ def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog):
     assert "error one" in out
     assert "warning one" in out
     assert automl.data_check_results == MockDataCheckErrorAndWarning().validate(X, y)
+
 
 @pytest.mark.parametrize("data_checks",
                          [[MockDataCheckErrorAndWarning()],

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -339,36 +339,6 @@ class MockDataCheckErrorAndWarning(DataCheck):
         return [DataCheckError("error one", self.name), DataCheckWarning("warning one", self.name)]
 
 
-@patch('evalml.pipelines.BinaryClassificationPipeline.score')
-@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
-def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog, X_y_binary):
-    X, y = X_y_binary
-
-    class MockDataCheckNoError(DataCheck):
-        name = "Mock Check"
-
-        def __init__(self, foo):
-            """Mock Init"""
-
-        def validate(self, X, y=None):
-            """Mock validate"""
-            return []
-
-    automl = AutoMLSearch(problem_type="binary", max_pipelines=1)
-
-    with patch.object(MockDataCheckNoError, "__init__", return_value=None) as mock_init:
-        automl.search(X, y, data_checks=[MockDataCheckNoError], data_check_params={"Mock Check": {"foo": 1}})
-        mock_init.assert_called_once_with(foo=1)
-
-    with pytest.raises(ValueError, match="Data checks raised"):
-        automl.search(X, y, data_checks=[MockDataCheckErrorAndWarning()])
-
-    out = caplog.text
-    assert "error one" in out
-    assert "warning one" in out
-    assert automl.data_check_results == MockDataCheckErrorAndWarning().validate(X, y)
-
-
 @pytest.mark.parametrize("data_checks",
                          [[MockDataCheckErrorAndWarning()],
                           DataChecks([MockDataCheckErrorAndWarning()])])

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -341,15 +341,14 @@ class MockDataCheckErrorAndWarning(DataCheck):
 
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
-def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog):
-    X = pd.DataFrame()
-    y = pd.Series()
+def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog, X_y_binary):
+    X, y = X_y_binary
 
     class MockDataCheckNoError(DataCheck):
         name = "Mock Check"
 
         def __init__(self, foo):
-            self.foo = foo
+            """Mock Init"""
 
         def validate(self, X, y=None):
             """Mock validate"""
@@ -357,11 +356,12 @@ def test_automl_can_init_data_checks_from_classes(mock_fit, mock_score, caplog):
 
     automl = AutoMLSearch(problem_type="binary", max_pipelines=1)
 
+    with patch.object(MockDataCheckNoError, "__init__", return_value=None) as mock_init:
+        automl.search(X, y, data_checks=[MockDataCheckNoError], data_check_params={"Mock Check": {"foo": 1}})
+        mock_init.assert_called_once_with(foo=1)
+
     with pytest.raises(ValueError, match="Data checks raised"):
-        with patch.object(MockDataCheckNoError, "__init__", return_value=None) as mock_init:
-            automl.search(X, y, data_checks=[MockDataCheckErrorAndWarning, MockDataCheckNoError],
-                          data_check_params={"Mock Check": {"foo": 1}})
-            assert mock_init.assert_called_once_with(foo=1)
+        automl.search(X, y, data_checks=[MockDataCheckErrorAndWarning()])
 
     out = caplog.text
     assert "error one" in out

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -341,7 +341,7 @@ class MockDataCheckErrorAndWarning(DataCheck):
 
 @pytest.mark.parametrize("data_checks",
                          [[MockDataCheckErrorAndWarning()],
-                          DataChecks([MockDataCheckErrorAndWarning()])])
+                          DataChecks([MockDataCheckErrorAndWarning])])
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 def test_automl_data_checks_raises_error(mock_fit, mock_score, data_checks, caplog):

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -374,6 +374,8 @@ def test_automl_bad_data_check_parameter_type():
         automl.search(X, y, data_checks="default")
     with pytest.raises(ValueError, match="All elements of parameter data_checks must be an instance of DataCheck."):
         automl.search(X, y, data_checks=[DataChecks([]), 1])
+    with pytest.raises(ValueError, match="All elements of parameter data_checks must be an instance of DataCheck."):
+        automl.search(X, y, data_checks=[MockDataCheckErrorAndWarning])
 
 
 def test_automl_str_no_param_search():

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -10,7 +10,6 @@ from evalml.data_checks.class_imbalance_data_check import (
 
 def test_class_imbalance_invalid_threshold():
     X = pd.DataFrame()
-    class_imbalance_check = ClassImbalanceDataCheck()
 
     with pytest.raises(ValueError, match="threshold 0 is not within the range"):
         ClassImbalanceDataCheck(threshold=0).validate(X, y=pd.Series([0, 1, 1]))

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -13,13 +13,13 @@ def test_class_imbalance_invalid_threshold():
     class_imbalance_check = ClassImbalanceDataCheck()
 
     with pytest.raises(ValueError, match="threshold 0 is not within the range"):
-        class_imbalance_check.validate(X, y=pd.Series([0, 1, 1]), threshold=0)
+        ClassImbalanceDataCheck(threshold=0).validate(X, y=pd.Series([0, 1, 1]))
 
     with pytest.raises(ValueError, match="threshold 0.51 is not within the range"):
-        class_imbalance_check.validate(X, y=pd.Series([0, 1, 1]), threshold=0.51)
+        ClassImbalanceDataCheck(threshold=0.51).validate(X, y=pd.Series([0, 1, 1]))
 
     with pytest.raises(ValueError, match="threshold -0.5 is not within the range"):
-        class_imbalance_check.validate(X, y=pd.Series([0, 1, 1]), threshold=-0.5)
+        ClassImbalanceDataCheck(threshold=-0.5).validate(X, y=pd.Series([0, 1, 1]))
 
 
 def test_class_imbalance_data_check_binary():
@@ -29,7 +29,7 @@ def test_class_imbalance_data_check_binary():
     assert class_imbalance_check.validate(X, y=[0, 1, 1]) == []
     assert class_imbalance_check.validate(X, y=pd.Series([0, 1, 1])) == []
     assert class_imbalance_check.validate(X, y=pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])) == [DataCheckWarning("The following labels fall below 10% of the target: [0]", "ClassImbalanceDataCheck")]
-    assert class_imbalance_check.validate(X, y=pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]), threshold=0.25) == [DataCheckWarning("The following labels fall below 25% of the target: [0]", "ClassImbalanceDataCheck")]
+    assert ClassImbalanceDataCheck(threshold=0.25).validate(X, y=pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])) == [DataCheckWarning("The following labels fall below 25% of the target: [0]", "ClassImbalanceDataCheck")]
 
 
 def test_class_imbalance_data_check_multiclass():
@@ -38,7 +38,7 @@ def test_class_imbalance_data_check_multiclass():
 
     assert class_imbalance_check.validate(X, y=pd.Series([0, 2, 1, 1])) == []
     assert class_imbalance_check.validate(X, y=pd.Series([0, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])) == [DataCheckWarning("The following labels fall below 10% of the target: [0]", "ClassImbalanceDataCheck")]
-    assert class_imbalance_check.validate(X, y=pd.Series([0, 2, 2, 2, 3, 3, 1, 1, 1, 1]), threshold=0.25) == [DataCheckWarning("The following labels fall below 25% of the target: [3, 0]", "ClassImbalanceDataCheck")]
+    assert ClassImbalanceDataCheck(threshold=0.25).validate(X, y=pd.Series([0, 2, 2, 2, 3, 3, 1, 1, 1, 1])) == [DataCheckWarning("The following labels fall below 25% of the target: [3, 0]", "ClassImbalanceDataCheck")]
 
 
 def test_class_imbalance_empty_and_nan():
@@ -46,13 +46,13 @@ def test_class_imbalance_empty_and_nan():
     class_imbalance_check = ClassImbalanceDataCheck()
 
     assert class_imbalance_check.validate(X, y=pd.Series([])) == []
-    assert class_imbalance_check.validate(X, y=pd.Series([np.nan, np.nan, np.nan, np.nan, 1, 1, 1, 1, 2]), threshold=0.5) == [DataCheckWarning("The following labels fall below 50% of the target: [2.0]", "ClassImbalanceDataCheck")]
+    assert ClassImbalanceDataCheck(threshold=0.5).validate(X, y=pd.Series([np.nan, np.nan, np.nan, np.nan, 1, 1, 1, 1, 2])) == [DataCheckWarning("The following labels fall below 50% of the target: [2.0]", "ClassImbalanceDataCheck")]
 
 
 def test_class_imbalance_nonnumeric():
     X = pd.DataFrame()
-    class_imbalance_check = ClassImbalanceDataCheck()
+    class_imbalance_check = ClassImbalanceDataCheck(threshold=0.25)
 
-    assert class_imbalance_check.validate(X, y=[True, False, False, False, False], threshold=0.25) == [DataCheckWarning("The following labels fall below 25% of the target: [True]", "ClassImbalanceDataCheck")]
-    assert class_imbalance_check.validate(X, y=["yes", "no", "yes", "yes", "yes"], threshold=0.25) == [DataCheckWarning("The following labels fall below 25% of the target: ['no']", "ClassImbalanceDataCheck")]
-    assert class_imbalance_check.validate(X, y=["red", "green", "red", "red", "blue", "green", "red", "blue", "green", "red"], threshold=0.35) == [DataCheckWarning("The following labels fall below 35% of the target: ['green', 'blue']", "ClassImbalanceDataCheck")]
+    assert class_imbalance_check.validate(X, y=[True, False, False, False, False]) == [DataCheckWarning("The following labels fall below 25% of the target: [True]", "ClassImbalanceDataCheck")]
+    assert class_imbalance_check.validate(X, y=["yes", "no", "yes", "yes", "yes"]) == [DataCheckWarning("The following labels fall below 25% of the target: ['no']", "ClassImbalanceDataCheck")]
+    assert ClassImbalanceDataCheck(threshold=0.35).validate(X, y=["red", "green", "red", "red", "blue", "green", "red", "blue", "green", "red"]) == [DataCheckWarning("The following labels fall below 35% of the target: ['green', 'blue']", "ClassImbalanceDataCheck")]

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -10,10 +10,6 @@ from evalml.data_checks.data_checks import DataChecks
 from evalml.data_checks import DefaultDataChecks, EmptyDataChecks
 
 
-def get_default_data_checks(problem_type):
-    return DataChecks(DefaultDataChecks, {"InvalidTargetDataCheck": {"problem_type": problem_type}})
-
-
 def test_data_checks(X_y_binary):
     X, y = X_y_binary
 
@@ -64,7 +60,7 @@ def test_default_data_checks_classification():
                       'id': [0, 1, 2, 3, 4],
                       'has_label_leakage': [100, 200, 100, 200, 100]})
     y = pd.Series([0, 1, np.nan, 1, 0])
-    data_checks = get_default_data_checks("binary")
+    data_checks = DefaultDataChecks("binary")
 
     leakage = [DataCheckWarning("Column 'has_label_leakage' is 95.0% or more correlated with the target", "LabelLeakageDataCheck")]
 
@@ -72,7 +68,7 @@ def test_default_data_checks_classification():
 
     # multiclass
     y = pd.Series([0, 1, np.nan, 2, 0])
-    data_checks = get_default_data_checks("multiclass")
+    data_checks = DefaultDataChecks("multiclass")
     assert data_checks.validate(X, y) == messages
 
 
@@ -86,7 +82,7 @@ def test_default_data_checks_regression():
     y = pd.Series([0.3, 100.0, np.nan, 1.0, 0.2])
     y2 = pd.Series([5] * 4)
 
-    data_checks = get_default_data_checks("regression")
+    data_checks = DefaultDataChecks("regression")
     assert data_checks.validate(X, y) == messages
 
     # Skip Invalid Target

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -7,8 +7,11 @@ from evalml.data_checks.data_check_message import (
     DataCheckWarning
 )
 from evalml.data_checks.data_checks import DataChecks
-from evalml.data_checks.default_data_checks import DefaultDataChecks
-from evalml.data_checks.utils import EmptyDataChecks
+from evalml.data_checks import DefaultDataChecks, EmptyDataChecks
+
+
+def get_default_data_checks(problem_type):
+    return DataChecks(DefaultDataChecks, {"InvalidTargetDataCheck": {"problem_type": problem_type}})
 
 
 def test_data_checks(X_y_binary):
@@ -61,7 +64,7 @@ def test_default_data_checks_classification():
                       'id': [0, 1, 2, 3, 4],
                       'has_label_leakage': [100, 200, 100, 200, 100]})
     y = pd.Series([0, 1, np.nan, 1, 0])
-    data_checks = DefaultDataChecks()
+    data_checks = get_default_data_checks("binary")
 
     leakage = [DataCheckWarning("Column 'has_label_leakage' is 95.0% or more correlated with the target", "LabelLeakageDataCheck")]
 
@@ -69,7 +72,7 @@ def test_default_data_checks_classification():
 
     # multiclass
     y = pd.Series([0, 1, np.nan, 2, 0])
-    data_checks = DefaultDataChecks()
+    data_checks = get_default_data_checks("multiclass")
     assert data_checks.validate(X, y) == messages
 
 
@@ -83,7 +86,7 @@ def test_default_data_checks_regression():
     y = pd.Series([0.3, 100.0, np.nan, 1.0, 0.2])
     y2 = pd.Series([5] * 4)
 
-    data_checks = DefaultDataChecks()
+    data_checks = get_default_data_checks("regression")
     assert data_checks.validate(X, y) == messages
 
     # Skip Invalid Target

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -1,7 +1,8 @@
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
 
+from evalml.data_checks import DefaultDataChecks, EmptyDataChecks
 from evalml.data_checks.data_check import DataCheck
 from evalml.data_checks.data_check_message import (
     DataCheckError,
@@ -9,7 +10,6 @@ from evalml.data_checks.data_check_message import (
 )
 from evalml.data_checks.data_checks import DataChecks
 from evalml.data_checks.default_data_checks import _default_data_checks_classes
-from evalml.data_checks import DefaultDataChecks, EmptyDataChecks
 from evalml.exceptions import DataCheckInitError
 
 
@@ -97,7 +97,7 @@ def test_default_data_checks_regression():
     # Skip Invalid Target
     assert data_checks.validate(X, y2) == messages[:3] + messages[4:] + [DataCheckError("Y has 1 unique value.", "NoVarianceDataCheck")]
 
-    data_checks = DataChecks(_default_data_checks_classes,  {"InvalidTargetDataCheck": {"problem_type": "regression"}})
+    data_checks = DataChecks(_default_data_checks_classes, {"InvalidTargetDataCheck": {"problem_type": "regression"}})
     assert data_checks.validate(X, y) == messages
 
 
@@ -141,7 +141,7 @@ class MockCheck(DataCheck):
                          [([MockCheck], {"mock_check": 1}, DataCheckInitError,
                            "Parameters for mock_check were not in a dictionary. Received 1."),
                           ([MockCheck], {"mock_check": {"foo": 1}}, DataCheckInitError,
-                           "Encountered the following error while initializing mock_check: __init__\(\) missing 1 required positional argument: 'bar'"),
+                           r"Encountered the following error while initializing mock_check: __init__\(\) missing 1 required positional argument: 'bar'"),
                           ([MockCheck], {"mock_check": {"Bar": 2}}, DataCheckInitError,
                            r"Encountered the following error while initializing mock_check: __init__\(\) got an unexpected keyword argument 'Bar'"),
                           ([MockCheck], {"mock_check": {"fo": 3, "ba": 4}}, DataCheckInitError,
@@ -151,7 +151,7 @@ class MockCheck(DataCheck):
                           ([1], None, ValueError, ("All elements of parameter data_checks must be an instance of DataCheck " +
                                                    "or a DataCheck class with any desired parameters specified in the " +
                                                    "data_check_params dictionary.")),
-                          ([MockCheck], [1], ValueError, "Params must be a dictionary. Received \[1\]")])
+                          ([MockCheck], [1], ValueError, r"Params must be a dictionary. Received \[1\]")])
 def test_data_checks_raises_value_errors_on_init(classes, params, expected_exception, expected_message):
 
     with pytest.raises(expected_exception, match=expected_message):

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -13,7 +13,7 @@ from evalml.utils.gen_utils import (
 
 def test_invalid_target_data_check_nan_error():
     X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck()
+    invalid_targets_check = InvalidTargetDataCheck("regression")
 
     assert invalid_targets_check.validate(X, y=pd.Series([1, 2, 3])) == []
     assert invalid_targets_check.validate(X, y=pd.Series([np.nan, np.nan, np.nan])) == [DataCheckError("3 row(s) (100.0%) of target values are null", "InvalidTargetDataCheck")]
@@ -21,13 +21,13 @@ def test_invalid_target_data_check_nan_error():
 
 def test_invalid_target_data_check_numeric_binary_classification_valid_float():
     X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck()
+    invalid_targets_check = InvalidTargetDataCheck("binary")
     assert invalid_targets_check.validate(X, y=pd.Series([0.0, 1.0, 0.0, 1.0])) == []
 
 
 def test_invalid_target_data_check_numeric_binary_classification_error():
     X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck()
+    invalid_targets_check = InvalidTargetDataCheck("classification")
     assert invalid_targets_check.validate(X, y=pd.Series([1, 5, 1, 5, 1, 1])) == [DataCheckError("Numerical binary classification target classes must be [0, 1], got [1, 5] instead", "InvalidTargetDataCheck")]
     assert invalid_targets_check.validate(X, y=pd.Series([0, 5, np.nan, np.nan])) == [DataCheckError("2 row(s) (50.0%) of target values are null", "InvalidTargetDataCheck"),
                                                                                       DataCheckError("Numerical binary classification target classes must be [0, 1], got [5.0, 0.0] instead", "InvalidTargetDataCheck")]
@@ -35,7 +35,7 @@ def test_invalid_target_data_check_numeric_binary_classification_error():
 
 def test_invalid_target_data_check_invalid_data_types_error():
     X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck()
+    invalid_targets_check = InvalidTargetDataCheck("binary")
     valid_data_types = numeric_and_boolean_dtypes + categorical_dtypes
     y = pd.Series([0, 1, 0, 0, 1, 0, 1, 0])
     for data_type in valid_data_types:
@@ -47,7 +47,7 @@ def test_invalid_target_data_check_invalid_data_types_error():
 
 
 def test_invalid_target_data_input_formats():
-    invalid_targets_check = InvalidTargetDataCheck()
+    invalid_targets_check = InvalidTargetDataCheck("binary")
     X = pd.DataFrame()
 
     # test None

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -27,10 +27,11 @@ def test_invalid_target_data_check_numeric_binary_classification_valid_float():
 
 def test_invalid_target_data_check_numeric_binary_classification_error():
     X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck("classification")
+    invalid_targets_check = InvalidTargetDataCheck("binary")
     assert invalid_targets_check.validate(X, y=pd.Series([1, 5, 1, 5, 1, 1])) == [DataCheckError("Numerical binary classification target classes must be [0, 1], got [1, 5] instead", "InvalidTargetDataCheck")]
     assert invalid_targets_check.validate(X, y=pd.Series([0, 5, np.nan, np.nan])) == [DataCheckError("2 row(s) (50.0%) of target values are null", "InvalidTargetDataCheck"),
                                                                                       DataCheckError("Numerical binary classification target classes must be [0, 1], got [5.0, 0.0] instead", "InvalidTargetDataCheck")]
+    assert invalid_targets_check.validate(X, y=pd.Series([0, 1, 1, 0, 1, 2])) == [DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]
 
 
 def test_invalid_target_data_check_invalid_data_types_error():
@@ -43,7 +44,8 @@ def test_invalid_target_data_check_invalid_data_types_error():
         assert invalid_targets_check.validate(X, y) == []
 
     y = pd.date_range('2000-02-03', periods=5, freq='W')
-    assert invalid_targets_check.validate(X, y) == [DataCheckError("Target is unsupported {} type. Valid target types include: {}".format(y.dtype, ", ".join(valid_data_types)), "InvalidTargetDataCheck")]
+    assert invalid_targets_check.validate(X, y) == [DataCheckError("Target is unsupported {} type. Valid target types include: {}".format(y.dtype, ", ".join(valid_data_types)), "InvalidTargetDataCheck"),
+                                                    DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]
 
 
 def test_invalid_target_data_input_formats():
@@ -52,16 +54,18 @@ def test_invalid_target_data_input_formats():
 
     # test None
     messages = invalid_targets_check.validate(X, y=None)
-    assert messages == []
+    assert messages == [DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]
 
     # test empty pd.Series
     messages = invalid_targets_check.validate(X, pd.Series())
-    assert messages == []
+    assert messages == [DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]
 
     #  test list
     messages = invalid_targets_check.validate(X, [None, None, None, 0])
-    assert messages == [DataCheckError("3 row(s) (75.0%) of target values are null", "InvalidTargetDataCheck")]
+    assert messages == [DataCheckError("3 row(s) (75.0%) of target values are null", "InvalidTargetDataCheck"),
+                        DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]
 
     # test np.array
     messages = invalid_targets_check.validate(X, np.array([None, None, None, 0]))
-    assert messages == [DataCheckError("3 row(s) (75.0%) of target values are null", "InvalidTargetDataCheck")]
+    assert messages == [DataCheckError("3 row(s) (75.0%) of target values are null", "InvalidTargetDataCheck"),
+                        DataCheckError("Target does not have two unique values which is not supported for binary classification", "InvalidTargetDataCheck")]


### PR DESCRIPTION
### Pull Request Description

Fixes #931 by:

- Adding a `problem_type` parameter to the `DefaultDataChecks` `__init__` method. This change is not visible to users of `AutoMLSearch` if they pass in `data_checks = "auto"`
- This was done by modifying the `__init__` method of the `DataChecks` class. Users can now pass in a list of `DataCheck` instances, or a list of `DataCheck` classes and a params_dict, similar to how we parametrize pipelines. This is backwards compatible with the "old way" of creating `DataChecks`.  
- The original issue tracks raising a `DataCheckError` if there are not two unique values in a binary problem, so I modified `InvalidTargetDataCheck`. 

For AutoMLSearch, the api of the `search` method stays the same. If users want to pass in parameters to the data checks, or use their own data check, they can pass in a list of `DataCheck` instances of a `DataChecks` class. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
