### PR TITLE
Fix SimpleImputer error which occurs when all features are bool type

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -39,6 +39,7 @@ Release Notes
         * Updated calls to ``Woodwork``'s ``to_pandas()`` to ``to_series()`` and ``to_dataframe()`` :pr:`1428`
         * Fixed bug in OHE where column names were not guaranteed to be unique :pr:`1349`
         * Fixed bug with percent improvement of ``ExpVariance`` objective on data with highly skewed target :pr:`1467`
+        * Added conversion of all bool to categories internally for imputers :pr:`1215`
     * Changes
         * Changed ``OutliersDataCheck`` to return the list of columns, rather than rows, that contain outliers :pr:`1377`
         * Simplified and cleaned output for Code Generation :pr:`1371`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -39,7 +39,7 @@ Release Notes
         * Updated calls to ``Woodwork``'s ``to_pandas()`` to ``to_series()`` and ``to_dataframe()`` :pr:`1428`
         * Fixed bug in OHE where column names were not guaranteed to be unique :pr:`1349`
         * Fixed bug with percent improvement of ``ExpVariance`` objective on data with highly skewed target :pr:`1467`
-        * Added conversion of all bool to categories internally for imputers :pr:`1215`
+        * Fix SimpleImputer error which occurs when all features are bool type :pr:`1215`
     * Changes
         * Changed ``OutliersDataCheck`` to return the list of columns, rather than rows, that contain outliers :pr:`1377`
         * Simplified and cleaned output for Code Generation :pr:`1371`

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -71,7 +71,6 @@ class Imputer(Transformer):
 
         self._all_null_cols = set(X.columns) - set(X.dropna(axis=1, how='all').columns)
         X_copy = X.copy()
-
         X_null_dropped = X_copy.drop(self._all_null_cols, axis=1, errors='ignore')
 
         X_numerics = X_null_dropped[[col for col in numeric_cols if col not in self._all_null_cols]]

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -72,9 +72,6 @@ class Imputer(Transformer):
         self._all_null_cols = set(X.columns) - set(X.dropna(axis=1, how='all').columns)
         X_copy = X.copy()
 
-        if (X.dtypes == bool).all():
-            X_copy = X_copy.astype('category')
-
         X_null_dropped = X_copy.drop(self._all_null_cols, axis=1, errors='ignore')
 
         X_numerics = X_null_dropped[[col for col in numeric_cols if col not in self._all_null_cols]]
@@ -103,10 +100,6 @@ class Imputer(Transformer):
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
         X_null_dropped = X.copy()
-
-        if (X.dtypes == bool).all():
-            return X
-
         X_null_dropped.drop(self._all_null_cols, inplace=True, axis=1, errors='ignore')
         X_null_dropped.reset_index(inplace=True, drop=True)
         if X_null_dropped.empty:

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -71,6 +71,10 @@ class Imputer(Transformer):
 
         self._all_null_cols = set(X.columns) - set(X.dropna(axis=1, how='all').columns)
         X_copy = X.copy()
+
+        if (X.dtypes == bool).all():
+            X_copy = X_copy.astype('category')
+
         X_null_dropped = X_copy.drop(self._all_null_cols, axis=1, errors='ignore')
 
         X_numerics = X_null_dropped[[col for col in numeric_cols if col not in self._all_null_cols]]
@@ -99,6 +103,11 @@ class Imputer(Transformer):
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
         X_null_dropped = X.copy()
+
+        all_bool = (X.dtypes == bool).all()
+        if all_bool:
+            X_null_dropped = X_null_dropped.astype('category')
+
         X_null_dropped.drop(self._all_null_cols, inplace=True, axis=1, errors='ignore')
         X_null_dropped.reset_index(inplace=True, drop=True)
         if X_null_dropped.empty:
@@ -111,5 +120,8 @@ class Imputer(Transformer):
         if self._categorical_cols is not None and len(self._categorical_cols) > 0:
             X_categorical = X_null_dropped[self._categorical_cols]
             X_null_dropped[X_categorical.columns] = self._categorical_imputer.transform(X_categorical)
