### PR TITLE
Codegen support for bool

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
-        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and Json :pr:``
+        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON :pr:`1524`
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
+        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and Json :pr:``
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -172,7 +172,7 @@ def _json_dict(dictionary):
         else:
             try:
                 json.dumps(v)
-            except:
+            except TypeError:
                 raise TypeError(f"Value {v} of type {type(v)} cannot be JSON-serialized")
 
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -174,7 +174,7 @@ def generate_pipeline_code(element):
         Does not include code for custom component implementation.
     """
     # hold the imports needed and add code to end
-    code_strings = []
+    code_strings = ['import json']
     if not isinstance(element, PipelineBase):
         raise ValueError("Element must be a pipeline instance, received {}".format(type(element)))
 
@@ -192,13 +192,13 @@ def generate_pipeline_code(element):
     base_string = "\nclass {0}({1}):\n" \
                   "\tcomponent_graph = [\n\t\t{2}\n\t]\n" \
                   "{3}" \
-                  "\nparameters = {4}\n" \
+                  "\nparameters = json.loads(\"\"\"{4}\"\"\")\n" \
                   "pipeline = {0}(parameters)" \
                   .format(element.__class__.__name__,
                           element.__class__.__bases__[0].__name__,
                           component_graph_string,
                           pipeline_string,
-                          json.dumps(element.parameters, indent='\t').replace('null', 'None'))
+                          json.dumps(element.parameters, indent='\t'))
     code_strings.append(base_string)
     return "\n".join(code_strings)
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -163,6 +163,19 @@ def make_pipeline_from_components(component_instances, problem_type, custom_name
     return TemplatedPipeline({c.name: c.parameters for c in component_instances}, random_state=random_state)
 
 
+def _json_dict(dictionary):
+    """Helper method to make sure all elements in the provided dictionary are JSON-serializable
+    """
+    for v in dictionary.values():
+        if isinstance(v, dict):
+            _json_dict(v)
+        else:
+            try:
+                json.dumps(v)
+            except:
+                raise TypeError(f"Value {v} of type {type(v)} cannot be JSON-serialized")
+
+
 def generate_pipeline_code(element):
     """Creates and returns a string that contains the Python imports and code required for running the EvalML pipeline.
 
@@ -188,6 +201,7 @@ def generate_pipeline_code(element):
         pipeline_list += ["{} = '{}'".format(k, v)] if isinstance(v, str) else ["{} = {}".format(k, v)]
 
     pipeline_string = "\t" + "\n\t".join(pipeline_list) + "\n" if len(pipeline_list) else ""
+    _json_dict(element.parameters)
     # create the base string for the pipeline
     base_string = "\nclass {0}({1}):\n" \
                   "\tcomponent_graph = [\n\t\t{2}\n\t]\n" \

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -8,7 +8,7 @@ ipywidgets==7.5.1
 lightgbm==3.1.0
 nlp-primitives==1.1.0
 numpy==1.19.4
-pandas==1.1.4
+pandas==1.1.5
 plotly==4.14.0
 psutil==5.7.3
 requirements-parser==0.2.0

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1582,7 +1582,7 @@ def test_generate_code_pipeline():
         component_graph = ['Imputer', 'Random Forest Classifier']
         custom_hyperparameters = {
             "Imputer": {
-                "numeric_impute_strategy": "most_frequent"
+                "numeric_impute_strategy": 'most_frequent'
             }
         }
 
@@ -1591,34 +1591,37 @@ def test_generate_code_pipeline():
         component_graph = ['Imputer', 'Random Forest Regressor']
 
     mock_binary_pipeline = MockBinaryPipeline({})
-    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+    expected_code = 'import json\n' \
+                    'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
                     '\n\nclass MockBinaryPipeline(BinaryClassificationPipeline):' \
                     '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Classifier\'\n\t]' \
                     '\n\tcustom_hyperparameters = {\'Imputer\': {\'numeric_impute_strategy\': \'most_frequent\'}}\n' \
-                    '\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
-                    '\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}\n' \
+                    '\nparameters = json.loads("""{\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": null,\n\t\t"numeric_fill_value": null\n\t},' \
+                    '\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}""")\n' \
                     'pipeline = MockBinaryPipeline(parameters)'
     pipeline = generate_pipeline_code(mock_binary_pipeline)
     assert expected_code == pipeline
 
     mock_regression_pipeline = MockRegressionPipeline({})
-    expected_code = 'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
+    expected_code = 'import json\n' \
+                    'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
                     '\n\nclass MockRegressionPipeline(RegressionPipeline):' \
                     '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Regressor\'\n\t]\n\t' \
                     'name = \'Mock Regression Pipeline\'\n\n' \
-                    'parameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
-                    '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                    'parameters = json.loads("""{\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": null,\n\t\t"numeric_fill_value": null\n\t},' \
+                    '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}""")' \
                     '\npipeline = MockRegressionPipeline(parameters)'
     pipeline = generate_pipeline_code(mock_regression_pipeline)
     assert pipeline == expected_code
 
     mock_regression_pipeline_params = MockRegressionPipeline({"Imputer": {"numeric_impute_strategy": "most_frequent"}, "Random Forest Regressor": {"n_estimators": 50}})
