### PR TITLE
Remove `copy_dataframe` parameter, update requirements with release of Woodwork v0.0.6

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -10,6 +10,6 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.35.0
 texttable>=1.6.2
-woodwork>=0.0.3
+woodwork>=0.0.5
 featuretools>=0.20.0
 nlp-primitives>=1.1.0

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -10,6 +10,6 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.35.0
 texttable>=1.6.2
-woodwork>=0.0.5
+woodwork>=0.0.6
 featuretools>=0.20.0
 nlp-primitives>=1.1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
     * Changes
         * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
+        * Removed ``copy_dataframe`` parameter for ``Woodwork``, updated ``Woodwork`` to >=0.0.6 in ``core-requirements.txt`` :pr:`1478`
     * Changes
         * Changed ``make clean`` to delete coverage reports as a convenience for developers :pr:`1464`
     * Documentation Changes

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1767,7 +1767,7 @@ def test_automl_woodwork_user_types_preserved(mock_binary_fit, mock_binary_score
     X['num col'] = pd.Series(new_col)
     X['text col'] = pd.Series([f"{num}" for num in range(len(new_col))])
     X = ww.DataTable(X, semantic_tags={'cat col': 'category', 'num col': 'numeric'},
-                     logical_types={'cat col': 'Categorical', 'num col': 'WholeNumber', 'text col': 'NaturalLanguage'})
+                     logical_types={'cat col': 'Categorical', 'num col': 'Integer', 'text col': 'NaturalLanguage'})
     automl = AutoMLSearch(problem_type=problem_type, max_batches=5)
     automl.search(X, y)
     for arg in mock_fit.call_args[0]:
@@ -1776,7 +1776,7 @@ def test_automl_woodwork_user_types_preserved(mock_binary_fit, mock_binary_score
             assert arg.semantic_tags['cat col'] == {'category'}
             assert arg.logical_types['cat col'] == ww.logical_types.Categorical
             assert arg.semantic_tags['num col'] == {'numeric'}
-            assert arg.logical_types['num col'] == ww.logical_types.WholeNumber
+            assert arg.logical_types['num col'] == ww.logical_types.Integer
             assert arg.semantic_tags['text col'] == set()
             assert arg.logical_types['text col'] == ww.logical_types.NaturalLanguage
     for arg in mock_score.call_args[0]:
@@ -1785,7 +1785,7 @@ def test_automl_woodwork_user_types_preserved(mock_binary_fit, mock_binary_score
             assert arg.semantic_tags['cat col'] == {'category'}
             assert arg.logical_types['cat col'] == ww.logical_types.Categorical
             assert arg.semantic_tags['num col'] == {'numeric'}
-            assert arg.logical_types['num col'] == ww.logical_types.WholeNumber
+            assert arg.logical_types['num col'] == ww.logical_types.Integer
             assert arg.semantic_tags['text col'] == set()
             assert arg.logical_types['text col'] == ww.logical_types.NaturalLanguage
 

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -300,8 +300,10 @@ def _convert_to_woodwork_structure(data):
         ww_data = pd.DataFrame(ww_data)
 
     # Convert pandas data structures to Woodwork data structures
+    ww_data = ww.data.copy()
     if isinstance(ww_data, pd.Series):
         return ww.DataColumn(ww_data)
+    
     return ww.DataTable(ww_data)
 
 

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -302,7 +302,7 @@ def _convert_to_woodwork_structure(data):
     # Convert pandas data structures to Woodwork data structures
     if isinstance(ww_data, pd.Series):
         return ww.DataColumn(ww_data)
-    return ww.DataTable(ww_data, copy_dataframe=True)
+    return ww.DataTable(ww_data)
 
 
 def _convert_woodwork_types_wrapper(pd_data):

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -303,7 +303,7 @@ def _convert_to_woodwork_structure(data):
     ww_data = ww_data.copy()
     if isinstance(ww_data, pd.Series):
         return ww.DataColumn(ww_data)
-    
+
     return ww.DataTable(ww_data)
 
 

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -300,7 +300,7 @@ def _convert_to_woodwork_structure(data):
         ww_data = pd.DataFrame(ww_data)
 
     # Convert pandas data structures to Woodwork data structures
-    ww_data = ww.data.copy()
+    ww_data = ww_data.copy()
     if isinstance(ww_data, pd.Series):
         return ww.DataColumn(ww_data)
     


### PR DESCRIPTION
- Remove use of `copy_dataframe` parameter which was removed in 0.0.6
- Update Woodwork requirement to >=0.0.6