### PR TITLE
Have lint run on `__init__.py` files

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Updates scikit-learn and scikit-optimize to use latest versions - 0.23.2 and 0.8.1 respectively :pr:`1141`
         * Add `ProblemTypes.all_problem_types` helper to get list of supported problem types :pr:`1219`
         * `DataChecks` can now be parametrized by passing a list of `DataCheck` classes and a parameter dictionary :pr:`1167`
+        * Updated `flake8` configuration to enable linting on `__init__.py` files :pr:`1234`
     * Fixes
         * Updated GitHub URL after migration to Alteryx GitHub org :pr:`1207`
         * Changed Problem Type enum to be more similar to the string name :pr:`1208`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -1,16 +1,8 @@
-# flake8:noqa
-
 import warnings
 
 # hack to prevent warnings from skopt
 # must import sklearn first
 import sklearn
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", FutureWarning)
-    warnings.simplefilter("ignore", DeprecationWarning)
-    import skopt
-
 import evalml.demos
 import evalml.model_family
 import evalml.objectives
@@ -21,7 +13,10 @@ import evalml.utils
 import evalml.data_checks
 from evalml.automl import AutoMLSearch
 from evalml.utils import print_info
-
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", FutureWarning)
+    warnings.simplefilter("ignore", DeprecationWarning)
+    import skopt
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/evalml/automl/__init__.py
+++ b/evalml/automl/__init__.py
@@ -1,3 +1,2 @@
-# flake8:noqas
 from .automl_search import AutoMLSearch
 from .data_splitters import TrainingValidationSplit

--- a/evalml/automl/automl_algorithm/__init__.py
+++ b/evalml/automl/automl_algorithm/__init__.py
@@ -1,3 +1,2 @@
-# flake8:noqas
 from .automl_algorithm import AutoMLAlgorithm, AutoMLAlgorithmException
 from .iterative_algorithm import IterativeAlgorithm

--- a/evalml/automl/data_splitters/__init__.py
+++ b/evalml/automl/data_splitters/__init__.py
@@ -1,2 +1,1 @@
-# flake8:noqas
 from .training_validation_split import TrainingValidationSplit

--- a/evalml/data_checks/__init__.py
+++ b/evalml/data_checks/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqas
 from .data_check import DataCheck
 from .data_checks import AutoMLDataChecks, DataChecks
 from .data_check_message import DataCheckMessage, DataCheckWarning, DataCheckError

--- a/evalml/demos/__init__.py
+++ b/evalml/demos/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .breast_cancer import load_breast_cancer
 from .diabetes import load_diabetes
 from .fraud import load_fraud

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -1,2 +1,13 @@
-# flake8:noqa
-from .exceptions import *
+
+from .exceptions import (
+    MethodPropertyNotFoundError,
+    PipelineNotFoundError,
+    ObjectiveNotFoundError,
+    IllFormattedClassNameError,
+    MissingComponentError,
+    ComponentNotYetFittedError,
+    PipelineNotYetFittedError,
+    AutoMLSearchException,
+    PipelineScoreError,
+    DataCheckInitError
+)

--- a/evalml/model_family/__init__.py
+++ b/evalml/model_family/__init__.py
@@ -1,3 +1,2 @@
-# flake8:noqas
 from .model_family import ModelFamily
 from .utils import handle_model_family