+
+        if all_bool:
+            X_null_dropped = X_null_dropped.astype(bool)
 
         return X_null_dropped

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -104,9 +104,8 @@ class Imputer(Transformer):
 
         X_null_dropped = X.copy()
 
-        all_bool = (X.dtypes == bool).all()
-        if all_bool:
-            X_null_dropped = X_null_dropped.astype('category')
+        if (X.dtypes == bool).all():
+            return X
 
         X_null_dropped.drop(self._all_null_cols, inplace=True, axis=1, errors='ignore')
         X_null_dropped.reset_index(inplace=True, drop=True)
@@ -120,8 +119,5 @@ class Imputer(Transformer):
         if self._categorical_cols is not None and len(self._categorical_cols) > 0:
             X_categorical = X_null_dropped[self._categorical_cols]
             X_null_dropped[X_categorical.columns] = self._categorical_imputer.transform(X_categorical)
-
-        if all_bool:
-            X_null_dropped = X_null_dropped.astype(bool)
 
         return X_null_dropped

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,6 +48,7 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
+        # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
         if (X.dtypes == bool).all():
             X = X.astype('category')
 

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,6 +48,7 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
+        # Convert all bool dtypes to category for fitting
         if (X.dtypes == bool).all():
             X = X.astype('category')
 

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,7 +48,6 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
-        # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
         if (X.dtypes == bool).all():
             X = X.astype('category')
 
@@ -75,6 +74,7 @@ class SimpleImputer(Transformer):
         # Convert None to np.nan, since None cannot be properly handled
         X = X.fillna(value=np.nan)
 
+        # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
         if (X.dtypes == bool).all():
             return X
         X_null_dropped = X.copy()

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,9 +48,6 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
-        # if (X.dtypes == bool).all():
-        #     X = X.astype('category')
-
         # Convert None to np.nan, since None cannot be properly handled
         X = X.fillna(value=np.nan)
 

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -74,11 +74,9 @@ class SimpleImputer(Transformer):
         # Convert None to np.nan, since None cannot be properly handled
         X = X.fillna(value=np.nan)
 
+        if (X.dtypes == bool).all():
+            return X
         X_null_dropped = X.copy()
-        all_bool = (X_null_dropped.dtypes == bool).all()
-        if all_bool:
-            X = X.astype('category')
-            X_null_dropped = X_null_dropped.astype('category')
         X_null_dropped.drop(self._all_null_cols, axis=1, errors='ignore', inplace=True)
         category_cols = X_null_dropped.select_dtypes(include=['category']).columns
         X_t = self._component_obj.transform(X)
@@ -87,8 +85,6 @@ class SimpleImputer(Transformer):
         X_t = pd.DataFrame(X_t, columns=X_null_dropped.columns)
         if len(category_cols) > 0:
             X_t[category_cols] = X_t[category_cols].astype('category')
-        if all_bool:
-            X_t = X_t.astype(bool)
         return X_t
 
     def fit_transform(self, X, y=None):

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,6 +48,9 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
+        if (X.dtypes == bool).all():
+            X = X.astype('category')
+
         # Convert None to np.nan, since None cannot be properly handled
         X = X.fillna(value=np.nan)
 

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -83,10 +83,7 @@ class SimpleImputer(Transformer):
         category_cols = X_null_dropped.select_dtypes(include=['category']).columns
         X_t = self._component_obj.transform(X)
         if X_null_dropped.empty:
-            if all_bool:
-                return pd.DataFrame(X_t, columns=X_null_dropped.columns, dtype=bool)
-            else:
-                return pd.DataFrame(X_t, columns=X_null_dropped.columns)
+            return pd.DataFrame(X_t, columns=X_null_dropped.columns)
         X_t = pd.DataFrame(X_t, columns=X_null_dropped.columns)
         if len(category_cols) > 0:
             X_t[category_cols] = X_t[category_cols].astype('category')

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -48,8 +48,8 @@ class SimpleImputer(Transformer):
         X = _convert_to_woodwork_structure(X)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
