### PR TITLE
Fixed IndexError when ensembling = True but number of pipelines to search over is 1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Enhancements
         * Added ability to freeze hyperparameters for AutoMLSearch :pr:`1284`
     * Fixes
+        * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -53,6 +53,7 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         Returns:
             list(PipelineBase): a list of instances of PipelineBase subclasses, ready to be trained and evaluated.
         """
+        run_ensembling = self.ensembling and len(self.allowed_pipelines) > 1
         if self._batch_number == 1:
             if len(self._first_batch_results) == 0:
                 raise AutoMLAlgorithmException('No results were reported from the first batch')
@@ -64,8 +65,7 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                           for pipeline_class in self.allowed_pipelines]
 
         # One after training all pipelines one round
-        elif (self.ensembling and
-              len(self._first_batch_results) > 1 and
+        elif (run_ensembling and
               self._batch_number != 1 and
               (self._batch_number) % (len(self._first_batch_results) + 1) == 0):
             input_pipelines = []
@@ -76,7 +76,7 @@ class IterativeAlgorithm(AutoMLAlgorithm):
             ensemble = _make_stacked_ensemble_pipeline(input_pipelines, input_pipelines[0].problem_type)
             next_batch.append(ensemble)
         else:
-            num_pipeline_classes = (len(self._first_batch_results) + 1) if self.ensembling else len(self._first_batch_results)
+            num_pipeline_classes = (len(self._first_batch_results) + 1) if run_ensembling else len(self._first_batch_results)
             idx = (self._batch_number - 1) % num_pipeline_classes
             pipeline_class = self._first_batch_results[idx][1]
             for i in range(self.pipelines_per_batch):

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -454,7 +454,7 @@ class AutoMLSearch:
             n_jobs=self.n_jobs,
             number_features=X.shape[1],
             pipelines_per_batch=self._pipelines_per_batch,
-            ensembling=self.ensembling
+            ensembling=run_ensembling
         )
 
         log_title(logger, "Beginning pipeline search")

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -425,7 +425,7 @@ class AutoMLSearch:
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")
         if self.max_batches and self.max_iterations is None:
-            if self.ensembling:
+            if self.ensembling and len(self.allowed_pipelines) > 1:
                 ensemble_nth_batch = len(self.allowed_pipelines) + 1
                 num_ensemble_batches = (self.max_batches - 1) // ensemble_nth_batch
                 self.max_iterations = (1 + len(self.allowed_pipelines) +

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -147,7 +147,7 @@ class AutoMLSearch:
             verbose (boolean): If True, turn verbosity on. Defaults to True.
 
             ensembling (boolean): If True, runs ensembling in a separate batch after every allowed pipeline class has been iterated over.
-                Defaults to False. If the number of unique pipelines to search over per batch is one, ensembling will not run.
+                If the number of unique pipelines to search over per batch is one, ensembling will not run. Defaults to False.
 
             max_batches (int): The maximum number of batches of pipelines to search. Parameters max_time, and
                 max_iterations have precedence over stopping the search.

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -146,7 +146,8 @@ class AutoMLSearch:
 
             verbose (boolean): If True, turn verbosity on. Defaults to True.
 
-            ensembling (boolean): If True, runs ensembling in a separate batch after every allowed pipeline class has been iterated over. Defaults to False.
+            ensembling (boolean): If True, runs ensembling in a separate batch after every allowed pipeline class has been iterated over.
+                Defaults to False. If the number of unique pipelines to search over per batch is one, ensembling will not run.
 
             max_batches (int): The maximum number of batches of pipelines to search. Parameters max_time, and
                 max_iterations have precedence over stopping the search.
@@ -424,8 +425,14 @@ class AutoMLSearch:
 
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")
+
+        run_ensembling = self.ensembling
+        if run_ensembling and len(self.allowed_pipelines) == 1:
+            logger.warning("Ensembling was set to True, but the number of unique pipelines is one, so ensembling will not run.")
+            run_ensembling = False
+
         if self.max_batches and self.max_iterations is None:
-            if self.ensembling and len(self.allowed_pipelines) > 1:
+            if run_ensembling:
                 ensemble_nth_batch = len(self.allowed_pipelines) + 1
                 num_ensemble_batches = (self.max_batches - 1) // ensemble_nth_batch
                 self.max_iterations = (1 + len(self.allowed_pipelines) +

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1353,8 +1353,6 @@ def test_automl_one_allowed_pipeline_ensembling_disabled(mock_pipeline_fit, mock
     caplog.clear()
     automl = AutoMLSearch(problem_type="binary", max_iterations=max_iterations, allowed_model_families=[ModelFamily.LINEAR_MODEL], ensembling=True)
     automl.search(X, y, data_checks=None)
-    if max_iterations is None:
-        max_iterations = 5  # Default value for max_iterations
     pipeline_names = automl.rankings['pipeline_name']
     assert pipeline_names.str.contains('Ensemble').any()
     assert "Ensembling was set to True, but the number of unique pipelines is one, so ensembling will not run." not in caplog.text

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -90,7 +90,7 @@ def test_iterative_algorithm_results(ensembling_value, dummy_binary_pipeline_cla
     assert [p.__class__ for p in next_batch] == dummy_binary_pipeline_classes
     assert algo.pipeline_number == len(dummy_binary_pipeline_classes)
     assert algo.batch_number == 1
-    assert all([p.parameters == (p.__class__)({}).parameters for p in next_batch])
+    assert all([p.parameters == p.__class__.default_parameters for p in next_batch])
     # the "best" score will be the 1st dummy pipeline
     scores = np.arange(0, len(next_batch))
     for score, pipeline in zip(scores, next_batch):
@@ -149,7 +149,7 @@ def test_iterative_algorithm_one_allowed_pipeline(ensembling_value, logistic_reg
     assert [p.__class__ for p in next_batch] == [logistic_regression_binary_pipeline_class] * len(next_batch)
     assert algo.pipeline_number == 1
     assert algo.batch_number == 1
-    assert all([p.parameters == (p.__class__)({}).parameters for p in next_batch])
+    assert all([p.parameters == p.__class__.default_parameters for p in next_batch])
     # the "best" score will be the 1st dummy pipeline
     scores = np.arange(0, len(next_batch))
     for score, pipeline in zip(scores, next_batch):
@@ -173,7 +173,7 @@ def test_iterative_algorithm_one_allowed_pipeline(ensembling_value, logistic_reg
         scores = -np.arange(0, len(next_batch))
         for score, pipeline in zip(scores, next_batch):
             algo.add_result(score, pipeline)
-        assert any([p != logistic_regression_binary_pipeline_class({}).parameters for p in all_parameters])
+        assert any([p != logistic_regression_binary_pipeline_class.default_parameters for p in all_parameters])
 
 
 def test_iterative_algorithm_instantiates_text(dummy_classifier_estimator_class):


### PR DESCRIPTION
Closes #1387 

- Fixes IndexError when number of pipelines to search over == 1
- Adds a warning that ensembling will not run if num of pipelines == 1