### PR TITLE
allow `add_to_rankings` to work before search

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
         * Added stacked ensemble component classes (StackedEnsembleClassifier, StackedEnsembleRegressor) :pr:`1134`
     * Fixes
     * Changes
-        * Allow ``add_to_rankings`` to be called before AutoMLSearch is called :pr:``
+        * Allow ``add_to_rankings`` to be called before AutoMLSearch is called :pr:`1250`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added stacked ensemble component classes (StackedEnsembleClassifier, StackedEnsembleRegressor) :pr:`1134`
     * Fixes
     * Changes
+        * Allow ``add_to_rankings`` to be called before AutoMLSearch is called :pr:``
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -337,6 +337,22 @@ class AutoMLSearch:
             else:
                 leading_char = ""
 
+    def _set_data_split(self, X):
+        """Sets the data split method for AutoMLSearch
+
+        Arguments:
+            X (DataFrame): Input dataframe to split
+        """
+        if self.problem_type == ProblemTypes.REGRESSION:
+            default_data_split = KFold(n_splits=3, random_state=self.random_state)
+        elif self.problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
+            default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state)
+
+        if X.shape[0] > self._LARGE_DATA_ROW_THRESHOLD:
+            default_data_split = TrainingValidationSplit(test_size=self._LARGE_DATA_PERCENT_VALIDATION)
+
+        self.data_split = self.data_split or default_data_split
+
     def search(self, X, y, data_checks="auto", feature_types=None, show_iteration_plot=True):
         """Find the best pipeline for the data set.
 
@@ -373,16 +389,7 @@ class AutoMLSearch:
         if not isinstance(y, pd.Series):
             y = pd.Series(y)
 
-        # Set the default data splitter
-        if self.problem_type == ProblemTypes.REGRESSION:
-            default_data_split = KFold(n_splits=3, random_state=self.random_state)
-        elif self.problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-            default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state)
-
-        if X.shape[0] > self._LARGE_DATA_ROW_THRESHOLD:
-            default_data_split = TrainingValidationSplit(test_size=self._LARGE_DATA_PERCENT_VALIDATION)
-
-        self.data_split = self.data_split or default_data_split
+        self._set_data_split(X)
 
         data_checks = self._validate_data_checks(data_checks)
         data_check_results = data_checks.validate(X, y)
@@ -798,8 +805,7 @@ class AutoMLSearch:
         if not isinstance(y, pd.Series):
             y = pd.Series(y)
 
-        if not self.has_searched:
-            raise RuntimeError("Please run automl search before calling `add_to_rankings()`")
+        self._set_data_split(X)
 
         pipeline_rows = self.full_rankings[self.full_rankings['pipeline_name'] == pipeline.name]
         for parameter in pipeline_rows['parameters']:

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -6,7 +6,7 @@ import cloudpickle
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import KFold, StratifiedKFold
 
 from evalml import AutoMLSearch
 from evalml.automl import (
@@ -714,8 +714,45 @@ def test_add_to_rankings_no_search(mock_fit, mock_score, dummy_binary_pipeline_c
 
     mock_score.return_value = {'Log Loss Binary': 0.1234}
     test_pipeline = dummy_binary_pipeline_class(parameters={})
-    with pytest.raises(RuntimeError, match="Please run automl"):
-        automl.add_to_rankings(test_pipeline, X, y)
+    assert automl.data_split is None
+
+    automl.add_to_rankings(test_pipeline, X, y)
+    assert isinstance(automl.data_split, StratifiedKFold)
+    assert len(automl.rankings) == 1
+    assert 0.1234 in automl.rankings['score'].values
+
+
+@patch('evalml.pipelines.RegressionPipeline.score')
+@patch('evalml.pipelines.RegressionPipeline.fit')
+def test_add_to_rankings_regression_large(mock_fit, mock_score, dummy_regression_pipeline_class):
+    X = pd.DataFrame({'col_0': [i for i in range(101000)]})
+    y = pd.Series([i for i in range(101000)])
+
+    automl = AutoMLSearch(problem_type='regression', max_time=1, max_iterations=1)
+    test_pipeline = dummy_regression_pipeline_class(parameters={})
+    mock_score.return_value = {automl.objective.name: 0.1234}
+    assert automl.data_split is None
+
+    automl.add_to_rankings(test_pipeline, X, y)
+    assert isinstance(automl.data_split, TrainingValidationSplit)
+    assert len(automl.rankings) == 1
+    assert 0.1234 in automl.rankings['score'].values
+
+
+@patch('evalml.pipelines.RegressionPipeline.score')
+@patch('evalml.pipelines.RegressionPipeline.fit')
+def test_add_to_rankings_regression(mock_fit, mock_score, dummy_regression_pipeline_class, X_y_regression):
+    X, y = X_y_regression
+
+    automl = AutoMLSearch(problem_type='regression', max_time=1, max_iterations=1)
+    test_pipeline = dummy_regression_pipeline_class(parameters={})
+    mock_score.return_value = {automl.objective.name: 0.1234}
+    assert automl.data_split is None
+
+    automl.add_to_rankings(test_pipeline, X, y)
+    assert isinstance(automl.data_split, KFold)
+    assert len(automl.rankings) == 1
+    assert 0.1234 in automl.rankings['score'].values
 
 
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -707,8 +707,7 @@ def test_add_to_rankings(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_
 
 
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
-@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
-def test_add_to_rankings_no_search(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary):
+def test_add_to_rankings_no_search(mock_score, dummy_binary_pipeline_class, X_y_binary):
     X, y = X_y_binary
     automl = AutoMLSearch(problem_type='binary', max_iterations=1, allowed_pipelines=[dummy_binary_pipeline_class])
 
@@ -723,8 +722,7 @@ def test_add_to_rankings_no_search(mock_fit, mock_score, dummy_binary_pipeline_c
 
 
 @patch('evalml.pipelines.RegressionPipeline.score')
-@patch('evalml.pipelines.RegressionPipeline.fit')
-def test_add_to_rankings_regression_large(mock_fit, mock_score, dummy_regression_pipeline_class):
+def test_add_to_rankings_regression_large(mock_score, dummy_regression_pipeline_class):
     X = pd.DataFrame({'col_0': [i for i in range(101000)]})
     y = pd.Series([i for i in range(101000)])
 
@@ -740,8 +738,7 @@ def test_add_to_rankings_regression_large(mock_fit, mock_score, dummy_regression
 
 
 @patch('evalml.pipelines.RegressionPipeline.score')
-@patch('evalml.pipelines.RegressionPipeline.fit')
-def test_add_to_rankings_regression(mock_fit, mock_score, dummy_regression_pipeline_class, X_y_regression):
+def test_add_to_rankings_regression(mock_score, dummy_regression_pipeline_class, X_y_regression):
     X, y = X_y_regression
 
     automl = AutoMLSearch(problem_type='regression', max_time=1, max_iterations=1)

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -707,9 +707,10 @@ def test_add_to_rankings(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_
 
 
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
-def test_add_to_rankings_no_search(mock_score, dummy_binary_pipeline_class, X_y_binary):
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+def test_add_to_rankings_no_search(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary):
     X, y = X_y_binary
-    automl = AutoMLSearch(problem_type='binary', max_iterations=1, allowed_pipelines=[dummy_binary_pipeline_class])
+    automl = AutoMLSearch(problem_type='binary', max_iterations=1)
 
     mock_score.return_value = {'Log Loss Binary': 0.1234}
     test_pipeline = dummy_binary_pipeline_class(parameters={})
@@ -719,6 +720,8 @@ def test_add_to_rankings_no_search(mock_score, dummy_binary_pipeline_class, X_y_
     assert isinstance(automl.data_split, StratifiedKFold)
     assert len(automl.rankings) == 1
     assert 0.1234 in automl.rankings['score'].values
+    automl.search(X, y)
+    assert len(automl.rankings) == 2
 
 
 @patch('evalml.pipelines.RegressionPipeline.score')


### PR DESCRIPTION
fix #900 

Implementation to allow `add_to_rankings()` to be called before AutoMLSearch().search(). 