### PR TITLE
Pin woodwork version

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -10,6 +10,6 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.35.0
 texttable>=1.6.2
-woodwork>=0.0.6
+woodwork==0.0.6
 featuretools>=0.20.0
 nlp-primitives>=1.1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+        * Pin woodwork version to v0.0.6 to avoid breaking changes :pr:`1484`
     * Fixes
         * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`
         * Removed ``copy_dataframe`` parameter for ``Woodwork``, updated ``Woodwork`` to >=0.0.6 in ``core-requirements.txt`` :pr:`1478`


### PR DESCRIPTION
In order to avoid breaking changes (#1478 ), let's pin the woodwork version in each evalml release, so that `pip install evalml` always produces a working installation.