### PR TITLE
Move JSON check to CodeGen rather than as helper function

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
-        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON :pr:`1524` :pr:``
+        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON :pr:`1524` :pr:`1531`
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
-        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON :pr:`1524`
+        * Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON :pr:`1524` :pr:``
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1614,7 +1614,7 @@ def test_generate_code_pipeline_json_errors():
     pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': BinaryClassificationPipeline}})
     with pytest.raises(TypeError, match="cannot be JSON-serialized"):
         generate_pipeline_code(pipeline)
-    
+
     pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': Estimator}})
     with pytest.raises(TypeError, match="cannot be JSON-serialized"):
         generate_pipeline_code(pipeline)
@@ -1622,6 +1622,7 @@ def test_generate_code_pipeline_json_errors():
     pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': Imputer()}})
     with pytest.raises(TypeError, match="cannot be JSON-serialized"):
         generate_pipeline_code(pipeline)
+
 
 def test_generate_code_pipeline():
     class MockBinaryPipeline(BinaryClassificationPipeline):

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1607,6 +1607,21 @@ def test_generate_code_pipeline_json_errors():
     with pytest.raises(TypeError, match="cannot be JSON-serialized"):
         generate_pipeline_code(pipeline)
 
+    pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': ProblemTypes.BINARY}})
+    with pytest.raises(TypeError, match="cannot be JSON-serialized"):
+        generate_pipeline_code(pipeline)
+
+    pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': BinaryClassificationPipeline}})
+    with pytest.raises(TypeError, match="cannot be JSON-serialized"):
+        generate_pipeline_code(pipeline)
+    
+    pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': Estimator}})
+    with pytest.raises(TypeError, match="cannot be JSON-serialized"):
+        generate_pipeline_code(pipeline)
+
+    pipeline = MockBinaryPipelineTransformer({'My Custom Estimator': {'random_arg': Imputer()}})
+    with pytest.raises(TypeError, match="cannot be JSON-serialized"):
+        generate_pipeline_code(pipeline)
 
 def test_generate_code_pipeline():
     class MockBinaryPipeline(BinaryClassificationPipeline):


### PR DESCRIPTION
fix #1495 

Follow-up on [this pr](https://github.com/alteryx/evalml/pull/1524#discussion_r538917116). Moved JSON check to CodeGen function, added additional tests