### PR TITLE
Update woodwork to >=0.0.5 for core-requirements.txt

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -10,6 +10,6 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.35.0
 texttable>=1.6.2
-woodwork>=0.0.3
+woodwork>=0.0.5
 featuretools>=0.20.0
 nlp-primitives>=1.1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
     * Changes
         * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes


### PR DESCRIPTION
Because Woodwork updated their API from `to_pandas` to `to_series`/`to_dataframe` in 0.0.5, we should update our core-requirements s.t. woodwork >= 0.0.5. Woodwork users for any versions before will run into issues with our library!

@rpeck FYI :)