### PR TITLE
Try rounding codecov down instead of up

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,5 @@
 coverage:
-  round: down
+  round: up
   precision: 1
 
 codecov:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,3 @@
 coverage:
-  round: up
+  round: down
   precision: 2

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,6 +1,10 @@
 coverage:
   round: up
   precision: 1
+  status:
+    project:
+      default:
+        threshold: 1%
 
 codecov:
   notify:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,3 @@
 coverage:
   round: down
-  precision: 2
+  precision: 1

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,3 +1,7 @@
 coverage:
   round: down
   precision: 1
+
+codecov:
+  notify:
+    wait_for_ci: true

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Added description of CLA to contributing guide, updated description of draft PRs :pr:`1402`
     * Testing Changes
         * Removed ``category_encoders`` from test-requirements.txt :pr:`1373`
+        * Tweak codecov.io settings again to avoid flakes :pr:`1413`
 
 **v0.15.0 Oct. 29, 2020**
     * Enhancements


### PR DESCRIPTION
Perhaps I had this backwards previously? I hope this helps with the recent codecov flakes we've been seeing occur when people delete lines of code.

https://docs.codecov.io/docs/codecovyml-reference#coverageround
