### PR TITLE
Update evalml docs to mention woodwork

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -51,6 +51,7 @@ Release Notes
         * Added documentation changes to make the API Docs easier to understand :pr:`1323`
         * Fixed documentation for ``feature_importance`` :pr:`1353`
         * Added tutorial for running `AutoML` with text data :pr:`1357`
+        * Added documentation for woodwork integration with automl search :pr:`1361`
     * Testing Changes
         * Added tests for ``jupyter_check`` to handle IPython :pr:`1256`
         * Cleaned up ``make_pipeline`` tests to test for all estimators :pr:`1257`

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -200,13 +200,6 @@
    "source": [
     "pipeline.graph()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -84,6 +84,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
+    "\n",
+    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork `DataTable`s include features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide woodwork objects, EvalML will raise a warning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import woodwork as ww\n",
+    "X_train_dt = ww.DataTable(X_train)\n",
+    "y_train_dc = ww.DataColumn(y_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "When we call `search()`, the search for the best pipeline will begin. There is no need to wrangle with missing data or categorical variables as EvalML includes various preprocessing steps (like imputation, one-hot encoding, feature selection) to ensure you're getting the best results. As long as your data is in a single table, EvalML can handle it. If not, you can reduce your data to a single table by utilizing [Featuretools](https://featuretools.featurelabs.com) and its Entity Sets.\n",
     "\n",
     "You can find more information on pipeline components and how to integrate your own custom pipelines into EvalML [here](user_guide/pipelines.ipynb)."
@@ -95,7 +115,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl.search(X_train, y_train)"
+    "automl.search(X_train_dt, y_train_dc)"
    ]
   },
   {
@@ -180,6 +200,13 @@
    "source": [
     "pipeline.graph()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -84,9 +84,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
+    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
     "\n",
-    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork `DataTable`s include features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide woodwork objects, EvalML will raise a warning."
+    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork's `DataTable` includes features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide Woodwork objects, EvalML will raise a warning."
    ]
   },
   {

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -42,6 +42,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
+    "\n",
+    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork `DataTable`s include features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide woodwork objects, EvalML will raise a warning."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -51,8 +60,12 @@
     "\n",
     "X, y = evalml.demos.load_breast_cancer()\n",
     "\n",
+    "import woodwork as ww\n",
+    "X_dt = ww.DataTable(X)\n",
+    "y_dc = ww.DataColumn(y)\n",
+    "\n",
     "automl = evalml.automl.AutoMLSearch(problem_type='binary')\n",
-    "automl.search(X, y)"
+    "automl.search(X_dt, y_dc)"
    ]
   },
   {

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -45,9 +45,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
+    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
     "\n",
-    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork `DataTable`s include features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide woodwork objects, EvalML will raise a warning."
+    "EvalML also accepts and works well with pandas `DataFrames`. But using the `DataTable` makes it easy to control how EvalML will treat each feature, as a numeric feature, a categorical feature, a text feature or other type of feature. Woodwork's `DataTable` includes features like inferring when a categorical feature should be treated as a text feature. For this reason, if you don't provide Woodwork objects, EvalML will raise a warning."
    ]
   },
   {


### PR DESCRIPTION
Fix #1287 

Adds a mention and example to the start page and to the automl user guide page about woodwork.

This is just to start us off. Eventually I'd like us to add a page or section to the automl guide about "formatting data for automl", which shows how to set the column types using woodwork, override some of the default inference and run automl with those settings.