### PR TITLE
Fix custom index bug in get_prediction_vs_actual_over_time_data

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Added parameter to ``InvalidTargetDataCheck`` to show only top unique values rather than all unique values :pr:`1485`
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
+        * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -561,25 +561,28 @@ def get_prediction_vs_actual_over_time_data(pipeline, X, y, dates):
     """Get the data needed for the prediction_vs_actual_over_time plot.
 
     Arguments:
-        pipeline (PipelineBase): Fitted time series regression pipeline.
+        pipeline (TimeSeriesRegressionPipeline): Fitted time series regression pipeline.
         X (pd.DataFrame): Features used to generate new predictions.
         y (pd.Series): Target values to compare predictions against.
+        dates (pd.Series): Dates corresponding to target values and predictions.
 
     Returns:
        pd.DataFrame
     """
-    return pd.DataFrame({"dates": dates,
-                         "target": y,
-                         "prediction": pipeline.predict(X, y)})
+    prediction = pipeline.predict(X, y)
+    return pd.DataFrame({"dates": dates.reset_index(drop=True),
+                         "target": y.reset_index(drop=True),
+                         "prediction": prediction.reset_index(drop=True)})
 
 
 def graph_prediction_vs_actual_over_time(pipeline, X, y, dates):
     """Plot the target values and predictions against time on the x-axis.
 
     Arguments:
-        pipeline (PipelineBase): Fitted time series regression pipeline.
+        pipeline (TimeSeriesRegressionPipeline): Fitted time series regression pipeline.
         X (pd.DataFrame): Features used to generate new predictions.
         y (pd.Series): Target values to compare predictions against.
+        dates (pd.Series): Dates corresponding to target values and predictions.
 
     Returns:
         plotly.Figure showing the prediction vs actual over time.

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -964,10 +964,12 @@ def test_graph_prediction_vs_actual_over_time():
         problem_type = ProblemTypes.TIME_SERIES_REGRESSION
 
         def predict(self, X, y):
-            return y + 10
+            preds = y + 10
+            preds.index = range(100, 161)
+            return preds
 
-    y = np.arange(61)
-    dates = pd.date_range("2020-03-01", "2020-04-30")
+    y = pd.Series(np.arange(61), index=range(200, 261))
+    dates = pd.Series(pd.date_range("2020-03-01", "2020-04-30"))
     pipeline = MockPipeline()
 
     # For this test it doesn't matter what the features are
@@ -981,10 +983,12 @@ def test_graph_prediction_vs_actual_over_time():
     assert len(fig_dict['data']) == 2
     assert fig_dict['data'][0]['line']['color'] == '#1f77b4'
     assert len(fig_dict['data'][0]['x']) == 61
+    assert not np.isnan(fig_dict['data'][0]['y']).all()
     assert len(fig_dict['data'][0]['y']) == 61
     assert fig_dict['data'][1]['line']['color'] == '#d62728'
     assert len(fig_dict['data'][1]['x']) == 61
     assert len(fig_dict['data'][1]['y']) == 61
+    assert not np.isnan(fig_dict['data'][1]['y']).all()
 
 
 def test_graph_prediction_vs_actual_over_time_value_error():


### PR DESCRIPTION
### Pull Request Description
After merging #1483 I realized that `get_prediction_vs_actual_over_time_data` does not support a custom index! This fixes that.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
