### PR TITLE
fix lightgbm warnings

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1369`
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -32,7 +33,7 @@ Release Notes
         * Fixed bug in ``explain_predictions_best_worst`` where a custom index in the target variable would cause a ``ValueError`` :pr:`1318`
         * Added stacked ensemble estimators to to ``evalml.pipelines.__init__`` file :pr:`1326`
         * Fixed bug in OHE where calls to transform were not deterministic if ``top_n`` was less than the number of categories in a column :pr:`1324`
-        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`, :pr:`1369`
+        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`
         * Fix warnings thrown during AutoMLSearch in ``HighVarianceCVDataCheck`` :pr:`1346`
         * Fixed bug where TrainingValidationSplit would return invalid location indices for dataframes with a custom index :pr:`1348`
         * Fixed bug where the AutoMLSearch ``random_state`` was not being passed to the created pipelines :pr:`1321`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,7 +25,7 @@ Release Notes
         * Fixed bug in ``explain_predictions_best_worst`` where a custom index in the target variable would cause a ``ValueError`` :pr:`1318`
         * Added stacked ensemble estimators to to ``evalml.pipelines.__init__`` file :pr:`1326`
         * Fixed bug in OHE where calls to transform were not deterministic if ``top_n`` was less than the number of categories in a column :pr:`1324`
-        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`, :pr:``
+        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`, :pr:`1369`
         * Fix warnings thrown during AutoMLSearch in ``HighVarianceCVDataCheck`` :pr:`1346`
         * Fixed bug where TrainingValidationSplit would return invalid location indices for dataframes with a custom index :pr:`1348`
         * Fixed bug where the AutoMLSearch ``random_state`` was not being passed to the created pipelines :pr:`1321`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,7 +25,7 @@ Release Notes
         * Fixed bug in ``explain_predictions_best_worst`` where a custom index in the target variable would cause a ``ValueError`` :pr:`1318`
         * Added stacked ensemble estimators to to ``evalml.pipelines.__init__`` file :pr:`1326`
         * Fixed bug in OHE where calls to transform were not deterministic if ``top_n`` was less than the number of categories in a column :pr:`1324`
-        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`
+        * Fixed LightGBM warning messages during AutoMLSearch :pr:`1342`, :pr:``
         * Fix warnings thrown during AutoMLSearch in ``HighVarianceCVDataCheck`` :pr:`1346`
         * Fixed bug where TrainingValidationSplit would return invalid location indices for dataframes with a custom index :pr:`1348`
         * Fixed bug where the AutoMLSearch ``random_state`` was not being passed to the created pipelines :pr:`1321`

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -22,9 +22,7 @@ class LightGBMClassifier(Estimator):
         "n_estimators": Integer(10, 100),
         "max_depth": Integer(0, 10),
         "num_leaves": Integer(2, 100),
-        "min_child_samples": Integer(1, 100),
-        "bagging_fraction": Real(0.000001, 1),
-        "bagging_freq": Integer(0, 1)
+        "min_child_samples": Integer(1, 100)
     }
     model_family = ModelFamily.LIGHTGBM
     supported_problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
@@ -32,7 +30,7 @@ class LightGBMClassifier(Estimator):
     SEED_MIN = 0
     SEED_MAX = SEED_BOUNDS.max_bound
 
-    def __init__(self, boosting_type="gbdt", learning_rate=0.1, n_estimators=100, max_depth=0, num_leaves=31, min_child_samples=20, n_jobs=-1, random_state=0, bagging_fraction=0.9, bagging_freq=0, **kwargs):
+    def __init__(self, boosting_type="gbdt", learning_rate=0.1, n_estimators=100, max_depth=0, num_leaves=31, min_child_samples=20, n_jobs=-1, random_state=0, **kwargs):
         # lightGBM's current release doesn't currently support numpy.random.RandomState as the random_state value so we convert to int instead
         random_seed = get_random_seed(random_state, self.SEED_MIN, self.SEED_MAX)
 