-        if (X.dtypes == bool).all():
-            X = X.astype('category')
+        # if (X.dtypes == bool).all():
+        #     X = X.astype('category')
 
         # Convert None to np.nan, since None cannot be properly handled
         X = X.fillna(value=np.nan)

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -294,7 +294,7 @@ def test_imputer_with_none():
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
-def test_imputer_all_bool(data_type):
+def test_imputer_all_bool_return_original(data_type):
     X = pd.DataFrame([True, True, False, True, True], dtype=bool)
     X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     y = pd.Series([1, 0, 0, 1, 0])
@@ -306,6 +306,9 @@ def test_imputer_all_bool(data_type):
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
+
+@pytest.mark.parametrize("data_type", ['pd', 'ww'])
+def test_imputer_bool_dtype_object(data_type):
     X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
     y = pd.Series([1, 0, 0, 1, 0])
     X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
@@ -317,17 +320,21 @@ def test_imputer_all_bool(data_type):
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
+
+@pytest.mark.parametrize("data_type", ['pd', 'ww'])
+def test_imputer_multitype_with_one_bool(data_type):
     X_multi = pd.DataFrame({
         "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype=object),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
-
+    y = pd.Series([1, 0, 0, 1, 0])
     X_multi_expected_arr = pd.DataFrame({
         "bool with nan": pd.Series([True, False, False, False, False], dtype=object),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
     if data_type == 'ww':
         X_multi = ww.DataTable(X_multi)
+        y = ww.DataColumn(y)
     imputer = Imputer()
     imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -291,3 +291,26 @@ def test_imputer_with_none():
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
     assert_frame_equal(transformed, expected, check_dtype=False)
+
+
+def test_imputer_all_bool():
+    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=bool)
+    y = pd.Series([1, 0, 0, 1, 0])
+    imputer = Imputer()
+    imputer.fit(X, y)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_t = imputer.transform(X)
+    assert_frame_equal(X_expected_arr, X_t)
+
+    X_multi = pd.DataFrame({
+        "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
+        "bool no nan": pd.Series([False, False, False, False, True]),
+    }, dtype=bool)
+    imputer = Imputer()
+    imputer.fit(X_multi, y)
+    X_multi_expected_arr = pd.DataFrame({
+        "bool with nan": pd.Series([True, True, False, True, False]),
+        "bool no nan": pd.Series([False, False, False, False, True]),
+    }, dtype=bool)
+    X_multi_t = imputer.transform(X_multi)
+    assert_frame_equal(X_multi_expected_arr, X_multi_t)

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -187,11 +187,11 @@ def test_imputer_empty_data(data_type):
     if data_type == 'pd':
         X = pd.DataFrame()
         y = pd.Series()
-        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
     elif data_type == 'ww':
         X = ww.DataTable(pd.DataFrame())
         y = ww.DataColumn(pd.Series())
-        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
     else:
         X = np.array([[]])
         y = np.array([])
@@ -293,12 +293,17 @@ def test_imputer_with_none():
     assert_frame_equal(transformed, expected, check_dtype=False)
 
 
-def test_imputer_all_bool():
+@pytest.mark.parametrize("data_type", ['pd', 'ww'])
+def test_imputer_all_bool(data_type):
     X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
     y = pd.Series([1, 0, 0, 1, 0])
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
+    if data_type == 'ww':
+        X = ww.DataTable(X)
+        y = ww.DataColumn(y)
+        X_expected_arr = X = ww.DataTable(X_expected_arr)
     imputer = Imputer()
     imputer.fit(X, y)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
@@ -306,11 +311,15 @@ def test_imputer_all_bool():
         "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype=object),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
-    imputer = Imputer()
-    imputer.fit(X_multi, y)
+
     X_multi_expected_arr = pd.DataFrame({
         "bool with nan": pd.Series([True, False, False, False, False], dtype=object),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
+    if data_type == 'ww':
+        X_multi = ww.DataTable(X_multi)
+        X_multi_expected_arr = X = ww.DataTable(X_multi_expected_arr)
+    imputer = Imputer()
+    imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)
     assert_frame_equal(X_multi_expected_arr, X_multi_t)

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -295,13 +295,23 @@ def test_imputer_with_none():
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_all_bool(data_type):
+    X = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    y = pd.Series([1, 0, 0, 1, 0])
+    if data_type == 'ww':
+        X = ww.DataTable(X)
+        y = ww.DataColumn(y)
+    imputer = Imputer()
+    imputer.fit(X, y)
+    X_t = imputer.transform(X)
+    assert_frame_equal(X_expected_arr, X_t)
+
     X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
     y = pd.Series([1, 0, 0, 1, 0])
     X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
     if data_type == 'ww':
         X = ww.DataTable(X)
         y = ww.DataColumn(y)
-        X_expected_arr = X = ww.DataTable(X_expected_arr)
     imputer = Imputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
@@ -318,7 +328,6 @@ def test_imputer_all_bool(data_type):
     })
     if data_type == 'ww':
         X_multi = ww.DataTable(X_multi)
-        X_multi_expected_arr = X = ww.DataTable(X_multi_expected_arr)
     imputer = Imputer()
     imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -187,11 +187,11 @@ def test_imputer_empty_data(data_type):
     if data_type == 'pd':
         X = pd.DataFrame()
         y = pd.Series()
-        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
     elif data_type == 'ww':
         X = ww.DataTable(pd.DataFrame())
         y = ww.DataColumn(pd.Series())
-        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
     else:
         X = np.array([[]])
         y = np.array([])
@@ -294,23 +294,23 @@ def test_imputer_with_none():
 
 
 def test_imputer_all_bool():
-    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=bool)
+    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
     y = pd.Series([1, 0, 0, 1, 0])
     imputer = Imputer()
     imputer.fit(X, y)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
     X_multi = pd.DataFrame({
-        "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
-        "bool no nan": pd.Series([False, False, False, False, True]),
-    }, dtype=bool)
+        "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype=object),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
+    })
     imputer = Imputer()
     imputer.fit(X_multi, y)
     X_multi_expected_arr = pd.DataFrame({
-        "bool with nan": pd.Series([True, True, False, True, False]),
-        "bool no nan": pd.Series([False, False, False, False, True]),
-    }, dtype=bool)
+        "bool with nan": pd.Series([True, False, False, False, False], dtype=object),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
+    })
     X_multi_t = imputer.transform(X_multi)
     assert_frame_equal(X_multi_expected_arr, X_multi_t)

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -105,13 +105,21 @@ def test_simple_imputer_col_with_non_numeric():
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_all_bool(data_type):
-    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
+    X = pd.DataFrame([True, True, False, True, True], dtype=object)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
     y = pd.Series([1, 0, 0, 1, 0])
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=object)
     if data_type == 'ww':
         X = ww.DataTable(X)
         y = ww.DataColumn(y)
