### PR TITLE
Adding a script to standardize the notebook versions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,13 @@ clean:
 
 .PHONY: lint
 lint:
-	flake8 evalml && isort --check-only --recursive evalml
+	flake8 evalml && isort --check-only --recursive evalml && python docs/notebook_version_standardizer.py check-versions
 
 .PHONY: lint-fix
 lint-fix:
 	autopep8 --in-place --recursive --max-line-length=100 --select="E225,E222,E303,E261,E241,E302,E203,E128,E231,E251,E271,E127,E126,E301,W291,W293,E226,E306,E221" evalml
 	isort --recursive evalml
+	python docs/notebook_version_standardizer.py standardize
 
 .PHONY: test
 test:

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -1,0 +1,77 @@
+import click
+import json
+import os
+
+DOCS_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "source")
+
+
+def _get_python_version(notebook):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        version = source['metadata']['language_info']['version']
+    return version
+
+
+def _standardize_python_version(notebook, desired_version='3.7.4'):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        source['metadata']['language_info']['version'] = desired_version
+    json.dump(source, open(notebook, "w"), indent=1)
+
+
+def _get_ipython_notebooks(docs_source):
+    directories_to_skip = ["_templates", "generated", ".ipynb_checkpoints"]
+    notebooks = []
+    for root, _, filenames in os.walk(docs_source):
+        if any(dir_ in root for dir_ in directories_to_skip):
+            continue
+        for filename in filenames:
+            if filename.endswith('.ipynb'):
+                notebooks.append(os.path.join(root, filename))
+    return notebooks
+
+
+def _get_notebooks_with_different_versions(notebooks, desired_version='3.7.4'):
+    different_versions = []
+    for notebook in notebooks:
+        version = _get_python_version(notebook)
+        if version != desired_version:
+            different_versions.append(notebook)
+    return different_versions
+
+
+def _standardize_versions(notebooks, desired_version='3.7.4'):
+    for notebook in notebooks:
+        _standardize_python_version(notebook, desired_version)
+
+
+@click.group()
+def cli():
+    """no-op"""
+
+
+@cli.command()
+@click.option('--desired-version', default='3.7.4', help='python version that all notebooks should match')
+def check_versions(desired_version):
+    notebooks = _get_ipython_notebooks(DOCS_PATH)
+    different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)
+    if different_versions:
+        different_versions = ['\t' + notebook for notebook in different_versions]
+        different_versions = "\n".join(different_versions)
+        raise SystemExit(f"The following notebooks don't match {desired_version}:\n {different_versions}")
+
+
+@cli.command()
+@click.option('--desired-version', default='3.7.4', help='python version that all notebooks should match')
+def standardize(desired_version):
+    notebooks = _get_ipython_notebooks(DOCS_PATH)
+    different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)
+    if different_versions:
+        _standardize_versions(different_versions, desired_version)
+        different_versions = ['\t' + notebook for notebook in different_versions]
+        different_versions = "\n".join(different_versions)
+        click.echo(f"Set the notebook version to {desired_version} for:\n {different_versions}")
+
+
+if __name__ == '__main__':
+    cli()

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -12,7 +12,7 @@ def _get_python_version(notebook):
     return version
 
 
-def _standardize_python_version(notebook, desired_version='3.7.4'):
+def _standardize_python_version(notebook, desired_version='3.8.2'):
     with open(notebook, "r") as f:
         source = json.load(f)
         source['metadata']['language_info']['version'] = desired_version
@@ -31,7 +31,7 @@ def _get_ipython_notebooks(docs_source):
     return notebooks
 
 
-def _get_notebooks_with_different_versions(notebooks, desired_version='3.7.4'):
+def _get_notebooks_with_different_versions(notebooks, desired_version='3.8.2'):
     different_versions = []
     for notebook in notebooks:
         version = _get_python_version(notebook)
@@ -40,7 +40,7 @@ def _get_notebooks_with_different_versions(notebooks, desired_version='3.7.4'):
     return different_versions
 
 
-def _standardize_versions(notebooks, desired_version='3.7.4'):
+def _standardize_versions(notebooks, desired_version='3.8.2'):
     for notebook in notebooks:
         _standardize_python_version(notebook, desired_version)
 
@@ -51,18 +51,19 @@ def cli():
 
 
 @cli.command()
-@click.option('--desired-version', default='3.7.4', help='python version that all notebooks should match')
+@click.option('--desired-version', default='3.8.2', help='python version that all notebooks should match')
 def check_versions(desired_version):
     notebooks = _get_ipython_notebooks(DOCS_PATH)
     different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)
     if different_versions:
         different_versions = ['\t' + notebook for notebook in different_versions]
         different_versions = "\n".join(different_versions)
-        raise SystemExit(f"The following notebooks don't match {desired_version}:\n {different_versions}")
+        raise SystemExit(f"The following notebooks don't match {desired_version}:\n {different_versions}\n"
+                         "Please run make lint-fix to fix this.")
 
 
 @cli.command()
-@click.option('--desired-version', default='3.7.4', help='python version that all notebooks should match')
+@click.option('--desired-version', default='3.8.2', help='python version that all notebooks should match')
 def standardize(desired_version):
     notebooks = _get_ipython_notebooks(DOCS_PATH)
     different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -12,7 +12,7 @@ def _get_python_version(notebook):
     return version
 
 
-def _standardize_python_version(notebook, desired_version='3.8.2'):
+def _standardize_python_version(notebook, desired_version='3.8.6'):
     with open(notebook, "r") as f:
         source = json.load(f)
         source['metadata']['language_info']['version'] = desired_version
@@ -31,7 +31,7 @@ def _get_ipython_notebooks(docs_source):
     return notebooks
 
 
