### PR TITLE
Fix high variance cv message for automl

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,7 +16,7 @@ Release Notes
         * Added ``DelayedFeaturesTransformer`` :pr:`1396`
         * Added a ``TimeSeriesRegressionPipeline`` class :pr:`1418`
         * Removed ``core-requirements.txt`` from the package distribution :pr:`1429`
-        * Updated data check messages to include a `"code"` and `"details"` fields :pr:`1451`
+        * Updated data check messages to include a `"code"` and `"details"` fields :pr:`1451`, :pr:`1462`
         * Added a ``TimeSeriesSplit`` data splitter for time series problems :pr:`1441`
     * Fixes
         * Fixed ``IndexError`` raised in ``AutoMLSearch`` when ``ensembling = True`` but only one pipeline to iterate over :pr:`1397`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -740,7 +740,7 @@ class AutoMLSearch:
         high_variance_cv = False
 
         if high_variance_cv_check_results["warnings"]:
-            logger.warning(high_variance_cv_check_results["warnings"][0])
+            logger.warning(high_variance_cv_check_results["warnings"][0]["message"])
             high_variance_cv = True
 
         self._results['pipeline_results'][pipeline_id] = {


### PR DESCRIPTION
Closes #1280 
Fixes the high variance CV message during AutoML after the data checks API update:
![image](https://user-images.githubusercontent.com/5422235/100034382-14c48800-2dca-11eb-9031-7134ba3f4e39.png)



Currently on main:

![image](https://user-images.githubusercontent.com/5422235/100034464-36be0a80-2dca-11eb-8c49-5dc37621e1a2.png)
