### PR TITLE
Wrap call to scikit-learn's partial dependence method in a try/finally block

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
     * Fixes
         * Updated GitHub URL after migration to Alteryx GitHub org :pr:`1207`
         * Changed Problem Type enum to be more similar to the string name :pr:`1208`
+        * Wrapped call to scikit-learn's partial dependence method in a `try`/`finally` block :pr:`1232`
     * Changes
         * Added `allow_writing_files` as a named argument to CatBoost estimators. :pr:`1202`
         * Added `solver` and `multi_class` as named arguments to LogisticRegressionClassifier :pr:`1202`

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -437,11 +437,12 @@ def partial_dependence(pipeline, X, feature, grid_resolution=100):
     elif isinstance(pipeline, evalml.pipelines.RegressionPipeline):
         pipeline._estimator_type = "regressor"
     pipeline.feature_importances_ = pipeline.feature_importance
-    avg_pred, values = sk_partial_dependence(pipeline, X=X, features=[feature], grid_resolution=grid_resolution)
-
-    # Delete scikit-learn attributes that were temporarily set
-    del pipeline._estimator_type
-    del pipeline.feature_importances_
+    try:
+        avg_pred, values = sk_partial_dependence(pipeline, X=X, features=[feature], grid_resolution=grid_resolution)
+    finally:
+        # Delete scikit-learn attributes that were temporarily set
+        del pipeline._estimator_type
+        del pipeline.feature_importances_
     return pd.DataFrame({"feature_values": values[0],
                          "partial_dependence": avg_pred[0]})
 

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -689,6 +689,20 @@ def test_partial_dependence_problem_types(problem_type, X_y_binary, X_y_multi, X
         pipeline.feature_importances_
 
 
+@patch('evalml.model_understanding.graphs.sk_partial_dependence')
+def test_partial_dependence_error_still_deletes_attributes(mock_part_dep, X_y_binary, logistic_regression_binary_pipeline_class):
+    X, y = X_y_binary
+    pipeline = logistic_regression_binary_pipeline_class(parameters={})
+    pipeline.fit(X, y)
+    mock_part_dep.side_effect = Exception()
+    with pytest.raises(Exception):
+        partial_dependence(pipeline, X, feature=0, grid_resolution=20)
+    with pytest.raises(AttributeError):
+        pipeline._estimator_type
+    with pytest.raises(AttributeError):
+        pipeline.feature_importances_
+
+
 def test_partial_dependence_string_feature_name(logistic_regression_binary_pipeline_class):
     X, y = load_breast_cancer()
     pipeline = logistic_regression_binary_pipeline_class(parameters={})


### PR DESCRIPTION
From @dsherry's comment in #1150, wrap call to scikit-learn's partial dependence method in a try/finally block so that we still delete the set attributes even if call to scikit-learn's partial dependence method fails or errors out.