### PR TITLE
Update dependencies to fix `ImportError: cannot import name 'MaskedArray' from 'sklearn.utils.fixes'` errors

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.16.4
 pandas>=0.25.0
 scipy>=1.2.1
-scikit-learn>=0.23
-scikit-optimize>=0.8
+scikit-learn>=0.23.1
+scikit-optimize>=0.8.1
 colorama
 cloudpickle>=0.2.2
 click>=7.0.0

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.16.4
-pandas>=0.25.0
+numpy>=1.19.1
+pandas>=1.1.0
 scipy>=1.2.1
 scikit-learn>=0.23.1
 scikit-optimize>=0.8.1

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,6 +20,7 @@ Release Notes
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`
+        * Updated dependencies to fix ``ImportError: cannot import name 'MaskedArray' from 'sklearn.utils.fixes'`` error and to address Woodwork and Featuretool dependencies :pr:`1540`
     * Documentation Changes
     * Testing Changes
         * Set ``n_jobs=1`` in most unit tests to reduce memory :pr:`1505`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -27,6 +27,12 @@ Release Notes
     * Testing Changes
         * Set ``n_jobs=1`` in most unit tests to reduce memory :pr:`1505`
 
+.. warning::
+
+    **Breaking Changes**
+        * Updated minimal dependencies: ``numpy>=1.19.1``, ``pandas>=1.1.0``, ``scikit-learn>=0.23.1``, ``scikit-optimize>=0.8.1``
+
+
 
 **v0.16.1 Dec. 1, 2020**
     * Enhancements


### PR DESCRIPTION
Closes #1519 

Repro steps:
1. Create new virtualenv with no packages installed. I used python 3.7.6
2. Install the following:
numpy>=1.19.1
pandas>1.1.0
scikit-learn==0.23
scikit-optimize==0.8
3. Run `pip install -r requirements.txt` and install pytest
4. Run tests

This should raise the following:
```
================================================================= ERRORS =================================================================
_____________________________________________________ ERROR collecting test session ______________________________________________________
../../.pyenv/versions/3.7.6/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1006: in _gcd_import
    ???
<frozen importlib._bootstrap>:983: in _find_and_load
    ???
<frozen importlib._bootstrap>:953: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1006: in _gcd_import
    ???
<frozen importlib._bootstrap>:983: in _find_and_load
    ???
<frozen importlib._bootstrap>:953: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1006: in _gcd_import
    ???
<frozen importlib._bootstrap>:983: in _find_and_load
    ???
<frozen importlib._bootstrap>:967: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:677: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:728: in exec_module
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
evalml/__init__.py:9: in <module>
    import evalml.pipelines
evalml/pipelines/__init__.py:1: in <module>
    from .components import (
evalml/pipelines/components/__init__.py:2: in <module>
    from .estimators import (
evalml/pipelines/components/estimators/__init__.py:2: in <module>
    from .classifiers import (LogisticRegressionClassifier,
evalml/pipelines/components/estimators/classifiers/__init__.py:1: in <module>
    from .logistic_regression import LogisticRegressionClassifier
evalml/pipelines/components/estimators/classifiers/logistic_regression.py:3: in <module>
    from skopt.space import Real
../../.pyenv/versions/3.7.6/lib/python3.7/site-packages/skopt/__init__.py:55: in <module>
    from .searchcv import BayesSearchCV
../../.pyenv/versions/3.7.6/lib/python3.7/site-packages/skopt/searchcv.py:16: in <module>
    from sklearn.utils.fixes import MaskedArray
E   ImportError: cannot import name 'MaskedArray' from 'sklearn.utils.fixes' (/Users/angela.lin/.pyenv/versions/3.7.6/lib/python3.7/site-packages/sklearn/utils/fixes.py)
======================================================== short test summary info =========================================================
ERROR  - ImportError: cannot import name 'MaskedArray' from 'sklearn.utils.fixes' (/Users/angela.lin/.pyenv/versions/3.7.6/lib/python3....
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================ 1 error in 3.06s ============================================================
```


Upgrading `scikit-learn==0.23.1` and `scikit-optimize==0.8.1` fixes this :)

--

This PR also tracks updating numpy and pandas versions. Since we rely on woodwork, we'll get errors (see issue) with our current minimal versions.
