### PR TITLE
Removing core-requirements from installed package

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
         * Added a ``random_state`` parameter to ``make_pipeline_from_components`` function :pr:`1411`
         * Added ``DelayedFeaturesTransformer`` :pr:`1396`
         * Added a ``TimeSeriesRegressionPipeline`` class :pr:`1418`
-        * Removed ``core-requirements.txt`` from the package distribution :pr:``1429``
+        * Removed ``core-requirements.txt`` from the package distribution :pr:`1429`
     * Fixes
         * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`
         * Fixed stacked ensemble input bug and LightGBM warning and bug in ``AutoMLSearch`` :pr:`1388`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Added a ``random_state`` parameter to ``make_pipeline_from_components`` function :pr:`1411`
         * Added ``DelayedFeaturesTransformer`` :pr:`1396`
         * Added a ``TimeSeriesRegressionPipeline`` class :pr:`1418`
+        * Removed ``core-requirements.txt`` from the package distribution :pr:``1429``
     * Fixes
         * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`
         * Fixed stacked ensemble input bug and LightGBM warning and bug in ``AutoMLSearch`` :pr:`1388`

--- a/evalml/tests/utils_tests/test_cli_utils.py
+++ b/evalml/tests/utils_tests/test_cli_utils.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+import requirements
 from click.testing import CliRunner
 
 from evalml.__main__ import cli
@@ -13,7 +14,6 @@ from evalml.utils.cli_utils import (
     print_info,
     print_sys_info
 )
-import requirements
 
 
 @pytest.fixture

--- a/evalml/tests/utils_tests/test_cli_utils.py
+++ b/evalml/tests/utils_tests/test_cli_utils.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 from unittest.mock import patch
 
 import pytest
@@ -22,7 +23,7 @@ def current_dir():
 
 
 def get_core_requirements(current_dir):
-    reqs_path = os.path.join(current_dir, '../../../core-requirements.txt')
+    reqs_path = os.path.join(current_dir, pathlib.Path('..', '..', '..', 'core-requirements.txt'))
     lines = open(reqs_path, 'r').readlines()
     lines = [line for line in lines if '-r ' not in line]
     reqs = requirements.parse(''.join(lines))

