### PR TITLE
Add DecisionTree estimators to API Reference

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -203,6 +203,7 @@ Classifiers are components that output a predicted class label.
     XGBoostClassifier
     BaselineClassifier
     StackedEnsembleClassifier
+    DecisionTreeClassifier
 
 Regressors
 -----------
@@ -222,6 +223,7 @@ Regressors are components that output a predicted target value.
     XGBoostRegressor
     BaselineRegressor
     StackedEnsembleRegressor
+    DecisionTreeRegressor
 
 .. currentmodule:: evalml.model_understanding
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Added DecisionTree estimators to API Reference :pr:`1246`
     * Testing Changes
 
 


### PR DESCRIPTION
Closes #1245 by adding DecisionTree estimators to API Reference.

[Here they are!](https://evalml.alteryx.com/en/1245_decision_tree_api/api_reference.html#classifiers)