### PR TITLE
Add script to generate github markdown for release notes

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
+        * Added script to generate github markdown for releases :pr:`1487`
     * Documentation Changes
     * Testing Changes
 

--- a/release.md
+++ b/release.md
@@ -22,7 +22,7 @@ Create a release PR with the following changes:
 * Update `setup.py` and `evalml/__init__.py` to bump `__version__` to the new version.
 * Move all entries in `docs/source/release_notes.rst` currently listed under `**Future Releases**` to be under a new heading with the version number and release date.
 * Make sure `**Future Releases**` is empty except for the sub-headings, so its ready for new entries.
-* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/). You'll reuse this text in step 2. This is currently done by hand and can be done faster with some clever text editor features.
+* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/). You'll reuse this text in step 2. You can generate the markdown by running `tools/format_release_notes.sh` locally.
 * Confirm that all release items are in the release notes under the correct header, and that no extra items are listed. You may have to do an "empty cache and hard reset" in your browser to see updates.
 
 An example can be found here: https://github.com/alteryx/evalml/pull/163

--- a/release.md
+++ b/release.md
@@ -18,11 +18,13 @@ If you'd like to create a development release, which won't be deployed to pypi a
 ## 1. Create release PR to update version and release notes
 Please use the following pattern for the release PR branch name: "release_vX.X.X". Doing so will bypass our release notes checkin test which requires all other PRs to add a release note entry.
 
-Create a release PR with the following changes:
+Before creating the release PR, generate the [GitHub markdown](https://guides.github.com/features/mastering-markdown/) you'll use to populate the release PR and the GitHub release, like so: `tools/format_release_notes.sh X.X.X`, where the `X.X.X` argument is the new release version.
+
+Then, create a release PR with the following changes:
 * Update `setup.py` and `evalml/__init__.py` to bump `__version__` to the new version.
 * Move all entries in `docs/source/release_notes.rst` currently listed under `**Future Releases**` to be under a new heading with the version number and release date.
 * Make sure `**Future Releases**` is empty except for the sub-headings, so its ready for new entries.
-* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/). You'll reuse this text in step 2. This is currently done by hand and can be done faster with some clever text editor features.
+* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/).
 * Confirm that all release items are in the release notes under the correct header, and that no extra items are listed. You may have to do an "empty cache and hard reset" in your browser to see updates.
 
 An example can be found here: https://github.com/alteryx/evalml/pull/163

--- a/release.md
+++ b/release.md
@@ -18,13 +18,11 @@ If you'd like to create a development release, which won't be deployed to pypi a
 ## 1. Create release PR to update version and release notes
 Please use the following pattern for the release PR branch name: "release_vX.X.X". Doing so will bypass our release notes checkin test which requires all other PRs to add a release note entry.
 
