### PR TITLE
Add codecov yaml, round coverage up instead of down

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  round: up
+  precision: 2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,6 +36,7 @@ Release Notes
         * Cleaned up ``make_pipeline`` tests to test for all estimators :pr:`1257`
         * Added a test to check conda build after merge to main :pr:`1247`
         * Removed code that was lacking codecov for ``__main__.py`` and unnecessary :pr:`1293`
+        * Codecov: round coverage up instead of down :pr:`1334`
 
 
 .. warning::


### PR DESCRIPTION
I think this will help with some of the codecov precision issues we've been seeing lately. If not, we can continue to tweak.

[The default codecov.io precision is 2](https://docs.codecov.io/docs/codecov-yaml#default-yaml) -- this just changes to [round](https://docs.codecov.io/docs/codecovyml-reference#coverageround) up instead of down when computing the codecov percentage.