### PR TITLE
Don't add OneHotEncoder to pipeline for text features

### DIFF
--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -63,6 +63,7 @@ def _get_preprocessing_components(X, y, problem_type, text_columns, estimator_cl
 
     # DateTimeFeaturizer can create categorical columns
     categorical_cols = X.select_dtypes(include=categorical_dtypes)
+    categorical_cols.drop(text_columns, inplace=True, errors='ignore', axis=1)
     if (add_datetime_featurizer or len(categorical_cols.columns) > 0) and estimator_class not in {CatBoostClassifier, CatBoostRegressor}:
         pp_components.append(OneHotEncoder)
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -63,7 +63,7 @@ def _get_preprocessing_components(X, y, problem_type, text_columns, estimator_cl
 
     # DateTimeFeaturizer can create categorical columns
     categorical_cols = X.select_dtypes(include=categorical_dtypes)
-    categorical_cols.drop(text_columns, inplace=True, errors='ignore', axis=1)
+    categorical_cols.drop(columns=text_columns, inplace=True, errors='ignore')
     if (add_datetime_featurizer or len(categorical_cols.columns) > 0) and estimator_class not in {CatBoostClassifier, CatBoostRegressor}:
         pp_components.append(OneHotEncoder)
 


### PR DESCRIPTION
**Problem**
Our `make_pipelines` code builds a pipeline based on the feature types present in the data. The [`_get_preprocessing_components` method](https://github.com/alteryx/evalml/blob/main/evalml/pipelines/utils.py#L66) will currently add a one-hot encoder component if there are any features of type `object` or `category` in the pandas dataframe. However, in the case where the data includes text features but no categorical features, this is unnecessary.

**Fix**
Short-term (this PR): during pipeline creation, exclude text features when determining whether or not to add an encoder for categorical features.

Long-term: use woodwork to get categorical cols, not pandas! (#1229 ). The `make_pipelines` code should be given a woodwork datatable, and we should instead use woodwork's select method.

