### PR TITLE
Refined `make_pipeline_from_components` implementation

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -124,6 +124,7 @@ Pipeline Utils
     :nosignatures:
 
     make_pipeline
+    make_pipeline_from_components
 
 
 .. currentmodule:: evalml.pipelines.components

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,9 +16,7 @@ Release Notes
         * `DataChecks` can now be parametrized by passing a list of `DataCheck` classes and a parameter dictionary :pr:`1167`
         * Added first CV fold score as validation score in `AutoMLSearch.rankings` :pr:`1221`
         * Updated `flake8` configuration to enable linting on `__init__.py` files :pr:`1234`
-        * Add `get_all_objective_names`, `get_core_objective_names`, and `get_non_core_objectives` util functions :pr:`1230`
-        * All functions in `evaml.objectives.utils` now show up in the api reference :pr:`1230`
-        * Added `get_default_primary_search_objective` to get the default objective for each problem type :pr:`1230`
+        * Refined `make_pipeline_from_components` implementation :pr:`1204`
     * Fixes
         * Updated GitHub URL after migration to Alteryx GitHub org :pr:`1207`
         * Changed Problem Type enum to be more similar to the string name :pr:`1208`

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -123,7 +123,6 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
         >>> components = [Imputer(), StandardScaler(), CatBoostClassifier()]
         >>> pipeline = make_pipeline_from_components(components, problem_type="binary")
         >>> pipeline.describe()
-        >>> assert pipeline.component_graph == components
 
     """
     if not isinstance(component_instances[-1], Estimator):

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -120,7 +120,7 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
         Pipeline instance with component instances and specified estimator
 
     Example:
-        >>> components = [Imputer(), StandardScaler(), CatBoostClassifier()]
+        >>> components = [Imputer(), StandardScaler(), LogisticRegressionClassifier()]
         >>> pipeline = make_pipeline_from_components(components, problem_type="binary")
         >>> pipeline.describe()
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -119,6 +119,12 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
     Returns:
         Pipeline instance with component instances and specified estimator
 
+    Example:
+        >>> components = [Imputer(), StandardScaler(), CatBoostClassifier()]
+        >>> pipeline = make_pipeline_from_components(components, problem_type="binary")
+        >>> pipeline.describe()
+        >>> assert pipeline.components_graph == components
+
     """
     if not isinstance(component_instances[-1], Estimator):
         raise ValueError("Pipeline needs to have an estimator at the last position of the component list")
@@ -129,7 +135,4 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
     class TemplatedPipeline(_get_pipeline_base_class(problem_type)):
         custom_name = pipeline_name
         component_graph = [c.__class__ for c in component_instances]
-
-    pipeline_instance = TemplatedPipeline({})
-    pipeline_instance.component_graph = component_instances
-    return pipeline_instance
+    return TemplatedPipeline({c.name: c.parameters for c in component_instances})

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -120,7 +120,7 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
         Pipeline instance with component instances and specified estimator
 
     Example:
-        >>> components = [Imputer(), StandardScaler(), LogisticRegressionClassifier()]
+        >>> components = [Imputer(), StandardScaler(), Estimator()]
         >>> pipeline = make_pipeline_from_components(components, problem_type="binary")
         >>> pipeline.describe()
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -123,7 +123,7 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
         >>> components = [Imputer(), StandardScaler(), CatBoostClassifier()]
         >>> pipeline = make_pipeline_from_components(components, problem_type="binary")
         >>> pipeline.describe()
-        >>> assert pipeline.components_graph == components
+        >>> assert pipeline.component_graph == components
 
     """
     if not isinstance(component_instances[-1], Estimator):

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -292,6 +292,7 @@ def test_make_pipeline_from_components(X_y_binary):
     assert np.array_equal(best_predictions, new_predictions)
     assert np.array_equal(best_pipeline.feature_importance, new_pipeline.feature_importance)
 
+
 def test_required_fields():
     class TestPipelineWithoutComponentGraph(PipelineBase):
         pass

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 from skopt.space import Integer, Real
 
-from evalml import AutoMLSearch
 from evalml.demos import load_breast_cancer, load_wine
 from evalml.exceptions import (
     IllFormattedClassNameError,
@@ -243,9 +242,21 @@ def test_make_pipeline_problem_type_mismatch():
         make_pipeline(pd.DataFrame(), pd.Series(), Transformer, ProblemTypes.MULTICLASS)
 
 
-def test_make_pipeline_from_components(X_y_binary):
+def test_make_pipeline_from_components(X_y_binary, logistic_regression_binary_pipeline_class):
     with pytest.raises(ValueError, match="Pipeline needs to have an estimator at the last position of the component list"):
-        make_pipeline_from_components([Imputer], problem_type='binary')
+        make_pipeline_from_components([Imputer()], problem_type='binary')
+
+    with pytest.raises(KeyError, match="Problem type 'invalid_type' does not exist"):
+        make_pipeline_from_components([RandomForestClassifier()], problem_type='invalid_type')
+
+    with pytest.raises(TypeError, match="Custom pipeline name must be a string"):
+        make_pipeline_from_components([RandomForestClassifier()], problem_type='binary', custom_name=True)
+
+    with pytest.raises(TypeError, match="Every element of `component_instances` must be an instance of ComponentBase"):
+        make_pipeline_from_components([RandomForestClassifier], problem_type='binary')
+
+    with pytest.raises(TypeError, match="Every element of `component_instances` must be an instance of ComponentBase"):
+        make_pipeline_from_components(['RandomForestClassifier'], problem_type='binary')
 
     imp = Imputer(numeric_impute_strategy='median')
     est = RandomForestClassifier()
@@ -280,17 +291,19 @@ def test_make_pipeline_from_components(X_y_binary):
     assert pipeline.parameters == expected_parameters
 
     X, y = X_y_binary
-    automl = AutoMLSearch(problem_type='binary', objective="Log Loss Binary", max_pipelines=5)
-    automl.search(X, y)
-    best_pipeline = automl.best_pipeline
-    new_pipeline = make_pipeline_from_components(best_pipeline.component_graph, ProblemTypes.BINARY)
-    assert best_pipeline.describe() == new_pipeline.describe()
-    best_pipeline.fit(X, y)
-    best_predictions = best_pipeline.predict(X)
+    pipeline = logistic_regression_binary_pipeline_class(parameters={}, random_state=np.random.RandomState(42))
+    new_pipeline = make_pipeline_from_components(pipeline.component_graph, ProblemTypes.BINARY)
+    pipeline.fit(X, y)
+    predictions = pipeline.predict(X)
     new_pipeline.fit(X, y)
     new_predictions = new_pipeline.predict(X)
-    assert np.array_equal(best_predictions, new_predictions)
-    assert np.array_equal(best_pipeline.feature_importance, new_pipeline.feature_importance)
+    assert np.array_equal(predictions, new_predictions)
+    assert np.array_equal(pipeline.feature_importance, new_pipeline.feature_importance)
+    assert new_pipeline.name == 'Templated Pipeline'
+    assert pipeline.parameters == new_pipeline.parameters
+    for component, new_component in zip(pipeline.component_graph, new_pipeline.component_graph):
+        assert isinstance(new_component, type(component))
+    assert pipeline.describe() == new_pipeline.describe()
 
 
 def test_required_fields():


### PR DESCRIPTION
Continuing from the initial PR (#1176 ), additional work for #1162.

- Added fixes so that `make_pipeline_from_components` shows up in the API documentation
- Updated function implementation so that `component_graph` isn't directly set
- Added additional test to show that two pipelines with the same components will have the same predictions  
- Added example in API reference