### PR TITLE
Clean up returned Codegen code

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
     * Fixes
         * Updated enum classes to show possible enum values as attributes :pr:`1391`
     * Changes
+        * Simplified and cleaned output for Code Generation :pr:`1371`
     * Documentation Changes
         * Added description of CLA to contributing guide, updated description of draft PRs :pr:`1402`
     * Testing Changes

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -396,15 +396,8 @@
     "\n",
     "pipeline_instance = CustomPipeline(parameters={\"Imputer\": {\"numeric_impute_strategy\": \"median\"}})\n",
     "code = generate_pipeline_code(pipeline_instance)\n",
-    "print(code)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "print(code)\n",
+    "\n",
     "# This string can then be pasted into a separate window and run, although since the pipeline has custom component `MyDropNullColumns`, \n",
     "#      the code for that component must also be included\n",
     "\n",

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1524,41 +1524,35 @@ def test_generate_code_pipeline():
         component_graph = ['Imputer', 'Random Forest Regressor']
 
     mock_binary_pipeline = MockBinaryPipeline({})
-    expected_code = "from evalml.pipelines.components import (" \
-                    "\n\tImputer," \
-                    "\n\tRandomForestClassifier\n)" \
-                    "\nfrom evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline\n" \
-                    "\nclass MockBinaryPipeline(BinaryClassificationPipeline):" \
-                    "\n\tcomponent_graph = ['Imputer', 'Random Forest Classifier']" \
-                    "\n\tcustom_hyperparameters = {'Imputer': {'numeric_impute_strategy': 'most_frequent'}}\n" \
-                    "\nparameters = {'Imputer': {'categorical_impute_strategy': 'most_frequent', 'numeric_impute_strategy': 'mean', 'categorical_fill_value': None, 'numeric_fill_value': None}, 'Random Forest Classifier': {'n_estimators': 100, 'max_depth': 6, 'n_jobs': -1}}" \
-                    "\npipeline = MockBinaryPipeline(parameters)"
-    pipeline_code = generate_pipeline_code(mock_binary_pipeline)
-    assert expected_code == pipeline_code
+    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+                    '\n\nclass MockBinaryPipeline(BinaryClassificationPipeline):' \
+                    '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Classifier\'\n\t]' \
+                    '\n\tcustom_hyperparameters = {\'Imputer\': {\'numeric_impute_strategy\': \'most_frequent\'}}\n' \
+                    '\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
+                    '\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}\n' \
+                    'pipeline = MockBinaryPipeline(parameters)'
+    pipeline = generate_pipeline_code(mock_binary_pipeline)
+    assert expected_code == pipeline
 
     mock_regression_pipeline = MockRegressionPipeline({})
-    expected_code = "from evalml.pipelines.components import (" \
-                    "\n\tImputer," \
-                    "\n\tRandomForestRegressor\n)" \
-                    "\nfrom evalml.pipelines.regression_pipeline import RegressionPipeline\n" \
-                    "\nclass MockRegressionPipeline(RegressionPipeline):" \
-                    "\n\tcomponent_graph = ['Imputer', 'Random Forest Regressor']" \
-                    "\n\tname = 'Mock Regression Pipeline'\n" \
-                    "\nparameters = {'Imputer': {'categorical_impute_strategy': 'most_frequent', 'numeric_impute_strategy': 'mean', 'categorical_fill_value': None, 'numeric_fill_value': None}, 'Random Forest Regressor': {'n_estimators': 100, 'max_depth': 6, 'n_jobs': -1}}" \
-                    "\npipeline = MockRegressionPipeline(parameters)"
+    expected_code = 'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
+                    '\n\nclass MockRegressionPipeline(RegressionPipeline):' \
+                    '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Regressor\'\n\t]\n\t' \
+                    'name = \'Mock Regression Pipeline\'\n\n' \
+                    'parameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
+                    '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                    '\npipeline = MockRegressionPipeline(parameters)'
     pipeline = generate_pipeline_code(mock_regression_pipeline)
     assert pipeline == expected_code
 
     mock_regression_pipeline_params = MockRegressionPipeline({"Imputer": {"numeric_impute_strategy": "most_frequent"}, "Random Forest Regressor": {"n_estimators": 50}})
