### PR TITLE
Deleting coverage reports in make clean.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ clean:
 	find . -name '*.pyc' -delete
 	find . -name __pycache__ -delete
 	find . -name '*~' -delete
+	find . -name '.coverage.*' -delete
 
 .PHONY: lint
 lint:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes
     * Testing Changes
 


### PR DESCRIPTION
### Pull Request Description
Over time, developers will accumulate coverage reports if they run `make circleci-test` or any of the circleci make commands. This modifies `make clean` to additionally delete these reports as a convenience for developers.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