-Before creating the release PR, generate the [GitHub markdown](https://guides.github.com/features/mastering-markdown/) you'll use to populate the release PR and the GitHub release, like so: `tools/format_release_notes.sh X.X.X`, where the `X.X.X` argument is the new release version.
-
-Then, create a release PR with the following changes:
+Create a release PR with the following changes:
 * Update `setup.py` and `evalml/__init__.py` to bump `__version__` to the new version.
 * Move all entries in `docs/source/release_notes.rst` currently listed under `**Future Releases**` to be under a new heading with the version number and release date.
 * Make sure `**Future Releases**` is empty except for the sub-headings, so its ready for new entries.
-* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/).
+* Populate the release PR body with a copy of this release's release notes, reformatted to [GitHub markdown](https://guides.github.com/features/mastering-markdown/). You'll reuse this text in step 2. This is currently done by hand and can be done faster with some clever text editor features.
 * Confirm that all release items are in the release notes under the correct header, and that no extra items are listed. You may have to do an "empty cache and hard reset" in your browser to see updates.
 
 An example can be found here: https://github.com/alteryx/evalml/pull/163

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$1" ] || [ "$1" = "-h" ]
+  then
+    echo -e 'Grab the "Future Releases" section from the release notes and format it in markdown for GitHub releases
+
+Usage: tools/format_release_notes.sh 0.16.1'
+    exit 0
+fi
+new_evalml_version=$1
+content_raw=$(cat docs/source/release_notes.rst |  sed -n -e '/^\*\*Future Releases\*\*/,/^\*\*v/p;/^\*\*v/q' | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
+date_formatted=$(date '+%b. %-d, %Y')
+content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E 's/:pr:\`([0-9]+)\`/#\1/g')
+full_markdown=$(echo -e "# v${new_evalml_version} ${date_formatted}\n${content_markdown}")
+echo -e "${full_markdown}"

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -8,7 +8,7 @@ Usage: tools/format_release_notes.sh'
     exit 0
 fi
 evalml_version=$(sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p" setup.py)
-content_raw=$(sed -n -e "/^\*\*v0.16.1/,/^\*\*v0.16.0/p;/^\*\*v0.16.0/q" docs/source/release_notes.rst | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
+content_raw=$(sed -n -E '/^\*\*v[A-Za-z0-9\., ]+\*\*$/,$p' docs/source/release_notes.rst | tail -n +2 | sed -E '/\*\*v[A-Za-z0-9\., ]+\*\*$/q' | sed '$ d' | awk 'NF')
 date_formatted=$(date '+%b. %-d, %Y')
 content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E "s/:pr:\`([0-9]+)\`/#\1/g")
 full_markdown=$(echo -e "# v${evalml_version} ${date_formatted}\n${content_markdown}")

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -7,10 +7,9 @@ if [ "$1" = "-h" ]
 Usage: tools/format_release_notes.sh'
     exit 0
 fi
-evalml_version=$(cat setup.py | sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p")
-#content_raw=$(cat docs/source/release_notes.rst |  sed -e "/^\*\*v${evalml_version}[A-Za-z0-9\.\,\ ]+\*\*$/,/^\*\*v/p;/^\*\*v/q" | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
-content_raw=$(cat docs/source/release_notes.rst |  sed -n -e "/^\*\*v0.16.1/,/^\*\*v0.16.0/p;/^\*\*v0.16.0/q" | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
+evalml_version=$(sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p" setup.py)
+content_raw=$(sed -n -e "/^\*\*v0.16.1/,/^\*\*v0.16.0/p;/^\*\*v0.16.0/q" docs/source/release_notes.rst | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
 date_formatted=$(date '+%b. %-d, %Y')
-content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E 's/:pr:\`([0-9]+)\`/#\1/g')
+content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E "s/:pr:\`([0-9]+)\`/#\1/g")
 full_markdown=$(echo -e "# v${evalml_version} ${date_formatted}\n${content_markdown}")
 echo -e "${full_markdown}"

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -4,7 +4,9 @@ if [ "$1" = "-h" ]
   then
     echo -e 'Grab the "Future Releases" section from the release notes and format it in markdown for GitHub releases
 
-Usage: tools/format_release_notes.sh'
+Usage: tools/format_release_notes.sh
+
+Note: this was written to work properly on mac. It should work on linux if -r is used instead of -E for sed.'
     exit 0
 fi
 evalml_version=$(sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p" setup.py)

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-if [ -z "$1" ] || [ "$1" = "-h" ]
+if [ "$1" = "-h" ]
   then
     echo -e 'Grab the "Future Releases" section from the release notes and format it in markdown for GitHub releases
 
-Usage: tools/format_release_notes.sh 0.16.1'
+Usage: tools/format_release_notes.sh'
     exit 0
 fi
-new_evalml_version=$1
-content_raw=$(cat docs/source/release_notes.rst |  sed -n -e '/^\*\*Future Releases\*\*/,/^\*\*v/p;/^\*\*v/q' | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
+evalml_version=$(cat setup.py | sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p")
+#content_raw=$(cat docs/source/release_notes.rst |  sed -e "/^\*\*v${evalml_version}[A-Za-z0-9\.\,\ ]+\*\*$/,/^\*\*v/p;/^\*\*v/q" | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
+content_raw=$(cat docs/source/release_notes.rst |  sed -n -e "/^\*\*v0.16.1/,/^\*\*v0.16.0/p;/^\*\*v0.16.0/q" | sed '/^\.\. warning::$/d' | tail -n +2 | sed '$ d' | awk 'NF')
 date_formatted=$(date '+%b. %-d, %Y')
 content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E 's/:pr:\`([0-9]+)\`/#\1/g')
-full_markdown=$(echo -e "# v${new_evalml_version} ${date_formatted}\n${content_markdown}")
+full_markdown=$(echo -e "# v${evalml_version} ${date_formatted}\n${content_markdown}")
 echo -e "${full_markdown}"


### PR DESCRIPTION
Usage:
* Make release branch, update version, update release notes
* Run `tools/format_format_release_notes.sh` to print out the markdown to paste into the release PR and github release

It was only a matter of time 😂  https://xkcd.com/1319/