--- a/evalml/model_understanding/__init__.py
+++ b/evalml/model_understanding/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .graphs import (
     precision_recall_curve,
     graph_precision_recall_curve,

--- a/evalml/model_understanding/prediction_explanations/__init__.py
+++ b/evalml/model_understanding/prediction_explanations/__init__.py
@@ -1,2 +1,1 @@
-# flake8:noqa
 from .explainers import explain_prediction, explain_predictions_best_worst, explain_predictions

--- a/evalml/objectives/__init__.py
+++ b/evalml/objectives/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .binary_classification_objective import BinaryClassificationObjective
 from .cost_benefit_matrix import CostBenefitMatrix
 from .fraud_cost import FraudCost

--- a/evalml/pipelines/__init__.py
+++ b/evalml/pipelines/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .components import (
     Estimator,
     OneHotEncoder,

--- a/evalml/pipelines/classification/__init__.py
+++ b/evalml/pipelines/classification/__init__.py
@@ -1,3 +1,2 @@
-# flake8:noqa
 from .baseline_binary import BaselineBinaryPipeline, ModeBaselineBinaryPipeline
 from .baseline_multiclass import BaselineMulticlassPipeline, ModeBaselineMulticlassPipeline

--- a/evalml/pipelines/components/__init__.py
+++ b/evalml/pipelines/components/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .component_base import ComponentBase, ComponentBaseMeta
 from .estimators import (
     Estimator,
@@ -34,4 +33,4 @@ from .transformers import (
     SelectColumns,
     TextFeaturizer,
     LSA,
-    )
+)

--- a/evalml/pipelines/components/estimators/__init__.py
+++ b/evalml/pipelines/components/estimators/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .estimator import Estimator
 from .classifiers import (LogisticRegressionClassifier,
                           RandomForestClassifier,

--- a/evalml/pipelines/components/estimators/classifiers/__init__.py
+++ b/evalml/pipelines/components/estimators/classifiers/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .logistic_regression import LogisticRegressionClassifier
 from .rf_classifier import RandomForestClassifier
 from .xgboost_classifier import XGBoostClassifier

--- a/evalml/pipelines/components/estimators/regressors/__init__.py
+++ b/evalml/pipelines/components/estimators/regressors/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .elasticnet_regressor import ElasticNetRegressor
 from .linear_regressor import LinearRegressor
 from .rf_regressor import RandomForestRegressor

--- a/evalml/pipelines/components/transformers/__init__.py
+++ b/evalml/pipelines/components/transformers/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .transformer import Transformer
 from .encoders import OneHotEncoder
 from .feature_selection import FeatureSelector, RFClassifierSelectFromModel, RFRegressorSelectFromModel

--- a/evalml/pipelines/components/transformers/encoders/__init__.py
+++ b/evalml/pipelines/components/transformers/encoders/__init__.py
@@ -1,2 +1,1 @@
-# flake8:noqa
 from .onehot_encoder import OneHotEncoder

--- a/evalml/pipelines/components/transformers/feature_selection/__init__.py
+++ b/evalml/pipelines/components/transformers/feature_selection/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .feature_selector import FeatureSelector
 from .rf_classifier_feature_selector import RFClassifierSelectFromModel
 from .rf_regressor_feature_selector import RFRegressorSelectFromModel

--- a/evalml/pipelines/components/transformers/imputers/__init__.py
+++ b/evalml/pipelines/components/transformers/imputers/__init__.py
@@ -1,5 +1,3 @@
-# flake8:noqa
 from .per_column_imputer import PerColumnImputer
 from .simple_imputer import SimpleImputer
 from .imputer import Imputer
-

--- a/evalml/pipelines/components/transformers/preprocessing/__init__.py
+++ b/evalml/pipelines/components/transformers/preprocessing/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .datetime_featurizer import DateTimeFeaturizer
 from .drop_null_columns import DropNullColumns
 from .text_transformer import TextTransformer

--- a/evalml/pipelines/components/transformers/scalers/__init__.py
+++ b/evalml/pipelines/components/transformers/scalers/__init__.py
@@ -1,2 +1,1 @@
-# flake8:noqa
 from .standard_scaler import StandardScaler

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -1,10 +1,9 @@
-# flake8:noqa
 import inspect
 
 from evalml.exceptions import MissingComponentError
 from evalml.model_family.utils import handle_model_family
 from evalml.pipelines.components import ComponentBase, Estimator, Transformer
-from evalml.problem_types import ProblemTypes, handle_problem_types
+from evalml.problem_types import handle_problem_types
 from evalml.utils import get_logger
 from evalml.utils.gen_utils import get_importable_subclasses
 

--- a/evalml/pipelines/regression/__init__.py
+++ b/evalml/pipelines/regression/__init__.py
@@ -1,2 +1,1 @@
-# flake8:noqa
 from .baseline_regression import BaselineRegressionPipeline, MeanBaselineRegressionPipeline

--- a/evalml/preprocessing/__init__.py
+++ b/evalml/preprocessing/__init__.py
@@ -1,2 +1,7 @@
-# flake8:noqa
-from .utils import *
+from .utils import (
+    load_data,
+    split_data,
+    number_of_features,
+    target_distribution,
+    drop_nan_target_rows
+)

--- a/evalml/problem_types/__init__.py
+++ b/evalml/problem_types/__init__.py
@@ -1,3 +1,2 @@
-# flake8:noqa
 from .problem_types import ProblemTypes
 from .utils import handle_problem_types

--- a/evalml/tuners/__init__.py
+++ b/evalml/tuners/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .skopt_tuner import SKOptTuner
 from .tuner import Tuner
 from .tuner_exceptions import NoParamsException, ParameterError

--- a/evalml/utils/__init__.py
+++ b/evalml/utils/__init__.py
@@ -1,4 +1,3 @@
-# flake8:noqa
 from .logger import get_logger, log_subtitle, log_title
 from .gen_utils import classproperty, import_or_raise, convert_to_seconds, get_random_state, check_random_state_equality, get_random_seed, SEED_BOUNDS, jupyter_check
 from .cli_utils import print_info, get_evalml_root, get_installed_packages, get_sys_info, print_sys_info, print_deps

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ filterwarnings =
 [flake8]
 exclude = docs/*
 ignore = E501,W504
+per-file-ignores =
+    **/__init__.py:F401
 [metadata]
 description-file = README.md
 [aliases]


### PR DESCRIPTION
Closes #737 by adding configuration to ignore F401 (module imported but unused) on `__init__.py` files.