### PR TITLE
Include editable installs in all install make targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ commands:
       - run: |
             virtualenv test_python -q
             source test_python/bin/activate
-            make installdeps
             make installdeps-dev
   install_dependencies_core:
     steps:

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,12 @@ installdeps:
 
 .PHONY: installdeps-test
 installdeps-test:
+	pip install -e . -q
 	pip install -r test-requirements.txt -q
 
 .PHONY: installdeps-dev
 installdeps-dev:
+	pip install -e . -q
 	pip install -r dev-requirements.txt -q
 
 .PHONY: dependenciesfile

--- a/contributing.md
+++ b/contributing.md
@@ -19,8 +19,10 @@ The code is hosted on GitHub, so you will need to use Git to clone the project a
 * clone with `git clone https://github.com/alteryx/evalml.git`
 * install in edit mode with:
     ```bash
-    cd evalml  # move to directory
-    make installdeps-dev # installs the repo in edit mode, meaning changes to any files will be picked up in python. also installs all depenedencies.
+    # move into the repo
+    cd evalml
+    # installs the repo in edit mode, meaning changes to any files will be picked up in python. also installs all dependencies.
+    make installdeps-dev
     ```
 
 Note that if you're on Mac, there are a few extra steps you'll want to keep track of.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,6 +20,7 @@ Release Notes
     * Changes
         * Allow ``add_to_rankings`` to be called before AutoMLSearch is called :pr:`1250`
         * Removed ``max_pipelines`` parameter from ``AutoMLSearch`` :pr:`1264`
+        * Include editable installs in all install make targets :pr:`1335`
     * Documentation Changes
         * Fixed and updated code blocks in Release Notes :pr:`1243`
         * Added DecisionTree estimators to API Reference :pr:`1246`


### PR DESCRIPTION
Our contributing guide asks people to run `make installdeps-dev`, but that doesn't include `pip install -e .`, which is important! This gave @rpeck some trouble getting the dev env working.