### PR TITLE
Update Woodwork `to_pandas` to `to_dataframe` and `to_series`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,7 +16,7 @@ Release Notes
         * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`
         * Fixed stacked ensemble input bug and LightGBM warning and bug in ``AutoMLSearch`` :pr:`1388`
         * Updated enum classes to show possible enum values as attributes :pr:`1391`
-        * Updated calls to ``Woodwork``'s ``to_pandas()`` to ``to_series()`` and ``to_dataframe`()` :pr:`1428`
+        * Updated calls to ``Woodwork``'s ``to_pandas()`` to ``to_series()`` and ``to_dataframe()`` :pr:`1428`
     * Changes
         * Changed ``OutliersDataCheck`` to return the list of columns, rather than rows, that contain outliers :pr:`1377`
         * Simplified and cleaned output for Code Generation :pr:`1371`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Release Notes
         * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`
         * Fixed stacked ensemble input bug and LightGBM warning and bug in ``AutoMLSearch`` :pr:`1388`
         * Updated enum classes to show possible enum values as attributes :pr:`1391`
+        * Updated calls to ``Woodwork``'s ``to_pandas()`` to ``to_series()`` and ``to_dataframe`()` :pr:`1428`
     * Changes
         * Changed ``OutliersDataCheck`` to return the list of columns, rather than rows, that contain outliers :pr:`1377`
         * Simplified and cleaned output for Code Generation :pr:`1371`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -402,7 +402,7 @@ class AutoMLSearch:
             X = _convert_to_woodwork_structure(X)
 
         text_column_vals = X.select('natural_language')
-        text_columns = list(text_column_vals.to_pandas().columns)
+        text_columns = list(text_column_vals.to_dataframe().columns)
         if len(text_columns) == 0:
             text_columns = None
 
@@ -410,8 +410,8 @@ class AutoMLSearch:
             logger.warning("`y` passed was not a DataColumn. EvalML will try to convert the input as a Woodwork DataTable and types will be inferred. To control this behavior, please pass in a Woodwork DataTable instead.")
             y = _convert_to_woodwork_structure(y)
 
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
-        y = _convert_woodwork_types_wrapper(y.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_dataframe())
 
         self._set_data_split(X)
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -411,7 +411,7 @@ class AutoMLSearch:
             y = _convert_to_woodwork_structure(y)
 
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_series())
 
         self._set_data_split(X)
 

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -42,7 +42,7 @@ class ClassificationPipeline(PipelineBase):
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_series())
         self._encoder.fit(y)
         y = self._encode_targets(y)
         self._fit(X, y)
@@ -127,7 +127,7 @@ class ClassificationPipeline(PipelineBase):
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_series())
 
         objectives = [get_objective(o, return_instance=True) for o in objectives]
         y = self._encode_targets(y)

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -41,8 +41,8 @@ class ClassificationPipeline(PipelineBase):
         """
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
-        y = _convert_woodwork_types_wrapper(y.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_dataframe())
         self._encoder.fit(y)
         y = self._encode_targets(y)
         self._fit(X, y)
@@ -93,7 +93,7 @@ class ClassificationPipeline(PipelineBase):
             pd.Series : Estimated labels
         """
         X = _convert_to_woodwork_structure(X)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         predictions = self._predict(X, objective)
         return pd.Series(self._decode_targets(predictions))
 
@@ -107,7 +107,7 @@ class ClassificationPipeline(PipelineBase):
             pd.DataFrame: Probability estimates
         """
         X = _convert_to_woodwork_structure(X)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         X = self.compute_estimator_features(X)
         proba = self.estimator.predict_proba(X)
         proba.columns = self._encoder.classes_
@@ -126,8 +126,8 @@ class ClassificationPipeline(PipelineBase):
         """
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
-        y = _convert_woodwork_types_wrapper(y.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_dataframe())
 
         objectives = [get_objective(o, return_instance=True) for o in objectives]
         y = self._encode_targets(y)

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -227,7 +227,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             pd.Series: Predicted values.
         """
         X = _convert_to_woodwork_structure(X)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         X_t = self.compute_estimator_features(X)
         return self.estimator.predict(X_t)
 

--- a/evalml/pipelines/regression_pipeline.py
+++ b/evalml/pipelines/regression_pipeline.py
@@ -27,7 +27,7 @@ class RegressionPipeline(PipelineBase):
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_series())
         if y.dtype not in numeric_dtypes:
             raise ValueError(f"Regression pipeline cannot handle targets with dtype: {y.dtype}")
         self._fit(X, y)
@@ -47,7 +47,7 @@ class RegressionPipeline(PipelineBase):
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_series())
 
         objectives = [get_objective(o, return_instance=True) for o in objectives]
         y_predicted = self.predict(X)

--- a/evalml/pipelines/regression_pipeline.py
+++ b/evalml/pipelines/regression_pipeline.py
@@ -26,8 +26,8 @@ class RegressionPipeline(PipelineBase):
         """
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
-        y = _convert_woodwork_types_wrapper(y.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_dataframe())
         if y.dtype not in numeric_dtypes:
             raise ValueError(f"Regression pipeline cannot handle targets with dtype: {y.dtype}")
         self._fit(X, y)
@@ -46,8 +46,8 @@ class RegressionPipeline(PipelineBase):
         """
         X = _convert_to_woodwork_structure(X)
         y = _convert_to_woodwork_structure(y)
-        X = _convert_woodwork_types_wrapper(X.to_pandas())
-        y = _convert_woodwork_types_wrapper(y.to_pandas())
+        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        y = _convert_woodwork_types_wrapper(y.to_dataframe())
 
         objectives = [get_objective(o, return_instance=True) for o in objectives]
         y_predicted = self.predict(X)

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -47,7 +47,7 @@ def _get_preprocessing_components(X, y, problem_type, text_columns, estimator_cl
         list[Transformer]: A list of applicable preprocessing components to use with the estimator
     """
 
-    X_pd = X.to_pandas()
+    X_pd = X.to_dataframe()
     pp_components = []
     all_null_cols = X_pd.columns[X_pd.isnull().all()]
     if len(all_null_cols) > 0:

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -305,8 +305,7 @@ def _convert_woodwork_types_wrapper(pd_data):
     nullable_to_numpy_mapping = {pd.Int64Dtype: 'int64',
                                  pd.BooleanDtype: 'bool',
                                  pd.StringDtype: 'object'}
-    if isinstance(pd_data, pd.api.extensions.ExtensionArray):
-        pd_data = pd.Series(pd_data)
+
     if isinstance(pd_data, pd.Series) and type(pd_data.dtype) in nullable_to_numpy_mapping:
         return pd_data.astype(nullable_to_numpy_mapping[type(pd_data.dtype)])
     if isinstance(pd_data, pd.DataFrame):


### PR DESCRIPTION
Update Woodwork `to_pandas` to `to_dataframe` and `to_series` after 0.5.0 release.