### PR TITLE
Removed pandas warning when converting to Woodwork in search()

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -29,6 +29,7 @@ Release Notes
         * Fix warnings thrown during AutoMLSearch in ``HighVarianceCVDataCheck`` :pr:`1346`
         * Fixed bug where TrainingValidationSplit would return invalid location indices for dataframes with a custom index :pr:`1348`
         * Fixed bug where the AutoMLSearch ``random_state`` was not being passed to the created pipelines :pr:`1321`
+        * Removed pandas warning when converting to Woodwork in ``search()`` :pr:`1358`
     * Changes
         * Allow ``add_to_rankings`` to be called before AutoMLSearch is called :pr:`1250`
         * Removed Graphviz from test-requirements to add to requirements.txt :pr:`1327`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -386,7 +386,7 @@ class AutoMLSearch:
             logger.warning("`X` passed was not a DataTable. EvalML will try to convert the input as a Woodwork DataTable and types will be inferred. To control this behavior, please pass in a Woodwork DataTable instead.")
             if isinstance(X, np.ndarray):
                 X = pd.DataFrame(X)
-            X = ww.DataTable(X)
+            X = ww.DataTable(X, copy_dataframe=True)
 
         text_column_vals = X.select('natural_language')
         text_columns = list(text_column_vals.to_pandas().columns)


### PR DESCRIPTION
Three possible solutions: 
1. Use `copy_datatable=True` in setting the Woodwork table internally. This might have a degradation in the speed of `search()` since it's copying the entire data table, will need to run performance testing to verify. Current route that this PR goes with. 
2. [Disable the warning in pandas](https://stackoverflow.com/questions/20625582/how-to-deal-with-settingwithcopywarning-in-pandas/20627316#20627316). Another possible solution, but I'm hesitant to disable error messages just to remove the out. 
3.  Change [evalml/preprocessing/utils.py](https://github.com/alteryx/evalml/blob/4c9e5a99d420213aac21ab63a1459a626cb326bc/evalml/preprocessing/utils.py#L68-L69) to use `.loc` instead of `.iloc`. This may cause issues with indexes that are not sequential integer values (such as strings) and unique numbers but aren't zero-indexed. 

Open to hearing why we should or should not go with another approach that isn't option 1. 

Resolves #1344 