### PR TITLE
Update `detect_problem_types` implementation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
+        * Updated ``detect_problem_type`` to use ``pandas.api.is_numeric_dtype`` :pr:``
     * Changes
         * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
-        * Updated ``detect_problem_type`` to use ``pandas.api.is_numeric_dtype`` :pr:``
+        * Updated ``detect_problem_type`` to use ``pandas.api.is_numeric_dtype`` :pr:`1476`
     * Changes
         * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes

--- a/evalml/problem_types/utils.py
+++ b/evalml/problem_types/utils.py
@@ -1,8 +1,7 @@
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 
 from .problem_types import ProblemTypes
-
-from pandas.api.types import is_numeric_dtype
 
 
 def handle_problem_types(problem_type):

--- a/evalml/problem_types/utils.py
+++ b/evalml/problem_types/utils.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from .problem_types import ProblemTypes
 
-from evalml.utils.gen_utils import numeric_dtypes
+from pandas.api.types import is_numeric_dtype
 
 
 def handle_problem_types(problem_type):
@@ -46,7 +46,7 @@ def detect_problem_type(y):
         raise ValueError("Less than 2 classes detected! Target unusable for modeling")
     if num_classes == 2:
         return ProblemTypes.BINARY
-    if y.dtype in numeric_dtypes:
+    if is_numeric_dtype(y.dtype):
         if (num_classes > 10):
             return ProblemTypes.REGRESSION
     return ProblemTypes.MULTICLASS

--- a/evalml/tests/problem_type_tests/test_problem_types.py
+++ b/evalml/tests/problem_type_tests/test_problem_types.py
@@ -94,6 +94,7 @@ def test_detect_problem_type_regression():
     assert detect_problem_type(y_values) == ProblemTypes.REGRESSION
     assert detect_problem_type(y_float) == ProblemTypes.REGRESSION
 
+
 def test_numeric_extensions():
     y_Int64 = pd.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype='Int64')
     y_Int64_null = pd.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, None], dtype='Int64')

--- a/evalml/tests/problem_type_tests/test_problem_types.py
+++ b/evalml/tests/problem_type_tests/test_problem_types.py
@@ -94,6 +94,13 @@ def test_detect_problem_type_regression():
     assert detect_problem_type(y_values) == ProblemTypes.REGRESSION
     assert detect_problem_type(y_float) == ProblemTypes.REGRESSION
 
+def test_numeric_extensions():
+    y_Int64 = pd.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], dtype='Int64')
+    y_Int64_null = pd.Series([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, None], dtype='Int64')
+
+    assert detect_problem_type(y_Int64) == ProblemTypes.REGRESSION
+    assert detect_problem_type(y_Int64_null) == ProblemTypes.REGRESSION
+
 
 def test_nan_none_na():
     y_none = pd.Series([None])


### PR DESCRIPTION
fix #1469 

Updated this implementation to catch Int64 dtypes. Previously, using `analyze_metadata` in looking_glass, if the target data was `Int64`, the problem_type would be classified as multiclass as long as there were `>2` unique values. 

After using `is_numeric_dtype`:
![image](https://user-images.githubusercontent.com/22552445/100647944-395eb980-330e-11eb-9d87-d5567c2198b9.png)

Since we drop NaN data, classifying Boolean (nullable) as a numeric dtype is ok, since we'll catch this binary case before determining if it is regression or multiclass. 
