### PR TITLE
Build conda on merge to main

### DIFF
--- a/.circleci/conda_config.py
+++ b/.circleci/conda_config.py
@@ -1,0 +1,40 @@
+import yaml, argparse, os, pathlib
+
+
+class CondaDumper(yaml.Dumper):
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(CondaDumper, self).increase_indent(flow, False)
+
+
+def write_conda_recipe(version):
+    """
+    Writes the EvalML recipe to build a conda package based on the version
+    Args:
+        version: The version of EvalML we are building with this feedstock
+
+    Returns:
+        None: Side effect of overwriting the existing meta.yaml in the feedstock
+    """
+
+    recipe_file_path = os.path.join(os.path.join(os.path.join(os.getcwd(), 'evalml-core-feedstock'), 'recipe'), 'meta'
+                                                                                                                '.yaml')
+    with open(recipe_file_path, 'rb') as config_file:
+        # Toss out the first line that declares the version since its not supported YAML syntax
+        next(config_file)
+        config = yaml.safe_load(config_file)
+        # Path to the evalml repository on the docker container.  Since we are doing a local build this is
+        # the target we are copying this directory to.
+        recipe_path = str(pathlib.Path('..', 'feedstock_root', 'evalml'))
+        config['source'] = {'path': recipe_path}
+        config['package']['version'] = version
+
+    with open(recipe_file_path, 'w') as recipe:
+        yaml.dump(config, recipe, default_flow_style=False, sort_keys=False, Dumper=CondaDumper)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Configure conda for local build. Run from the feedstock root")
+    parser.add_argument('version', help='The version of EvalML being built')
+    args = parser.parse_args()
+    write_conda_recipe(args.version)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   windows: circleci/windows@2.2.0
+  shellcheck: circleci/shellcheck@2.0.0
 
 executors:
   python:
@@ -47,8 +48,42 @@ commands:
             # "!" negates return code. exit nonzero if any of these deps are found
             ! pip freeze | grep -E "xgboost|catboost|lightgbm|plotly|ipywidgets"
             exit $?
+  build_pkg:
+    steps:
+      - run: |
+            git clone https://github.com/conda-forge/evalml-core-feedstock
+            source test_python/bin/activate
+            mkdir evalml-core-feedstock/evalml
+            cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/
+            python .circleci/conda_config.py "$(python setup.py --version)"
+            cd evalml-core-feedstock
+            echo "$DOCKER_HUB_PASS" | docker login -u psalter --password-stdin
+            export DOCKER_CONTAINERID="$(docker run -td condaforge/linux-anvil-comp7)"
+            echo "Created container ${DOCKER_CONTAINERID}"
+            chmod -R 777 ./
+            docker cp . ${DOCKER_CONTAINERID}:/home/conda/feedstock_root/
+            docker cp ./recipe/. ${DOCKER_CONTAINERID}:/home/conda/recipe_root/
+            echo "COMMITING UPDATED IMAGE"
+            docker commit ${DOCKER_CONTAINERID} psalter/build:latest
+            docker stop ${DOCKER_CONTAINERID}
+            export CONFIG=linux_64_
+            export UPLOAD_PACKAGES=False
+            export HOST_USER_ID=$(id -u)
+            export FEEDSTOCK_NAME=evalml-core-feedstock
+            docker run -t -e CONFIG -e HOST_USER_ID -e UPLOAD_PACKAGES -e GIT_BRANCH -e UPLOAD_ON_BRANCH -e CI -e FEEDSTOCK_NAME -e CPU_COUNT -e BINSTAR_TOKEN -e FEEDSTOCK_TOKEN -e STAGING_BINSTAR_TOKEN psalter/build:latest bash /home/conda/feedstock_root/.scripts/build_steps.sh
 
 jobs:
+  build_conda_pkg:
+    working_directory: ~/evalml/
+    executor:
+      name: python
+      python_version: "3.6"
+    steps:
+      - checkout
+      - install_dependencies_test
+      - setup_remote_docker:
+          version: 19.03.12
+      - build_pkg
   lint_test:
       parameters:
         python_version:
@@ -298,3 +333,12 @@ workflows:
                 core_dependencies: [false, true]
                 codecov: [true]
             name: "linux python << matrix.python_version >> unit tests, core dependencies << matrix.core_dependencies >>, codecov << matrix.codecov >>"
+  build_conda_pkg:
+    jobs:
+      - shellcheck/check
+      - build_conda_pkg:
+          requires:
+            - shellcheck/check
+          filters:
+            branches:
+              only: main

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,3 +7,4 @@ pydata-sphinx-theme==0.3.1
 Sphinx==2.0.1; python_version>'3.4'
 nbconvert==5.5.0
 nbsphinx==0.4.2
+

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Added DecisionTree estimators to API Reference :pr:`1246`
         * Changed class inheritance display to flow vertically :pr:`1248`
     * Testing Changes
+        * Added a test to check conda build after merge to main :pr:`1247`
 
 
 **v0.14.1 Sep. 29, 2020**

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ codecov==2.1.0
 category_encoders>=2.0.0
 featuretools
 nlp_primitives>=1.0.0
+PyYAML==5.3.1


### PR DESCRIPTION
### Pull Request Description
Add in a conda package build as part of the ci when a PR is merged into main.  This PR adds in a small python script to change the recipe to use the local build (conda_config.py). Once we have that, we clone the feedstock and start to replicate what the python and shell scripts were doing do to issues on circleCI.  The end result is a build that passes or fails and produces no artifacts.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
