### PR TITLE
Removing category_encoders from test-requirements.txt

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Removed ``category_encoders`` from test-requirements.txt :pr:`1373`
 
 **v0.15.0 Oct. 29, 2020**
     * Enhancements

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,4 @@ pytest-cov==2.6.1
 nbval==0.9.3
 IPython>=5.0.0
 codecov==2.1.0
-category_encoders>=2.0.0
 PyYAML==5.3.1


### PR DESCRIPTION
### Pull Request Description
In #572, we moved `category-encoders` to test-requirements.txt because some unit tests needed it but this is no longer the case! We may need this dependency again in the future when we add new encoders, but we should add it to either core-requirements or requirements when we actually need it.

Performance tests [here](https://alteryx.quip.com/IQyDANbShtvs/Removing-categoryencoders).

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
