### PR TITLE
Changed copyright date

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath(path))
 # -- Project information -----------------------------------------------------
 
 project = 'EvalML'
-copyright = '2019, Alteryx, Inc.'
+copyright = '2020, Alteryx, Inc.'
 author = 'Alteryx Innovation Labs'
 
 # The short X.Y version

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Release Notes
         * Fixed and updated code blocks in Release Notes :pr:`1243`
         * Added DecisionTree estimators to API Reference :pr:`1246`
         * Changed class inheritance display to flow vertically :pr:`1248`
+        * Miscellaneous doc updates :pr:`1269`
     * Testing Changes
         * Added tests for ``jupyter_check`` to handle IPython :pr:`1256`
         * Cleaned up ``make_pipeline`` tests to test for all estimators :pr:`1257`


### PR DESCRIPTION
### Pull Request Description
Fixes #1268 . One line fix. Copyright date was 2019, not 2020. 

