### PR TITLE
fix release notes for class imbalance PR

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
-        * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190`
+        * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190` :pr:`1200`
     * Testing Changes
 
 


### PR DESCRIPTION
Moves the release notes from class imbalance PR from released version to `future_releases`. 