### PR TITLE
Reduce number of CircleCI workers to 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
-          OMP_NUM_THREADS: 1
+          OMP_NUM_THREADS: 8
 
 commands:
   install_dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
         environment:
-          OMP_NUM_THREADS: 8
+          OMP_NUM_THREADS: 1
 
 commands:
   install_dependencies:

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ test:
 
 .PHONY: circleci-test
 circleci-test:
-	pytest evalml/ -n 8 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure -v
+	pytest evalml/ -n 4 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure -v
 
 .PHONY: circleci-test-minimal-deps
 circleci-test-minimal-deps:
-	pytest evalml/ -n 8 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure -v --has-minimal-dependencies
+	pytest evalml/ -n 4 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure -v --has-minimal-dependencies
 
 .PHONY: win-circleci-test
 win-circleci-test:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -41,6 +41,7 @@ Release Notes
         * Modified ``make lint`` to check notebook versions in the docs :pr:`1431`
         * Modified ``make lint-fix`` to standardize notebook versions in the docs :pr:`1431`
         * Use new version of pull request Github Action for dependency check (:pr:`1443`)
+        * Reduced number of workers for tests to 4 :pr:`1447`
 
 .. warning::
 


### PR DESCRIPTION
To reduce memory utilization but retain some speedup, this PR reduces the number of CircleCI workers to 4.
