### PR TITLE
Changed default large dataset train/test splitting behavior

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Added `allow_writing_files` as a named argument to CatBoost estimators. :pr:`1202`
         * Added `solver` and `multi_class` as named arguments to LogisticRegressionClassifier :pr:`1202`
         * Replaced pipeline's `._transform` method to evaluate all the preprocessing steps of a pipeline with `.compute_estimator_features` :pr:`1231`
+        * Changed default large dataset train/test splitting behavior :pr:`1205`
     * Documentation Changes
         * Included description of how to access the component instances and features for pipeline user guide :pr:`1163`
         * Updated API docs to refer to target as "target" instead of "labels" for non-classification tasks and minor docs cleanup :pr:`1160`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -62,7 +62,7 @@ class AutoMLSearch:
     _MAX_NAME_LEN = 40
     _MAX_TRAINING_ROWS = int(1e5)
     _LARGE_DATA_ROW_THRESHOLD = int(1e5)
-    _LARGE_DATA_PERCENT_TEST = 0.75
+    _LARGE_DATA_PERCENT_VALIDATION = 0.75
 
     # Necessary for "Plotting" documentation, since Sphinx does not work well with instance attributes.
     plot = PipelineSearchPlots
@@ -381,8 +381,7 @@ class AutoMLSearch:
             default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state)
 
         if X.shape[0] > self._LARGE_DATA_ROW_THRESHOLD:
-            test_size = min(self._LARGE_DATA_PERCENT_TEST, float(self._MAX_TRAINING_ROWS / X.shape[0]))
-            default_data_split = TrainingValidationSplit(test_size=test_size)
+            default_data_split = TrainingValidationSplit(test_size=self._LARGE_DATA_PERCENT_VALIDATION)
 
         self.data_split = self.data_split or default_data_split
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -60,7 +60,6 @@ logger = get_logger(__file__)
 class AutoMLSearch:
     """Automated Pipeline search."""
     _MAX_NAME_LEN = 40
-    _MAX_TRAINING_ROWS = int(1e5)
     _LARGE_DATA_ROW_THRESHOLD = int(1e5)
     _LARGE_DATA_PERCENT_VALIDATION = 0.75
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -60,7 +60,9 @@ logger = get_logger(__file__)
 class AutoMLSearch:
     """Automated Pipeline search."""
     _MAX_NAME_LEN = 40
+    _MAX_TRAINING_ROWS = int(1e5)
     _LARGE_DATA_ROW_THRESHOLD = int(1e5)
+    _LARGE_DATA_PERCENT_TEST = 0.75
 
     # Necessary for "Plotting" documentation, since Sphinx does not work well with instance attributes.
     plot = PipelineSearchPlots
@@ -379,7 +381,8 @@ class AutoMLSearch:
             default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state)
 
         if X.shape[0] > self._LARGE_DATA_ROW_THRESHOLD:
-            default_data_split = TrainingValidationSplit(test_size=0.25)
+            test_size = min(self._LARGE_DATA_PERCENT_TEST, float(self._MAX_TRAINING_ROWS / X.shape[0]))
+            default_data_split = TrainingValidationSplit(test_size=test_size)
 
         self.data_split = self.data_split or default_data_split
 

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -621,15 +621,7 @@ def test_large_dataset_split_size(mock_score):
     X, y = generate_fake_dataset(under_max_rows)
     automl.search(X, y)
     assert isinstance(automl.data_split, TrainingValidationSplit)
-    assert automl.data_split.test_size == (automl._LARGE_DATA_PERCENT_TEST)
-
-    over_max_rows = int((automl._LARGE_DATA_ROW_THRESHOLD / automl._LARGE_DATA_PERCENT_TEST) + 10000)
-    X, y = generate_fake_dataset(over_max_rows)
-    automl.data_split = None
-    automl.search(X, y)
-    assert isinstance(automl.data_split, TrainingValidationSplit)
-    percent_for_100k_rows = automl._MAX_TRAINING_ROWS / over_max_rows
-    assert automl.data_split.test_size == (percent_for_100k_rows)
+    assert automl.data_split.test_size == (automl._LARGE_DATA_PERCENT_VALIDATION)
 
 
 def test_allowed_pipelines_with_incorrect_problem_type(dummy_binary_pipeline_class):

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -599,6 +599,39 @@ def test_large_dataset_regression(mock_score):
         assert automl.results['pipeline_results'][pipeline_id]['score'] == automl.results['pipeline_results'][pipeline_id]['validation_score']
 
 
+@patch('evalml.pipelines.RegressionPipeline.score')
+def test_large_dataset_split_size(mock_score):
+    def generate_fake_dataset(rows):
+        X = pd.DataFrame({'col_0': [i for i in range(rows)]})
+        y = pd.Series([i % 2 for i in range(rows)])
+        return X, y
+
+    fraud_objective = FraudCost(amount_col='col_0')
+
+    automl = AutoMLSearch(problem_type='binary',
+                          objective=fraud_objective,
+                          additional_objectives=['auc', 'f1', 'precision'],
+                          max_time=1,
+                          max_pipelines=1,
+                          optimize_thresholds=True)
+    mock_score.return_value = {automl.objective.name: 1.234}
+    assert automl.data_split is None
+
+    under_max_rows = automl._LARGE_DATA_ROW_THRESHOLD + 1
+    X, y = generate_fake_dataset(under_max_rows)
+    automl.search(X, y)
+    assert isinstance(automl.data_split, TrainingValidationSplit)
+    assert automl.data_split.test_size == (automl._LARGE_DATA_PERCENT_TEST)
+
+    over_max_rows = int((automl._LARGE_DATA_ROW_THRESHOLD / automl._LARGE_DATA_PERCENT_TEST) + 10000)
+    X, y = generate_fake_dataset(over_max_rows)
+    automl.data_split = None
+    automl.search(X, y)
+    assert isinstance(automl.data_split, TrainingValidationSplit)
+    percent_for_100k_rows = automl._MAX_TRAINING_ROWS / over_max_rows
+    assert automl.data_split.test_size == (percent_for_100k_rows)
+
+
 def test_allowed_pipelines_with_incorrect_problem_type(dummy_binary_pipeline_class):
     # checks that not setting allowed_pipelines does not error out
     AutoMLSearch(problem_type='binary')


### PR DESCRIPTION
Initial pass of managing large datasets. If a data splitter is not set, the default data splitter will only use 25% of the dataset or up to 100k rows (whichever one is lower). 

The values here are parameterized in the code. If users want to change these values, they can pass over their own data splitter.  

Resolves #1061 