-    expected_code_params = "from evalml.pipelines.components import (" \
-                           "\n\tImputer," \
-                           "\n\tRandomForestRegressor\n)" \
-                           "\nfrom evalml.pipelines.regression_pipeline import RegressionPipeline\n" \
-                           "\nclass MockRegressionPipeline(RegressionPipeline):" \
-                           "\n\tcomponent_graph = ['Imputer', 'Random Forest Regressor']" \
-                           "\n\tname = 'Mock Regression Pipeline'\n" \
-                           "\nparameters = {'Imputer': {'categorical_impute_strategy': 'most_frequent', 'numeric_impute_strategy': 'most_frequent', 'categorical_fill_value': None, 'numeric_fill_value': None}, 'Random Forest Regressor': {'n_estimators': 50, 'max_depth': 6, 'n_jobs': -1}}" \
-                           "\npipeline = MockRegressionPipeline(parameters)"
+    expected_code_params = 'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
+                           '\n\nclass MockRegressionPipeline(RegressionPipeline):' \
+                           '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Regressor\'\n\t]' \
+                           '\n\tname = \'Mock Regression Pipeline\'' \
+                           '\n\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "most_frequent",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
+                           '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 50,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                           '\npipeline = MockRegressionPipeline(parameters)'
     pipeline = generate_pipeline_code(mock_regression_pipeline_params)
     assert pipeline == expected_code_params
 
@@ -1606,36 +1600,31 @@ def test_generate_code_pipeline_custom():
         component_graph = [CustomTransformer, CustomEstimator]
 
     mockBinaryTransformer = MockBinaryPipelineTransformer({})
-    expected_code = "from evalml.pipelines.components import (" \
-                    "\n\tRandomForestClassifier\n)" \
-                    "\nfrom evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline\n" \
-                    "\nclass MockBinaryPipelineTransformer(BinaryClassificationPipeline):" \
-                    "\n\tcomponent_graph = [CustomTransformer, 'Random Forest Classifier']" \
-                    "\n\tname = 'Mock Binary Pipeline with Transformer'\n" \
-                    "\nparameters = {'Random Forest Classifier': {'n_estimators': 100, 'max_depth': 6, 'n_jobs': -1}}" \
-                    "\npipeline = MockBinaryPipelineTransformer(parameters)"
+    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+                    '\n\nclass MockBinaryPipelineTransformer(BinaryClassificationPipeline):' \
+                    '\n\tcomponent_graph = [\n\t\tCustomTransformer,\n\t\t\'Random Forest Classifier\'\n\t]' \
+                    '\n\tname = \'Mock Binary Pipeline with Transformer\'' \
+                    '\n\nparameters = {\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                    '\npipeline = MockBinaryPipelineTransformer(parameters)'
     pipeline = generate_pipeline_code(mockBinaryTransformer)
     assert pipeline == expected_code
 
     mockBinaryPipeline = MockBinaryPipelineEstimator({})
-    expected_code = "from evalml.pipelines.components import (" \
-                    "\n\tImputer\n)" \
-                    "\nfrom evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline\n" \
-                    "\nclass MockBinaryPipelineEstimator(BinaryClassificationPipeline):" \
-                    "\n\tcomponent_graph = ['Imputer', CustomEstimator]" \
-                    "\n\tcustom_hyperparameters = {'Imputer': {'numeric_impute_strategy': 'most_frequent'}}" \
-                    "\n\tname = 'Mock Binary Pipeline with Estimator'\n" \
-                    "\nparameters = {'Imputer': {'categorical_impute_strategy': 'most_frequent', 'numeric_impute_strategy': 'mean', 'categorical_fill_value': None, 'numeric_fill_value': None}}" \
-                    "\npipeline = MockBinaryPipelineEstimator(parameters)"
+    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+                    '\n\nclass MockBinaryPipelineEstimator(BinaryClassificationPipeline):' \
+                    '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\tCustomEstimator\n\t]' \
+                    '\n\tcustom_hyperparameters = {\'Imputer\': {\'numeric_impute_strategy\': \'most_frequent\'}}' \
+                    '\n\tname = \'Mock Binary Pipeline with Estimator\'' \
+                    '\n\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t}\n}' \
+                    '\npipeline = MockBinaryPipelineEstimator(parameters)'
     pipeline = generate_pipeline_code(mockBinaryPipeline)
     assert pipeline == expected_code
 
     mockAllCustom = MockAllCustom({})
-    expected_code = "from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline\n" \
-                    "\nclass MockAllCustom(BinaryClassificationPipeline):" \
-                    "\n\tcomponent_graph = [CustomTransformer, CustomEstimator]" \
-                    "\n\tname = 'Mock All Custom Pipeline'\n" \
-                    "\nparameters = {}\n" \
-                    "pipeline = MockAllCustom(parameters)"
+    expected_code = "from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline" \
+                    "\n\nclass MockAllCustom(BinaryClassificationPipeline):" \
+                    "\n\tcomponent_graph = [\n\t\tCustomTransformer,\n\t\tCustomEstimator\n\t]" \
+                    "\n\tname = 'Mock All Custom Pipeline'\n\nparameters = {}" \
+                    "\npipeline = MockAllCustom(parameters)"
     pipeline = generate_pipeline_code(mockAllCustom)
     assert pipeline == expected_code


### PR DESCRIPTION
fix #1375 

Added formatting for code generation (both for param dictionary and component graph). Remove unnecessary import code from `generate_code_pipelines`