--- a/evalml/tests/utils_tests/test_cli_utils.py
+++ b/evalml/tests/utils_tests/test_cli_utils.py
@@ -6,7 +6,6 @@ from click.testing import CliRunner
 
 from evalml.__main__ import cli
 from evalml.utils.cli_utils import (
-    get_core_requirements,
     get_evalml_root,
     get_installed_packages,
     get_sys_info,
@@ -14,6 +13,7 @@ from evalml.utils.cli_utils import (
     print_info,
     print_sys_info
 )
+import requirements
 
 
 @pytest.fixture
@@ -21,8 +21,13 @@ def current_dir():
     return os.path.dirname(os.path.abspath(__file__))
 
 
-def test_get_core_requirements():
-    assert len(get_core_requirements()) == 15
+def get_core_requirements(current_dir):
+    reqs_path = os.path.join(current_dir, '../../../core-requirements.txt')
+    lines = open(reqs_path, 'r').readlines()
+    lines = [line for line in lines if '-r ' not in line]
+    reqs = requirements.parse(''.join(lines))
+    reqs_names = [req.name for req in reqs]
+    return reqs_names
 
 
 def test_print_cli_cmd():
@@ -57,9 +62,9 @@ def test_print_sys_info(caplog):
     assert "SYSTEM INFO" in out
 
 
-def test_print_deps_info(caplog):
-    core_requirements = get_core_requirements()
-    print_deps(core_requirements)
+def test_print_deps_info(caplog, current_dir):
+    core_requirements = get_core_requirements(current_dir)
+    print_deps()
     out = caplog.text
     assert "INSTALLED VERSIONS" in out
     for requirement in core_requirements:
@@ -83,9 +88,9 @@ def test_sys_info_error(mock_uname):
     mock_uname.assert_called()
 
 
-def test_installed_packages():
+def test_installed_packages(current_dir):
     installed_packages = get_installed_packages()
-    core_requirements = get_core_requirements()
+    core_requirements = get_core_requirements(current_dir)
     assert set(core_requirements).issubset(installed_packages.keys())
 
 

--- a/evalml/utils/cli_utils.py
+++ b/evalml/utils/cli_utils.py
@@ -6,22 +6,12 @@ import sys
 
 import pkg_resources
 import psutil
-import requirements
 from psutil._common import bytes2human
 
 import evalml
 from evalml.utils import get_logger
 
 logger = get_logger(__file__)
-
-
-def get_core_requirements():
-    reqs_path = os.path.join(os.path.dirname(evalml.__file__), '../core-requirements.txt')
-    lines = open(reqs_path, 'r').readlines()
-    lines = [line for line in lines if '-r ' not in line]
-    reqs = requirements.parse(''.join(lines))
-    reqs_names = [req.name for req in reqs]
-    return reqs_names
 
 
 def print_info():
@@ -33,7 +23,7 @@ def print_info():
     logger.info("EvalML version: %s" % evalml.__version__)
     logger.info("EvalML installation directory: %s" % get_evalml_root())
     print_sys_info()
-    print_deps(get_core_requirements())
+    print_deps()
 
 
 def print_sys_info():
@@ -49,11 +39,8 @@ def print_sys_info():
         logger.info("{title}: {stat}".format(title=title, stat=stat))
 
 
-def print_deps(dependencies):
+def print_deps():
     """Prints the version number of each dependency.
-
-    Arguments:
-        dependencies (list): list of package names to get the version numbers for.
 
     Returns:
         None
@@ -62,12 +49,7 @@ def print_deps(dependencies):
     logger.info("------------------")
     installed_packages = get_installed_packages()
 
-    packages_to_log = []
-    for x in dependencies:
-        # prevents uninstalled deps from being printed
-        if x in installed_packages:
-            packages_to_log.append((x, installed_packages[x]))
-    for package, version in packages_to_log:
+    for package, version in installed_packages.items():
         logger.info("{package}: {version}".format(package=package, version=version))
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,4 @@ setup(
     },
     data_files=[('evalml/demos/data', ['evalml/demos/data/fraud_transactions.csv.tar.gz', 'evalml/demos/data/churn.csv']),
                 ('evalml/tests/data', ['evalml/tests/data/tips.csv', 'evalml/tests/data/titanic.csv'])],
-    package_data = {
-        '': ['../core-requirements.txt'],
-    },
 )


### PR DESCRIPTION
### Pull Request Description
Fixes #1328 

Based on the discussion on #1293, I am printing out all of the installed packages instead of just the core requirements.

This is what the cli output looks like now:


```
> evalml info
EvalML version: 0.15.0
EvalML installation directory: /Users/freddy.boulton/miniconda3/envs/fresh-env/lib/python3.8/site-packages/evalml

SYSTEM INFO
-----------
python: 3.8.5.final.0
python-bits: 64
OS: Darwin
OS-release: 19.5.0
machine: x86_64
processor: i386
byteorder: little
LC_ALL: None
LANG: en_US.UTF-8
LOCALE: en_US.UTF-8
# of CPUS: 16
Available memory: 16.2G

INSTALLED VERSIONS
------------------
zict: 2.0.0
xgboost: 1.2.1
woodwork: 0.0.5
widgetsnbextension: 3.5.1
wheel: 0.35.1
webencodings: 0.5.1
wcwidth: 0.2.5
traitlets: 5.0.5
tqdm: 4.51.0
tornado: 6.1
toolz: 0.11.1
threadpoolctl: 2.1.0
texttable: 1.6.3
testpath: 0.4.4
terminado: 0.9.1
tblib: 1.7.0
sortedcontainers: 2.3.0
slicer: 0.0.3
six: 1.15.0
shap: 0.37.0
setuptools: 50.3.1.post20201107
send2trash: 1.5.0
scipy: 1.5.4
scikit-optimize: 0.8.1
scikit-learn: 0.23.2
retrying: 1.3.3
requirements-parser: 0.2.0
regex: 2020.11.11
pyzmq: 19.0.2
pyyaml: 5.3.1
pytz: 2020.4
python-dateutil: 2.8.1
pyrsistent: 0.17.3
pyparsing: 2.4.7
pygments: 2.7.2
pyflakes: 2.2.0
pycparser: 2.20
pycodestyle: 2.6.0
pyarrow: 2.0.0
pyaml: 20.4.0
ptyprocess: 0.6.0
psutil: 5.7.3
prompt-toolkit: 3.0.8
prometheus-client: 0.8.0
plotly: 4.12.0
pip: 20.2.4
pillow: 8.0.1
pickleshare: 0.7.5
pexpect: 4.8.0
partd: 1.1.0
parso: 0.7.1
pandocfilters: 1.4.3
pandas: 1.1.4
packaging: 20.4
numpy: 1.19.4
numba: 0.51.2
notebook: 6.1.5
nltk: 3.5
nlp-primitives: 1.1.0
nest-asyncio: 1.4.3
nbformat: 5.0.8
nbconvert: 6.0.7
nbclient: 0.5.1
msgpack: 1.0.0
mistune: 0.8.4
mccabe: 0.6.1
matplotlib: 3.3.3
markupsafe: 1.1.1
locket: 0.2.0
llvmlite: 0.34.0
lightgbm: 3.0.0
kiwisolver: 1.3.1
jupyterlab-pygments: 0.1.2
jupyter-core: 4.6.3
jupyter-client: 6.1.7
jsonschema: 3.2.0
joblib: 0.17.0
jinja2: 2.11.2
jedi: 0.17.2
isort: 5.6.4
ipywidgets: 7.5.1
ipython: 7.19.0
ipython-genutils: 0.2.0
ipykernel: 5.3.4
heapdict: 1.0.1
graphviz: 0.14.2
fsspec: 0.8.4
flake8: 3.8.4
featuretools: 0.21.0
evalml: 0.15.0
entrypoints: 0.3
distributed: 2.30.1
defusedxml: 0.6.0
decorator: 4.4.2
dask: 2.30.0
cycler: 0.10.0
colorama: 0.4.4
cloudpickle: 1.6.0
click: 7.1.2
cffi: 1.14.3
certifi: 2020.6.20
catboost: 0.24.2
bleach: 3.2.1
backcall: 0.2.0
attrs: 20.3.0
async-generator: 1.10
argon2-cffi: 20.1.0
appnope: 0.1.0
```

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
