### PR TITLE
Add Target Encoder to Components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
             pip install -r core-requirements.txt
             pip install -r test-requirements.txt
             # "!" negates return code. exit nonzero if any of these deps are found
-            ! pip freeze | grep -E "xgboost|catboost|lightgbm|plotly|ipywidgets"
+            ! pip freeze | grep -E "xgboost|catboost|lightgbm|plotly|ipywidgets|category_encoders"
             exit $?
   build_pkg:
     steps:

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -189,6 +189,7 @@ Transformers are components that take in data as input and output transformed da
     DropColumns
     SelectColumns
     OneHotEncoder
+    TargetEncoder
     PerColumnImputer
     Imputer
     SimpleImputer

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,8 +3,9 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+        * Added ability to freeze hyperparameters for AutoMLSearch :pr:`1284`
+        * Added `Target Encoder` into transformer components :pr:`1401`
         * Updated pipelines and ``make_pipeline`` to accept Woodwork DataTables :pr:`1393`
-        * Added ability to freeze hyperparameters for ``AutoMLSearch`` :pr:`1284`
         * Added callback for error handling in ``AutoMLSearch`` :pr:`1403`
         * Added the index id to the ``explain_predictions_best_worst`` output to help users identify which rows in their data are included :pr:`1365`
         * The top_k features displayed in ``explain_predictions_*`` functions are now determined by the magnitude of shap values as opposed to the ``top_k`` largest and smallest shap values. :pr:`1374`

