### PR TITLE
Fix conda build: use the correct DockerHub credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/
             python .circleci/conda_config.py "$(python setup.py --version)"
             cd evalml-core-feedstock
-            echo "$DOCKER_HUB_PASS" | docker login -u psalter --password-stdin
+            echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USERNAME --password-stdin
             export DOCKER_CONTAINERID="$(docker run -td condaforge/linux-anvil-comp7)"
             echo "Created container ${DOCKER_CONTAINERID}"
             chmod -R 777 ./

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -57,7 +57,7 @@ Release Notes
         * Removed code that was lacking codecov for ``__main__.py`` and unnecessary :pr:`1293`
         * Codecov: round coverage up instead of down :pr:`1334`
         * Add DockerHub credentials to CI testing environment :pr:`1356`
-
+        * Add DockerHub credentials to conda testing environment :pr:`1363`
 
 .. warning::
 


### PR DESCRIPTION
- There was some un-updated DockerHub credentials in CI.
- Fixes #1260