-def _get_notebooks_with_different_versions(notebooks, desired_version='3.8.2'):
+def _get_notebooks_with_different_versions(notebooks, desired_version='3.8.6'):
     different_versions = []
     for notebook in notebooks:
         version = _get_python_version(notebook)
@@ -40,7 +40,7 @@ def _get_notebooks_with_different_versions(notebooks, desired_version='3.8.2'):
     return different_versions
 
 
-def _standardize_versions(notebooks, desired_version='3.8.2'):
+def _standardize_versions(notebooks, desired_version='3.8.6'):
     for notebook in notebooks:
         _standardize_python_version(notebook, desired_version)
 
@@ -51,7 +51,7 @@ def cli():
 
 
 @cli.command()
-@click.option('--desired-version', default='3.8.2', help='python version that all notebooks should match')
+@click.option('--desired-version', default='3.8.6', help='python version that all notebooks should match')
 def check_versions(desired_version):
     notebooks = _get_ipython_notebooks(DOCS_PATH)
     different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)
@@ -63,7 +63,7 @@ def check_versions(desired_version):
 
 
 @cli.command()
-@click.option('--desired-version', default='3.8.2', help='python version that all notebooks should match')
+@click.option('--desired-version', default='3.8.6', help='python version that all notebooks should match')
 def standardize(desired_version):
     notebooks = _get_ipython_notebooks(DOCS_PATH)
     different_versions = _get_notebooks_with_different_versions(notebooks, desired_version)

--- a/docs/source/demos/cost_benefit_matrix.ipynb
+++ b/docs/source/demos/cost_benefit_matrix.ipynb
@@ -266,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/cost_benefit_matrix.ipynb
+++ b/docs/source/demos/cost_benefit_matrix.ipynb
@@ -266,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/cost_benefit_matrix.ipynb
+++ b/docs/source/demos/cost_benefit_matrix.ipynb
@@ -266,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/fraud.ipynb
+++ b/docs/source/demos/fraud.ipynb
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/fraud.ipynb
+++ b/docs/source/demos/fraud.ipynb
@@ -299,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/lead_scoring.ipynb
+++ b/docs/source/demos/lead_scoring.ipynb
@@ -311,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/lead_scoring.ipynb
+++ b/docs/source/demos/lead_scoring.ipynb
@@ -311,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/text_input.ipynb
+++ b/docs/source/demos/text_input.ipynb
@@ -353,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/text_input.ipynb
+++ b/docs/source/demos/text_input.ipynb
@@ -353,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/demos/text_input.ipynb
+++ b/docs/source/demos/text_input.ipynb
@@ -353,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -100,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -100,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -100,7 +100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/install.ipynb
+++ b/docs/source/install.ipynb
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -30,6 +30,8 @@ Release Notes
     * Testing Changes
         * Removed ``category_encoders`` from test-requirements.txt :pr:`1373`
         * Tweak codecov.io settings again to avoid flakes :pr:`1413`
+        * Modified ``make lint`` to check notebook versions in the docs :pr:`1431`
+        * Modified ``make lint-fix`` to standardize notebook versions in the docs :pr:`1431`
 
 .. warning::
 

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -218,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -218,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -218,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials.ipynb
+++ b/docs/source/tutorials.ipynb
@@ -47,7 +47,7 @@
    "metadata": {
     "nbsphinx-toctree": {
      "maxdepth": 1
-     }
+    }
    },
    "source": [
     "[Using Text Data with EvalML](demos/text_input)"
@@ -70,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials.ipynb
+++ b/docs/source/tutorials.ipynb
@@ -70,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials.ipynb
+++ b/docs/source/tutorials.ipynb
@@ -70,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide.ipynb
+++ b/docs/source/user_guide.ipynb
@@ -114,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide.ipynb
+++ b/docs/source/user_guide.ipynb
@@ -114,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide.ipynb
+++ b/docs/source/user_guide.ipynb
@@ -114,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -336,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -336,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/components.ipynb
+++ b/docs/source/user_guide/components.ipynb
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/components.ipynb
+++ b/docs/source/user_guide/components.ipynb
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/data_checks.ipynb
+++ b/docs/source/user_guide/data_checks.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/data_checks.ipynb
+++ b/docs/source/user_guide/data_checks.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/faq.ipynb
+++ b/docs/source/user_guide/faq.ipynb
@@ -64,7 +64,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/faq.ipynb
+++ b/docs/source/user_guide/faq.ipynb
@@ -64,7 +64,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/faq.ipynb
+++ b/docs/source/user_guide/faq.ipynb
@@ -64,7 +64,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/objectives.ipynb
+++ b/docs/source/user_guide/objectives.ipynb
@@ -240,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/objectives.ipynb
+++ b/docs/source/user_guide/objectives.ipynb
@@ -240,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/objectives.ipynb
+++ b/docs/source/user_guide/objectives.ipynb
@@ -240,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -424,7 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -424,7 +424,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/utilities.ipynb
+++ b/docs/source/user_guide/utilities.ipynb
@@ -53,7 +53,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/utilities.ipynb
+++ b/docs/source/user_guide/utilities.ipynb
@@ -53,7 +53,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Pull Request Description
Fixes #1419 

This is a test to show that circle ci will fail when the notebook versions don't match: https://app.circleci.com/pipelines/github/alteryx/evalml/7250/workflows/8b47906b-6b9f-4f95-b0ee-c2f78f2a6d9c/jobs/80895

This is what the output looks like when lint fails:

![image](https://user-images.githubusercontent.com/41651716/98992586-5cf6c700-24fb-11eb-9ae9-c93072f20fd5.png)

Then you can fix with lint-fix:
![image](https://user-images.githubusercontent.com/41651716/98992694-7bf55900-24fb-11eb-85e8-dba111667b9f.png)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
