### PR TITLE
Removing conda pre-release check from the release process documents.

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,6 +21,7 @@ Release Notes
         * Changed class inheritance display to flow vertically :pr:`1248`
         * Updated cost-benefit tutorial to use a holdout/test set :pr:`1159`
         * Miscellaneous doc updates :pr:`1269`
+        * Removed conda pre-release testing from the release process document :pr:`1282`
     * Testing Changes
         * Added tests for ``jupyter_check`` to handle IPython :pr:`1256`
         * Cleaned up ``make_pipeline`` tests to test for all estimators :pr:`1257`


### PR DESCRIPTION
### Pull Request Description
In PR #1247, we added a CI job to build our conda package whenever `main` gets updated. This simplifies our release process because we no longer need to do a pre-release to test whether conda can build our package. This PR removes these steps from our release process document. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