@@ -42,16 +40,15 @@ class LightGBMClassifier(Estimator):
                       "max_depth": max_depth,
                       "num_leaves": num_leaves,
                       "min_child_samples": min_child_samples,
-                      "n_jobs": n_jobs,
-                      "bagging_freq": bagging_freq,
-                      "bagging_fraction": bagging_fraction}
+                      "n_jobs": n_jobs}
         parameters.update(kwargs)
         lg_parameters = copy.copy(parameters)
         # when boosting type is random forest (rf), LightGBM requires bagging_freq == 1 and  0 < bagging_fraction < 1.0
         if boosting_type == "rf":
             lg_parameters['bagging_freq'] = 1
-        # avoid lightgbm warnings having to do with parameter aliases
-        if lg_parameters['bagging_freq']:
+            if 'bagging_fraction' not in lg_parameters.keys():
+                lg_parameters['bagging_fraction'] = 0.9
+            # avoid lightgbm warnings having to do with parameter aliases
             lg_parameters.update({'subsample': None, 'subsample_freq': None})
 
         lgbm_error_msg = "LightGBM is not installed. Please install using `pip install lightgbm`."

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -205,7 +205,7 @@ def test_describe_component():
     try:
         lg_classifier = LightGBMClassifier()
         assert lg_classifier.describe(return_dict=True) == {'name': 'LightGBM Classifier', 'parameters': {'boosting_type': 'gbdt', 'learning_rate': 0.1, 'n_estimators': 100, 'max_depth': 0, 'num_leaves': 31,
-                                                                                                          'min_child_samples': 20, 'n_jobs': -1, 'bagging_fraction': 0.9, 'bagging_freq': 0}}
+                                                                                                          'min_child_samples': 20, 'n_jobs': -1}}
     except ImportError:
         pass
 

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -295,21 +295,21 @@ def test_binary_rf_not_defaults(X_y_binary):
         clf = LightGBMClassifier(boosting_type="rf", bagging_freq=0)
         clf.fit(X, y)
         assert clf.parameters['bagging_freq'] == 0
-        assert clf.parameters['bagging_fraction'] == 0.9
+        assert 'bagging_fraction' not in clf.parameters.keys()
     assert len(warnings) == 0
 
     with pytest.warns(None) as warnings:
         clf = LightGBMClassifier(boosting_type="gbdt", bagging_freq=0)
         clf.fit(X, y)
         assert clf.parameters['bagging_freq'] == 0
-        assert clf.parameters['bagging_fraction'] == 0.9
+        assert 'bagging_fraction' not in clf.parameters.keys()
     assert len(warnings) == 0
 
     with pytest.warns(None) as warnings:
         clf = LightGBMClassifier(boosting_type="gbdt", bagging_freq=1)
         clf.fit(X, y)
         assert clf.parameters['bagging_freq'] == 1
-        assert clf.parameters['bagging_fraction'] == 0.9
+        assert 'bagging_fraction' not in clf.parameters.keys()
     assert len(warnings) == 0
 
 
@@ -318,8 +318,8 @@ def test_binary_rf(X_y_binary):
 
     clf = LightGBMClassifier()
     clf.fit(X, y)
-    assert clf.parameters['bagging_freq'] == 0
-    assert clf.parameters['bagging_fraction'] == 0.9
+    assert 'bagging_freq' not in clf.parameters.keys()
+    assert 'bagging_fraction' not in clf.parameters.keys()
 
     with pytest.warns(None) as warnings:
         clf = LightGBMClassifier(boosting_type="rf")


### PR DESCRIPTION
fix #1330 

Patch fix from last time.
The issue is that if we set `bagging_freq` or `bagging_fraction`, we must set `subsample` and `subsample_freq` to None in order to remove this warning. Additionally, if `boosting type=goss`, it doesn't accept bagging, so we remove `bagging_freq` and `bagging_fraction` from the input parameters to avoid this error in AutoMLSearch. 