### PR TITLE
Release v0.16.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,14 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.16.1 Dec. 1, 2020**
+    * Enhancements
         * Pin woodwork version to v0.0.6 to avoid breaking changes :pr:`1484`
     * Fixes
         * Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` :pr:`1473`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.16.0'
+__version__ = '0.16.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.16.0',
+    version='0.16.1',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.16.1 Dec. 1, 2020
### Enhancements
- Pin woodwork version to v0.0.6 to avoid breaking changes #1484
### Fixes
- Updated ``Woodwork`` to >=0.0.5 in ``core-requirements.txt`` #1473
- Removed ``copy_dataframe`` parameter for ``Woodwork``, updated ``Woodwork`` to >=0.0.6 in ``core-requirements.txt`` #1478
- Updated ``detect_problem_type`` to use ``pandas.api.is_numeric_dtype`` #1476
### Changes
- Changed ``make clean`` to delete coverage reports as a convenience for developers #1464
### Documentation Changes
### Testing Changes
- Update dependency update checker to use everything from core and optional dependencies #1480