--- a/evalml/pipelines/__init__.py
+++ b/evalml/pipelines/__init__.py
@@ -1,6 +1,7 @@
 from .components import (
     Estimator,
     OneHotEncoder,
+    TargetEncoder,
     SimpleImputer,
     PerColumnImputer,
     StandardScaler,

--- a/evalml/pipelines/components/__init__.py
+++ b/evalml/pipelines/components/__init__.py
@@ -22,6 +22,7 @@ from .estimators import (
 from .transformers import (
     Transformer,
     OneHotEncoder,
+    TargetEncoder,
     RFClassifierSelectFromModel,
     RFRegressorSelectFromModel,
     PerColumnImputer,

--- a/evalml/pipelines/components/transformers/__init__.py
+++ b/evalml/pipelines/components/transformers/__init__.py
@@ -1,5 +1,5 @@
 from .transformer import Transformer
-from .encoders import OneHotEncoder
+from .encoders import OneHotEncoder, TargetEncoder
 from .feature_selection import FeatureSelector, RFClassifierSelectFromModel, RFRegressorSelectFromModel
 from .imputers import PerColumnImputer, SimpleImputer, Imputer
 from .scalers import StandardScaler

--- a/evalml/pipelines/components/transformers/encoders/__init__.py
+++ b/evalml/pipelines/components/transformers/encoders/__init__.py
@@ -1,1 +1,2 @@
 from .onehot_encoder import OneHotEncoder
+from .target_encoder import TargetEncoder

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -1,6 +1,10 @@
+import pandas as pd
+
 from ..transformer import Transformer
 
-from evalml.pipelines.components.transformers.encoders.onehot_encoder import OneHotEncoderMeta
+from evalml.pipelines.components.transformers.encoders.onehot_encoder import (
+    OneHotEncoderMeta
+)
 from evalml.utils import import_or_raise
 
 
@@ -48,8 +52,10 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
                          random_state=random_state)
 
     def fit(self, X, y):
-        X.reset_index(drop=True, inplace=True)
-        y.reset_index(drop=True, inplace=True)
+        if isinstance(X, pd.DataFrame):
+            X.reset_index(drop=True, inplace=True)
+        if isinstance(y, pd.Series):
+            y.reset_index(drop=True, inplace=True)
         return super().fit(X, y)
 
     def transform(self, X, y=None):

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -1,15 +1,10 @@
 from ..transformer import Transformer
 
-from evalml.pipelines.components import ComponentBaseMeta
+from evalml.pipelines.components.transformers.encoders.onehot_encoder import OneHotEncoderMeta
 from evalml.utils import import_or_raise
 
 
-class TargetEncoderMeta(ComponentBaseMeta):
-    """A version of the ComponentBaseMeta class which includes validation on an additional target-encoder method `categories`"""
-    METHODS_TO_CHECK = ComponentBaseMeta.METHODS_TO_CHECK + ['get_feature_names']
-
-
-class TargetEncoder(Transformer, metaclass=TargetEncoderMeta):
+class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
     """Target encoder to encode categorical data"""
     name = 'Target Encoder'
     hyperparameter_ranges = {}
@@ -26,7 +21,7 @@ class TargetEncoder(Transformer, metaclass=TargetEncoderMeta):
         Arguments:
             cols (list): Columns to encode. If None, all string columns will be encoded, otherwise only the columns provided will be encoded.
                 Defaults to None
-            smoothing (float): The smoothing factor to apply. The larger this value is, the more influence the expected value has
+            smoothing (float): The smoothing factor to apply. The larger this value is, the more influence the expected target value has
                 on the resulting target encodings. Must be strictly larger than 0. Defaults to 1.0
             handle_unknown (string): Determines how to handle unknown categories for a feature encountered. Options are 'value', 'error', nd 'return_nan'.
                 Defaults to 'value', which replaces with the target mean
@@ -53,10 +48,15 @@ class TargetEncoder(Transformer, metaclass=TargetEncoderMeta):
                          random_state=random_state)
 
     def fit(self, X, y):
+        X.reset_index(drop=True, inplace=True)
+        y.reset_index(drop=True, inplace=True)
         return super().fit(X, y)
 
     def transform(self, X, y=None):
         return super().transform(X, y)
+
+    def fit_transform(self, X, y):
+        return self.fit(X, y).transform(X)
 
     def get_feature_names(self):
         """Return feature names for the input features after fitting.

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -1,0 +1,67 @@
+from ..transformer import Transformer
+
+from evalml.pipelines.components import ComponentBaseMeta
+from evalml.utils import import_or_raise
+
+
+class TargetEncoderMeta(ComponentBaseMeta):
+    """A version of the ComponentBaseMeta class which includes validation on an additional target-encoder method `categories`"""
+    METHODS_TO_CHECK = ComponentBaseMeta.METHODS_TO_CHECK + ['get_feature_names']
+
+
+class TargetEncoder(Transformer, metaclass=TargetEncoderMeta):
+    """Target encoder to encode categorical data"""
+    name = 'Target Encoder'
+    hyperparameter_ranges = {}
+
+    def __init__(self,
+                 cols=None,
+                 smoothing=1.0,
+                 handle_unknown='value',
+                 handle_missing='value',
+                 random_state=0,
+                 **kwargs):
+        """Initializes a transformer that encodes categorical features into target encodings.
+
+        Arguments:
+            cols (list): Columns to encode. If None, all string columns will be encoded, otherwise only the columns provided will be encoded.
+                Defaults to None
+            smoothing (float): The smoothing factor to apply. The larger this value is, the more influence the expected value has
+                on the resulting target encodings. Must be strictly larger than 0. Defaults to 1.0
+            handle_unknown (string): Determines how to handle unknown categories for a feature encountered. Options are 'value', 'error', nd 'return_nan'.
+                Defaults to 'value', which replaces with the target mean
+            handle_missing (string): Determines how to handle missing values encountered during `fit` or `transform`. Options are 'value', 'error', and 'return_nan'.
+                Defaults to 'value', which replaces with the target mean"""
+
+        parameters = {"cols": cols,
+                      "smoothing": smoothing,
+                      "handle_unknown": handle_unknown,
+                      "handle_missing": handle_missing}
+        parameters.update(kwargs)
+
+        unknown_and_missing_input_options = ['error', 'return_nan', 'value']
+        if handle_unknown not in unknown_and_missing_input_options:
+            raise ValueError("Invalid input '{}' for handle_unknown".format(handle_unknown))
+        if handle_missing not in unknown_and_missing_input_options:
+            raise ValueError("Invalid input '{}' for handle_missing".format(handle_missing))
+        if smoothing <= 0:
+            raise ValueError("Smoothing value needs to be strictly larger than 0. {} provided".format(smoothing))
+
+        category_encode = import_or_raise('category_encoders', error_msg='category_encoders not installed. Please install using `pip install category_encoders`')
+        super().__init__(parameters=parameters,
+                         component_obj=category_encode.target_encoder.TargetEncoder(**parameters),
+                         random_state=random_state)
+
+    def fit(self, X, y):
+        return super().fit(X, y)
+
+    def transform(self, X, y=None):
+        return super().transform(X, y)
+
+    def get_feature_names(self):
+        """Return feature names for the input features after fitting.
+
+        Returns:
+            np.array: The feature names after encoding
+        """
+        return self._component_obj.get_feature_names()

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -205,7 +205,8 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         return X_t
 
     def _fit(self, X, y):
-
+        X.reset_index(inplace=True, drop=True)
+        y.reset_index(inplace=True, drop=True)
         X_t = self._compute_features_during_fit(X, y)
 
         self.estimator.fit(X_t, y)

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -205,8 +205,6 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         return X_t
 
     def _fit(self, X, y):
-        X.reset_index(inplace=True, drop=True)
-        y.reset_index(inplace=True, drop=True)
         X_t = self._compute_features_during_fit(X, y)
 
         self.estimator.fit(X_t, y)

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pytest import importorskip
+
+from evalml.exceptions import ComponentNotYetFittedError
+from evalml.pipelines.components import TargetEncoder
+
+importorskip('category_encoders', reason='Skipping test because category_encoders not installed')
+
+
+def test_init():
+    parameters = {"cols": None,
+                  "smoothing": 1.0,
+                  "handle_unknown": "value",
+                  "handle_missing": "value"}
+    encoder = TargetEncoder()
+    assert encoder.parameters == parameters
+
+
+def test_parameters():
+    encoder = TargetEncoder(cols=['a'])
+    expected_parameters = {"cols": ['a'],
+                           "smoothing": 1.0,
+                           "handle_unknown": "value",
+                           "handle_missing": "value"}
+    assert encoder.parameters == expected_parameters
+
+
+def test_invalid_inputs():
+    with pytest.raises(ValueError, match="Invalid input 'test' for handle_unknown"):
+        TargetEncoder(handle_unknown='test')
+    with pytest.raises(ValueError, match="Invalid input 'test2' for handle_missing"):
+        TargetEncoder(handle_missing='test2')
+    with pytest.raises(ValueError, match="Smoothing value needs to be strictly larger than 0"):
+        TargetEncoder(smoothing=0)
+
+
+def test_null_values_in_dataframe():
+    X = pd.DataFrame({'col_1': ["a", "b", "c", "d", np.nan],
+                      'col_2': ["a", "b", "a", "c", "b"],
+                      'col_3': ["a", "a", "a", "a", "a"]})
+    y = pd.Series([0, 1, 1, 1, 0])
+    encoder = TargetEncoder(handle_missing='value')
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [0.6, 0.6, 0.6, 0.6, 0.6],
+                               'col_2': [0.526894, 0.526894, 0.526894, 0.6, 0.526894],
+                               'col_3': [0.6, 0.6, 0.6, 0.6, 0.6, ]})
+
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+    encoder = TargetEncoder(handle_missing='return_nan')
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [0.6, 0.6, 0.6, 0.6, np.nan],
+                               'col_2': [0.526894, 0.526894, 0.526894, 0.6, 0.526894],
+                               'col_3': [0.6, 0.6, 0.6, 0.6, 0.6, ]})
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+    encoder = TargetEncoder(handle_missing='error')
+    with pytest.raises(ValueError, match='Columns to be encoded can not contain null'):
+        encoder.fit(X, y)
+
+
+def test_cols():
+    X = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                      'col_2': ['2', '1', '1', '1', '1'],
+                      'col_3': ["a", "a", "a", "a", "a"]})
+    y = pd.Series([0, 1, 1, 1, 0])
+    encoder = TargetEncoder(cols=[])
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    pd.testing.assert_frame_equal(X, X_t)
+
+    encoder = TargetEncoder(cols=['col_2'])
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                               'col_2': [0.60000, 0.742886, 0.742886, 0.742886, 0.742886],
+                               'col_3': ["a", "a", "a", "a", "a"]})
+    pd.testing.assert_frame_equal(X_t, X_expected, check_less_precise=True)
+
+    encoder = TargetEncoder(cols=['col_2', 'col_3'])
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    encoder2 = TargetEncoder()
+    encoder2.fit(X, y)
+    X_t2 = encoder2.transform(X)
+    pd.testing.assert_frame_equal(X_t, X_t2)
+
+
+def test_transform():
+    X = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                      'col_2': ["r", "t", "s", "t", "t"],
+                      'col_3': ["a", "a", "a", "b", "a"]})
+    y = pd.Series([0, 1, 1, 1, 0])
+    encoder = TargetEncoder()
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                               'col_2': [0.6, 0.65872, 0.6, 0.65872, 0.65872],
+                               'col_3': [0.504743, 0.504743, 0.504743, 0.6, 0.504743]})
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+
+def test_smoothing():
+    # larger smoothing values should bring the values closer to the global mean
+    X = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                      'col_2': [2, 1, 1, 1, 1],
+                      'col_3': ["a", "a", "a", "a", "b"]})
+    y = pd.Series([0, 1, 1, 1, 0])
+    encoder = TargetEncoder(smoothing=1)
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                               'col_2': [2, 1, 1, 1, 1],
+                               'col_3': [0.742886, 0.742886, 0.742886, 0.742886, 0.6]})
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+    encoder = TargetEncoder(smoothing=10)
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                               'col_2': [2, 1, 1, 1, 1],
+                               'col_3': [0.686166, 0.686166, 0.686166, 0.686166, 0.6]})
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+    encoder = TargetEncoder(smoothing=100)
+    encoder.fit(X, y)
+    X_t = encoder.transform(X)
+    X_expected = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                               'col_2': [2, 1, 1, 1, 1],
+                               'col_3': [0.676125, 0.676125, 0.676125, 0.676125, 0.6]})
+    pd.testing.assert_frame_equal(X_t, X_expected)
+
+
+def test_get_feature_names():
+    X = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
+                      'col_2': ["r", "t", "s", "t", "t"],
+                      'col_3': ["a", "a", "a", "b", "a"]})
+    y = pd.Series([0, 1, 1, 1, 0])
+    encoder = TargetEncoder()
+    with pytest.raises(ComponentNotYetFittedError, match='This TargetEncoder is not fitted yet. You must fit'):
+        encoder.get_feature_names()
+    encoder.fit(X, y)
+    np.testing.assert_array_equal(encoder.get_feature_names(), np.array(['col_1', 'col_2', 'col_3']))

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -167,3 +169,18 @@ def test_custom_indices():
     x1, x2, y1, y2 = split_data(X, y, regression=False)
     tp = MyTargetPipeline({})
     tp.fit(x2, y2)
+
+
+@patch('evalml.pipelines.components.transformers.transformer.Transformer.fit')
+def test_pandas_numpy(mock_fit, X_y_binary):
+    X, y = X_y_binary
+    X = pd.DataFrame(X).sample(frac=1)
+
+    encoder = TargetEncoder()
+    X_t = pd.DataFrame(X).reset_index(drop=True, inplace=False)
+
+    encoder.fit(X, y)
+    pd.testing.assert_frame_equal(mock_fit.call_args[0][0], X_t)
+
+    X_numpy = X.to_numpy()
+    encoder.fit(X_numpy, y)

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -20,7 +20,7 @@ def test_all_components(has_minimal_dependencies):
     if has_minimal_dependencies:
         assert len(all_components()) == 29
     else:
-        assert len(all_components()) == 34
+        assert len(all_components()) == 35
 
 
 def test_handle_component_class_names():

--- a/evalml/tests/latest_dependency_versions.txt
+++ b/evalml/tests/latest_dependency_versions.txt
@@ -4,7 +4,7 @@ distributed==2.30.1
 lightgbm==3.0.0
 numpy==1.19.4
 pandas==1.1.4
-pyzmq==19.0.2
+pyzmq==20.0.0
 scikit-learn==0.23.2
 scikit-optimize==0.8.1
 xgboost==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xgboost>=0.82
 catboost>=0.20
 lightgbm>=2.3.1
 graphviz>=0.13
+category_encoders >= 2.0.0


### PR DESCRIPTION
fix #1390 

Adding target encoder to components. Perf test results [are here](https://alteryx.quip.com/ly8rA0Ks3M6V/Target-Encoder-Transformer)

Docs are [here](https://evalml.alteryx.com/en/bc_1390_target/generated/evalml.pipelines.components.TargetEncoder.html#evalml.pipelines.components.TargetEncoder)

[UPDATE]
On Friday, 11/6, we decided to add additional perf tests for `TE` (discussion in the quip doc above).
Things to test:
1. Running OHE vs TE on categorical string data
2. Running OHE vs TE on categorical data that has already been converted to int/float
3. Running OHE vs TE on categorical data that has already been converted to int/float, where we convert the column type to categorical if there are less than 10 unique values in that column.

The perf test doc contains these 3 tests, ordered from 3, 1, 2. 