-        X_expected_arr = X = ww.DataTable(X_expected_arr)
+    imputer = SimpleImputer()
+    imputer.fit(X, y)
+    X_t = imputer.transform(X)
+    assert_frame_equal(X_expected_arr, X_t)
+
+    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
+    if data_type == 'ww':
+        X = ww.DataTable(X)
     imputer = SimpleImputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
@@ -123,12 +131,11 @@ def test_imputer_all_bool(data_type):
     })
 
     X_multi_expected_arr = pd.DataFrame({
-        "bool with nan": pd.Series([True, False, False, False, False], dtype=object),
-        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
+        "bool with nan": pd.Series([True, False, False, False, False], dtype='category'),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=object),
     })
     if data_type == 'ww':
         X_multi = ww.DataTable(X_multi)
-        X_multi_expected_arr = X = ww.DataTable(X_multi_expected_arr)
     imputer = SimpleImputer()
     imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -102,6 +102,29 @@ def test_simple_imputer_col_with_non_numeric():
     assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
+def test_imputer_all_bool():
+    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=bool)
+    y = pd.Series([1, 0, 0, 1, 0])
+    imputer = SimpleImputer()
+    imputer.fit(X, y)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_t = imputer.transform(X)
+    assert_frame_equal(X_expected_arr, X_t)
+
+    X_multi = pd.DataFrame({
+        "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
+        "bool no nan": pd.Series([False, False, False, False, True]),
+    }, dtype=bool)
+    imputer = SimpleImputer()
+    imputer.fit(X_multi, y)
+    X_multi_expected_arr = pd.DataFrame({
+        "bool with nan": pd.Series([True, True, False, True, False]),
+        "bool no nan": pd.Series([False, False, False, False, True]),
+    }, dtype=bool)
+    X_multi_t = imputer.transform(X_multi)
+    assert_frame_equal(X_multi_expected_arr, X_multi_t)
+
+
 def test_simple_imputer_fit_transform_drop_all_nan_columns():
     X = pd.DataFrame({"all_nan": [np.nan, np.nan, np.nan],
                       "some_nan": [np.nan, 1, 0],

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -104,10 +104,10 @@ def test_simple_imputer_col_with_non_numeric():
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
-def test_imputer_all_bool(data_type):
+def test_simple_imputer_all_bool_return_original(data_type):
     X = pd.DataFrame([True, True, False, True, True], dtype=bool)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     y = pd.Series([1, 0, 0, 1, 0])
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     if data_type == 'ww':
         X = ww.DataTable(X)
         y = ww.DataColumn(y)
@@ -116,7 +116,11 @@ def test_imputer_all_bool(data_type):
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
+
+@pytest.mark.parametrize("data_type", ['pd', 'ww'])
+def test_simple_imputer_bool_dtype_object(data_type):
     X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=object)
+    y = pd.Series([1, 0, 0, 1, 0])
     X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
     if data_type == 'ww':
         X = ww.DataTable(X)
@@ -125,11 +129,14 @@ def test_imputer_all_bool(data_type):
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
+
+@pytest.mark.parametrize("data_type", ['pd', 'ww'])
+def test_simple_imputer_multitype_with_one_bool(data_type):
     X_multi = pd.DataFrame({
         "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype=object),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
-
+    y = pd.Series([1, 0, 0, 1, 0])
     X_multi_expected_arr = pd.DataFrame({
         "bool with nan": pd.Series([True, False, False, False, False], dtype='category'),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=object),

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -105,8 +105,8 @@ def test_simple_imputer_col_with_non_numeric():
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_all_bool(data_type):
-    X = pd.DataFrame([True, True, False, True, True], dtype=object)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
+    X = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     y = pd.Series([1, 0, 0, 1, 0])
     if data_type == 'ww':
         X = ww.DataTable(X)

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -103,24 +103,31 @@ def test_simple_imputer_col_with_non_numeric():
 
 
 def test_imputer_all_bool():
-    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype=bool)
+    X = pd.DataFrame([True, True, False, False, True], dtype=bool)
     y = pd.Series([1, 0, 0, 1, 0])
     imputer = SimpleImputer()
     imputer.fit(X, y)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
+    X_t = imputer.transform(X)
+    assert_frame_equal(X, X_t)
+
+    X = pd.DataFrame([True, np.nan, False, np.nan, True])
+    y = pd.Series([1, 0, 0, 1, 0])
+    imputer = SimpleImputer()
+    imputer.fit(X, y)
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype="category")
     X_t = imputer.transform(X)
     assert_frame_equal(X_expected_arr, X_t)
 
     X_multi = pd.DataFrame({
         "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
-        "bool no nan": pd.Series([False, False, False, False, True]),
-    }, dtype=bool)
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
+    })
     imputer = SimpleImputer()
     imputer.fit(X_multi, y)
     X_multi_expected_arr = pd.DataFrame({
-        "bool with nan": pd.Series([True, True, False, True, False]),
-        "bool no nan": pd.Series([False, False, False, False, True]),
-    }, dtype=bool)
+        "bool with nan": pd.Series([True, False, False, False, False], dtype="category"),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=object),
+    })
     X_multi_t = imputer.transform(X_multi)
     assert_frame_equal(X_multi_expected_arr, X_multi_t)
 


### PR DESCRIPTION
Fixed issues with all-bool inputs for `Imputer` and `SimpleImputer` by internally converting to the category datatype and reconverting to bools at the end. 

Resolves #1166 