-    expected_code_params = 'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
+    expected_code_params = 'import json\n' \
+                           'from evalml.pipelines.regression_pipeline import RegressionPipeline' \
                            '\n\nclass MockRegressionPipeline(RegressionPipeline):' \
                            '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\t\'Random Forest Regressor\'\n\t]' \
                            '\n\tname = \'Mock Regression Pipeline\'' \
-                           '\n\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "most_frequent",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t},' \
-                           '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 50,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                           '\n\nparameters = json.loads("""{\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "most_frequent",\n\t\t"categorical_fill_value": null,\n\t\t"numeric_fill_value": null\n\t},' \
+                           '\n\t"Random Forest Regressor": {\n\t\t"n_estimators": 50,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}""")' \
                            '\npipeline = MockRegressionPipeline(parameters)'
     pipeline = generate_pipeline_code(mock_regression_pipeline_params)
     assert pipeline == expected_code_params
@@ -1642,8 +1645,8 @@ def test_generate_code_pipeline_custom():
         supported_problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
         model_family = ModelFamily.NONE
 
-        def __init__(self, random_state=0):
-            parameters = {}
+        def __init__(self, random_arg=False, random_state=0):
+            parameters = {'random_arg': random_arg}
 
             super().__init__(parameters=parameters,
                              component_obj=None,
@@ -1667,31 +1670,36 @@ def test_generate_code_pipeline_custom():
         component_graph = [CustomTransformer, CustomEstimator]
 
     mockBinaryTransformer = MockBinaryPipelineTransformer({})
-    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+    expected_code = 'import json\n' \
+                    'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
                     '\n\nclass MockBinaryPipelineTransformer(BinaryClassificationPipeline):' \
                     '\n\tcomponent_graph = [\n\t\tCustomTransformer,\n\t\t\'Random Forest Classifier\'\n\t]' \
                     '\n\tname = \'Mock Binary Pipeline with Transformer\'' \
-                    '\n\nparameters = {\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}' \
+                    '\n\nparameters = json.loads("""{\n\t"Random Forest Classifier": {\n\t\t"n_estimators": 100,\n\t\t"max_depth": 6,\n\t\t"n_jobs": -1\n\t}\n}""")' \
                     '\npipeline = MockBinaryPipelineTransformer(parameters)'
     pipeline = generate_pipeline_code(mockBinaryTransformer)
     assert pipeline == expected_code
 
     mockBinaryPipeline = MockBinaryPipelineEstimator({})
-    expected_code = 'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+    expected_code = 'import json\n' \
+                    'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
                     '\n\nclass MockBinaryPipelineEstimator(BinaryClassificationPipeline):' \
                     '\n\tcomponent_graph = [\n\t\t\'Imputer\',\n\t\tCustomEstimator\n\t]' \
                     '\n\tcustom_hyperparameters = {\'Imputer\': {\'numeric_impute_strategy\': \'most_frequent\'}}' \
                     '\n\tname = \'Mock Binary Pipeline with Estimator\'' \
-                    '\n\nparameters = {\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": None,\n\t\t"numeric_fill_value": None\n\t}\n}' \
+                    '\n\nparameters = json.loads("""{\n\t"Imputer": {\n\t\t"categorical_impute_strategy": "most_frequent",\n\t\t"numeric_impute_strategy": "mean",\n\t\t"categorical_fill_value": null,\n\t\t"numeric_fill_value": null\n\t},' \
+                    '\n\t"My Custom Estimator": {\n\t\t"random_arg": false\n\t}\n}""")' \
                     '\npipeline = MockBinaryPipelineEstimator(parameters)'
     pipeline = generate_pipeline_code(mockBinaryPipeline)
     assert pipeline == expected_code
 
     mockAllCustom = MockAllCustom({})
-    expected_code = "from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline" \
-                    "\n\nclass MockAllCustom(BinaryClassificationPipeline):" \
-                    "\n\tcomponent_graph = [\n\t\tCustomTransformer,\n\t\tCustomEstimator\n\t]" \
-                    "\n\tname = 'Mock All Custom Pipeline'\n\nparameters = {}" \
-                    "\npipeline = MockAllCustom(parameters)"
+    expected_code = 'import json\n' \
+                    'from evalml.pipelines.binary_classification_pipeline import BinaryClassificationPipeline' \
+                    '\n\nclass MockAllCustom(BinaryClassificationPipeline):' \
+                    '\n\tcomponent_graph = [\n\t\tCustomTransformer,\n\t\tCustomEstimator\n\t]' \
+                    '\n\tname = \'Mock All Custom Pipeline\'\n\nparameters = json.loads("""{\n\t"My Custom Estimator": {\n\t\t"random_arg": false\n\t}\n}""")' \
+                    '\npipeline = MockAllCustom(parameters)'
     pipeline = generate_pipeline_code(mockAllCustom)
     assert pipeline == expected_code
+

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1702,4 +1702,3 @@ def test_generate_code_pipeline_custom():
                     '\npipeline = MockAllCustom(parameters)'
     pipeline = generate_pipeline_code(mockAllCustom)
     assert pipeline == expected_code
-


### PR DESCRIPTION
fix #1495 

Add support for pythonic types that JSON doesn't normally support, like boolean and None values. 

I didn't add in support/tests for Python objects (like Datetime) or tuples (which get converted to lists by `json.dumps` and remains a list after `json.loads`) since these seem to be edge cases and are unlikely to be params in pipelines/pipeline hyperparameters. Certainly down to discuss this if it is otherwise important to have support for these/other cases!