### PR TITLE
Add libomp dependency on Mac for LightGBM to docs

### DIFF
--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -57,13 +57,6 @@
     "brew install libomp\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -47,8 +47,19 @@
     "\n",
     "## Windows\n",
     "\n",
-    "The [XGBoost](https://pypi.org/project/xgboost/) library may not be pip-installable in some Windows environments. If you are encountering installation issues, please try installing XGBoost from [Github](https://xgboost.readthedocs.io/en/latest/build.html) before installing EvalML or install evalml with conda."
+    "The [XGBoost](https://pypi.org/project/xgboost/) library may not be pip-installable in some Windows environments. If you are encountering installation issues, please try installing XGBoost from [Github](https://xgboost.readthedocs.io/en/latest/build.html) before installing EvalML or install evalml with conda.\n",
+    "\n",
+    "## Mac\n",
+    "\n",
+    "In order to run on Mac, [LightGBM](https://pypi.org/project/lightgbm/) requires the `OpenMP` libray to be installed, which can be done by running `brew install libomp` from [HomeBrew](https://brew.sh/)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -51,7 +51,11 @@
     "\n",
     "## Mac\n",
     "\n",
-    "In order to run on Mac, [LightGBM](https://pypi.org/project/lightgbm/) requires the `OpenMP` libray to be installed, which can be done by running `brew install libomp` from [HomeBrew](https://brew.sh/)"
+    "In order to run on Mac, [LightGBM](https://pypi.org/project/lightgbm/) requires the `OpenMP` libray to be installed, which can be done with [HomeBrew](https://brew.sh/) by running \n",
+    "\n",
+    "```bash\n",
+    "brew install libomp\n",
+    "```"
    ]
   },
   {

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,7 +19,7 @@ Release Notes
         * Updated API docs to refer to target as "target" instead of "labels" for non-classification tasks and minor docs cleanup :pr:`1160`
         * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190` :pr:`1200`
         * Add pipeline properties to API reference :pr:`1209`
-        * Added install documentation for `libomp` in order to use LightGBM on Mac :pr:``
+        * Added install documentation for `libomp` in order to use LightGBM on Mac :pr:`1233`
     * Testing Changes
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Release Notes
         * Updated API docs to refer to target as "target" instead of "labels" for non-classification tasks and minor docs cleanup :pr:`1160`
         * Added Class Imbalance Data Check to `api_reference.rst` :pr:`1190` :pr:`1200`
         * Add pipeline properties to API reference :pr:`1209`
+        * Added install documentation for `libomp` in order to use LightGBM on Mac :pr:``
     * Testing Changes
 
 


### PR DESCRIPTION
fix #1216 

Update install documentation for lightgbm on Mac. Local tests do fail on Mac when `libomp` isn't installed. 