### PR TITLE
Update documentation about objectives in AutoML

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,7 +24,6 @@ Release Notes
         * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190` :pr:`1200`
         * Added pipeline properties to API reference :pr:`1209`
         * Clarified what the objective parameter in AutoML is used for in AutoML API reference and AutoML user guide :pr:`1222`
-        * Add pipeline properties to API reference :pr:`1209`
         * Added install documentation for `libomp` in order to use LightGBM on Mac :pr:`1233`
         * Improved description of `max_iterations` in documentation :pr:`1212`
         * Removed unused code from sphinx conf :pr:`1235`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,8 @@ Release Notes
         * Included description of how to access the component instances and features for pipeline user guide :pr:`1163`
         * Updated API docs to refer to target as "target" instead of "labels" for non-classification tasks and minor docs cleanup :pr:`1160`
         * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190` :pr:`1200`
-        * Add pipeline properties to API reference :pr:`1209`
+        * Added pipeline properties to API reference :pr:`1209`
+        * Clarified what the objective parameter in AutoML is used for in AutoML API reference and AutoML user guide :pr:`1222`
     * Testing Changes
 
 

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -92,7 +92,8 @@
     "from evalml.problem_types import detect_problem_type\n",
     "\n",
     "y = pd.Series([0, 1, 1, 0, 1, 1])\n",
-    "detect_problem_type(y)"   ]
+    "detect_problem_type(y)"   
+	]
   },
   {
    "cell_type": "markdown",

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -75,6 +75,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Objective parameter\n",
+    "\n",
+    "AutoMLSearch takes in an `objective` parameter to determine which `objective` to optimize for. By default, this parameter is set to `auto`, which allows AutoML to choose `LogLossBinary` for binary classification problems, `LogLossMulticlass` for multiclass classification problems, and `R2` for regression problems.\n",
+    "\n",
+    "It should be noted that the `objective` parameter is only used in ranking and helping choose the pipelines to iterate over, but is not used to optimize each individual pipeline during fit-time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Using custom pipelines\n",
     "\n",
     "EvalML's AutoML algorithm generates a set of pipelines to search with. To provide a custom set instead, set allowed_pipelines to a list of [custom pipeline](pipelines.ipynb) classes. Note: this will prevent AutoML from generating other pipelines to search over."
@@ -212,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -102,10 +102,10 @@ class AutoMLSearch:
             problem_type (str or ProblemTypes): Choice of 'regression', 'binary', or 'multiclass', depending on the desired problem type.
 
             objective (str, ObjectiveBase): The objective to optimize for. Used to select and rank models, but not for optimizing each model during fit-time.
-                When set to auto, chooses:
-                    - LogLossBinary for binary classification problems,
-                    - LogLossMulticlass for multiclass classification problems, and
-                    - R2 for regression problems.
+                When set to 'auto', chooses:
+                - LogLossBinary for binary classification problems,
+                - LogLossMulticlass for multiclass classification problems, and
+                - R2 for regression problems.
 
             max_pipelines (int): Will be deprecated in the next release. Maximum number of pipelines to search. If max_pipelines and
                 max_time is not set, then max_pipelines will default to max_pipelines of 5.

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -103,6 +103,7 @@ class AutoMLSearch:
 
             objective (str, ObjectiveBase): The objective to optimize for. Used to select and rank models, but not for optimizing each model during fit-time.
                 When set to 'auto', chooses:
+
                 - LogLossBinary for binary classification problems,
                 - LogLossMulticlass for multiclass classification problems, and
                 - R2 for regression problems.

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -101,10 +101,11 @@ class AutoMLSearch:
         Arguments:
             problem_type (str or ProblemTypes): Choice of 'regression', 'binary', or 'multiclass', depending on the desired problem type.
 
-            objective (str, ObjectiveBase): The objective to optimize for. When set to auto, chooses:
-                LogLossBinary for binary classification problems,
-                LogLossMulticlass for multiclass classification problems, and
-                R2 for regression problems.
+            objective (str, ObjectiveBase): The objective to optimize for. Used to select and rank models, but not for optimizing each model during fit-time.
+                When set to auto, chooses:
+                    - LogLossBinary for binary classification problems,
+                    - LogLossMulticlass for multiclass classification problems, and
+                    - R2 for regression problems.
 
             max_pipelines (int): Will be deprecated in the next release. Maximum number of pipelines to search. If max_pipelines and
                 max_time is not set, then max_pipelines will default to max_pipelines of 5.


### PR DESCRIPTION
Closes #1211 by clarifying in AutoMLSearch docstring and AutoML docs what the objective parameter is used for.

[Updated API reference](https://evalml.alteryx.com/en/1211_objective_docs/user_guide/automl.html) and [updated automl guide](https://evalml.alteryx.com/en/1211_objective_docs/user_guide/automl.html)