### PR TITLE
1535 save graphs to file

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+        * Added ``save_plot`` that allows for saving of figures from different backends :pr:`1550`
         * Added ``visualize_decision_tree`` for tree visualization with ``decision_tree_data_from_estimator`` and ``decision_tree_data_from_pipeline`` to reformat tree structure output :pr:`1511`
         * Added `DFS Transformer` component into transformer components :pr:`1454`
         * Added ``MAPE`` to the standard metrics for time series problems and update objectives :pr:`1510`

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -299,7 +299,7 @@ def linear_regression_pipeline_class():
 @pytest.fixture
 def decision_tree_classification_pipeline_class(X_y_categorical_classification):
     class DTBinaryClassificationPipeline(BinaryClassificationPipeline):
-        component_graph = ['Simple Imputer', 'Target Encoder', 'Standard Scaler', 'Decision Tree Classifier']
+        component_graph = ['Simple Imputer', 'One Hot Encoder', 'Standard Scaler', 'Decision Tree Classifier']
     pipeline = DTBinaryClassificationPipeline({})
     X, y = X_y_categorical_classification
     pipeline.fit(X, y)

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -294,6 +294,16 @@ def linear_regression_pipeline_class():
 
 
 @pytest.fixture
+def decision_tree_classification_pipeline_class(X_y_categorical_classification):
+    class DTBinaryClassificationPipeline(BinaryClassificationPipeline):
+        component_graph = ['Simple Imputer', 'Target Encoder', 'Standard Scaler', 'Decision Tree Classifier']
+    pipeline = DTBinaryClassificationPipeline({})
+    X, y = X_y_categorical_classification
+    pipeline.fit(X, y)
+    return pipeline
+
+
+@pytest.fixture
 def binary_core_objectives():
     return get_core_objectives(ProblemTypes.BINARY)
 

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -7,6 +7,7 @@ graphviz==0.15
 ipywidgets==7.5.1
 kaleido==0.1.0
 lightgbm==3.1.1
+matplotlib=3.3.3
 networkx==2.5
 nlp-primitives==1.1.0
 numpy==1.19.4

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -7,7 +7,7 @@ graphviz==0.15
 ipywidgets==7.5.1
 kaleido==0.1.0
 lightgbm==3.1.1
-matplotlib=3.3.3
+matplotlib==3.3.3
 networkx==2.5
 nlp-primitives==1.1.0
 numpy==1.19.4

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -5,6 +5,7 @@ colorama==0.4.4
 featuretools==0.22.0
 graphviz==0.15
 ipywidgets==7.5.1
+kaleido==0.1.0
 lightgbm==3.1.1
 networkx==2.5
 nlp-primitives==1.1.0
@@ -16,6 +17,7 @@ requirements-parser==0.2.0
 scikit-learn==0.23.2
 scikit-optimize==0.8.1
 scipy==1.5.4
+seaborn==0.11.0
 shap==0.37.0
 texttable==1.6.3
 woodwork==0.0.6

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -516,8 +516,7 @@ def test_save_graphviz_default_format(file_name, format, interactive, fitted_tre
 
 @pytest.mark.parametrize("file_name,format,interactive",
                          [
-                             ('test_plot', 'jpeg', False),
-                             (None, 'jpeg', False)
+                             ('test_plot', 'jpeg', False)
                          ])
 def test_save_graphviz_different_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
     est_class, est_reg = fitted_tree_estimators
@@ -531,8 +530,6 @@ def test_save_graphviz_different_format(file_name, format, interactive, fitted_t
     assert os.path.exists(output_)
     assert isinstance(output_, str)
     assert os.path.basename(output_) == 'test_plot.jpeg'
-    if not file_name:
-        os.remove('test_plot.jpeg')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -588,7 +588,7 @@ def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree
     def setup_plt():
         data_ = [0, 1, 2, 3, 4]
         fig = sns.scatterplot(data=data_)
-        #fig_ = fig.figure
+        # fig_ = fig.figure
         return fig
 
     fig = setup_plt()

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -401,8 +401,7 @@ def test_convert_to_woodwork_structure():
                              ('test_plot', 'png', False),
                              ('test_plot.png', 'png', False),
                              ('test_plot.', 'png', False),
-                             ('test_plot.png', 'jpeg', False),
-                             (None, None, False)
+                             ('test_plot.png', 'jpeg', False)
                          ])
 def test_save_plotly_static_default_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
     if not has_minimal_dependencies:
@@ -417,8 +416,6 @@ def test_save_plotly_static_default_format(file_name, format, interactive, decis
         assert os.path.exists(output_)
         assert isinstance(output_, str)
         assert os.path.basename(output_) == 'test_plot.png'
-        if not file_name:   # Necessary because file_name of None will default to saving to the current working directory
-            os.remove('test_plot.png')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -571,8 +568,7 @@ def test_save_matplotlib_default_format(file_name, format, interactive, fitted_t
                              ('test_plot', 'png', False),
                              ('test_plot.png', 'png', False),
                              ('test_plot.', 'png', False),
-                             ('test_plot.png', 'jpeg', False),
-                             (None, None, False)
+                             ('test_plot.png', 'jpeg', False)
                          ])
 def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
     sns = pytest.importorskip("seaborn")
@@ -592,5 +588,3 @@ def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree
     assert os.path.exists(output_)
     assert isinstance(output_, str)
     assert os.path.basename(output_) == 'test_plot.png'
-    if not file_name:
-        os.remove('test_plot.png')

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -408,7 +408,7 @@ def test_save_plotly_static_default_format(file_name, format, interactive, decis
         pipeline = decision_tree_classification_pipeline_class
         feat_fig_ = pipeline.graph_feature_importance()
 
-        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        filepath = os.path.join(str(tmpdir), f'{file_name}')
         no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
         output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
@@ -576,7 +576,6 @@ def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree
     def setup_plt():
         data_ = [0, 1, 2, 3, 4]
         fig = sns.scatterplot(data=data_)
-        # fig_ = fig.figure
         return fig
 
     fig = setup_plt()

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -404,21 +404,21 @@ def test_convert_to_woodwork_structure():
                              ('test_plot.png', 'jpeg', False),
                              (None, None, False)
                          ])
-def test_save_plotly_static_default_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir):
+def test_save_plotly_static_default_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        pipeline = decision_tree_classification_pipeline_class
+        feat_fig_ = pipeline.graph_feature_importance()
 
-    pipeline = decision_tree_classification_pipeline_class
-    feat_fig_ = pipeline.graph_feature_importance()
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
-
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'test_plot.png'
-    if not file_name:   # Necessary because file_name of None will default to saving to the current working directory
-        os.remove('test_plot.png')
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.png'
+        if not file_name:   # Necessary because file_name of None will default to saving to the current working directory
+            os.remove('test_plot.png')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -426,21 +426,21 @@ def test_save_plotly_static_default_format(file_name, format, interactive, decis
                              ('test_plot', 'jpeg', False),
                              (None, 'jpeg', False)
                          ])
-def test_save_plotly_static_different_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir):
+def test_save_plotly_static_different_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        pipeline = decision_tree_classification_pipeline_class
+        feat_fig_ = pipeline.graph_feature_importance()
 
-    pipeline = decision_tree_classification_pipeline_class
-    feat_fig_ = pipeline.graph_feature_importance()
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
-
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'test_plot.jpeg'
-    if not file_name:
-        os.remove('test_plot.jpeg')
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.jpeg'
+        if not file_name:
+            os.remove('test_plot.jpeg')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -453,21 +453,21 @@ def test_save_plotly_static_different_format(file_name, format, interactive, dec
                              ('test_plot.html', None, True),
                              (None, None, True)
                          ])
-def test_save_plotly_interactive(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir):
+def test_save_plotly_interactive(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        pipeline = decision_tree_classification_pipeline_class
+        feat_fig_ = pipeline.graph_feature_importance()
 
-    pipeline = decision_tree_classification_pipeline_class
-    feat_fig_ = pipeline.graph_feature_importance()
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
-
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'test_plot.html'
-    if not file_name:
-        os.remove('test_plot.html')
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.html'
+        if not file_name:
+            os.remove('test_plot.html')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -478,52 +478,55 @@ def test_save_plotly_interactive(file_name, format, interactive, decision_tree_c
                              ('test_plot.png', 'jpeg', False),
                              (None, None, False)
                          ])
-def test_save_graphviz_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    est_class, _ = fitted_tree_estimators
-    src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
+def test_save_graphviz_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        est_class, _ = fitted_tree_estimators
+        src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'test_plot.png'
-    if not file_name:
-        os.remove('test_plot.png')
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.png'
+        if not file_name:
+            os.remove('test_plot.png')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
                          [
                              ('test_plot', 'jpeg', False)
                          ])
-def test_save_graphviz_different_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    est_class, _ = fitted_tree_estimators
-    src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
+def test_save_graphviz_different_format(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        est_class, _ = fitted_tree_estimators
+        src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'test_plot.jpeg'
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.jpeg'
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
                          [
                              ('Output/in_folder_plot', 'jpeg', True)
                          ])
-def test_save_graphviz_invalid_filepath(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    est_class, _ = fitted_tree_estimators
-    src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
+def test_save_graphviz_invalid_filepath(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        est_class, _ = fitted_tree_estimators
+        src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-    filepath = f'{file_name}.{format}'
+        filepath = f'{file_name}.{format}'
 
-    with pytest.raises(ValueError, match="Specified filepath is not writeable"):
-        save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        with pytest.raises(ValueError, match="Specified filepath is not writeable"):
+            save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -531,18 +534,19 @@ def test_save_graphviz_invalid_filepath(file_name, format, interactive, fitted_t
                              ('example_plot', None, False),
                              ('example_plot', 'png', False)
                          ])
-def test_save_graphviz_different_filename_output(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    est_class, _ = fitted_tree_estimators
-    src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
+def test_save_graphviz_different_filename_output(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        est_class, _ = fitted_tree_estimators
+        src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
-    no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
-    output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
+        output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
-    assert not no_output_
-    assert os.path.exists(output_)
-    assert isinstance(output_, str)
-    assert os.path.basename(output_) == 'example_plot.png'
+        assert not no_output_
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'example_plot.png'
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -554,7 +558,7 @@ def test_save_graphviz_different_filename_output(file_name, format, interactive,
                              (None, None, False)
                          ])
 def test_save_matplotlib_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    plt = import_or_raise("matplotlib.pyplot", error_msg="Cannot find dependency matplotlib.pyplot")
+    plt = pytest.importorskip("matplotlib.pyplot")
 
     def setup_plt():
         fig_ = plt.figure(figsize=(4.5, 4.5))
@@ -582,8 +586,8 @@ def test_save_matplotlib_default_format(file_name, format, interactive, fitted_t
                              ('test_plot.png', 'jpeg', False),
                              (None, None, False)
                          ])
-def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
-    sns = import_or_raise("seaborn", error_msg="Cannot find dependency seaborn")
+def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
+    sns = pytest.importorskip("seaborn")
 
     def setup_plt():
         data_ = [0, 1, 2, 3, 4]

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -6,6 +7,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 
+from evalml.pipelines import BinaryClassificationPipeline
 from evalml.pipelines.components import ComponentBase
 from evalml.utils.gen_utils import (
     SEED_BOUNDS,
@@ -21,7 +23,8 @@ from evalml.utils.gen_utils import (
     get_random_state,
     import_or_raise,
     jupyter_check,
-    pad_with_nans
+    pad_with_nans,
+    save_plot
 )
 
 
@@ -391,3 +394,38 @@ def test_convert_to_woodwork_structure():
     X_expected = ww.DataTable(pd.DataFrame(X_np))
     pd.testing.assert_frame_equal(X_expected.to_dataframe(), _convert_to_woodwork_structure(X_np).to_dataframe())
     assert np.array_equal(X_np, np.array([[1, 2], [3, 4]]))
+
+
+def test_save_plot_static_no_path(decision_tree_classification_pipeline_class):
+    pipeline = decision_tree_classification_pipeline_class
+    fig_ = pipeline.graph_feature_importance()
+    save_plot(fig_, interactive=False)
+    assert os.path.exists(os.path.join(os.getcwd(), 'test_plot.png'))
+
+
+def test_save_plot_interactive_no_path(decision_tree_classification_pipeline_class):
+    pipeline = decision_tree_classification_pipeline_class
+    fig_ = pipeline.graph_feature_importance()
+    save_plot(fig_, interactive=True)
+    assert os.path.exists(os.path.join(os.getcwd(), 'test_plot.html'))
+
+
+def test_save_plot_static_with_path(decision_tree_classification_pipeline_class, tmpdir):
+    pipeline = decision_tree_classification_pipeline_class
+    fig_ = pipeline.graph_feature_importance()
+    save_plot(fig_, filepath=f'{tmpdir}/test_plot.png', interactive=False)
+    assert os.path.exists(os.path.join(os.getcwd(), f'{tmpdir}/test_plot.png'))
+
+
+def test_save_plot_interactive_with_path(decision_tree_classification_pipeline_class, tmpdir):
+    pipeline = decision_tree_classification_pipeline_class
+    fig_ = pipeline.graph_feature_importance()
+    save_plot(fig_, filepath=f'{tmpdir}/test_plot.html', interactive=True)
+    assert os.path.exists(os.path.join(os.getcwd(), f'{tmpdir}/test_plot.html'))
+
+
+def test_save_plot_non_plotly(decision_tree_classification_pipeline_class, tmpdir):
+    pipeline = decision_tree_classification_pipeline_class
+    fig_ = pipeline.graph_feature_importance()
+    save_plot(fig_, filepath=f'{tmpdir}/test_plot.html', interactive=True)
+    assert os.path.exists(os.path.join(os.getcwd(), f'{tmpdir}/test_plot.html'))

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -427,7 +427,7 @@ def test_save_plotly_static_different_format(file_name, format, interactive, dec
         pipeline = decision_tree_classification_pipeline_class
         feat_fig_ = pipeline.graph_feature_importance()
 
-        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        filepath = os.path.join(str(tmpdir), f'{file_name}')
         no_output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
         output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
@@ -435,6 +435,24 @@ def test_save_plotly_static_different_format(file_name, format, interactive, dec
         assert os.path.exists(output_)
         assert isinstance(output_, str)
         assert os.path.basename(output_) == 'test_plot.jpeg'
+
+
+@pytest.mark.parametrize("file_name,format,interactive",
+                         [
+                             (None, 'jpeg', False)
+                         ])
+def test_save_plotly_static_no_filepath(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
+    if not has_minimal_dependencies:
+        pipeline = decision_tree_classification_pipeline_class
+        feat_fig_ = pipeline.graph_feature_importance()
+
+        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        output_ = save_plot(fig=feat_fig_, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
+
+        assert os.path.exists(output_)
+        assert isinstance(output_, str)
+        assert os.path.basename(output_) == 'test_plot.jpeg'
+        os.remove('test_plot.jpeg')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -492,7 +510,7 @@ def test_save_graphviz_different_format(file_name, format, interactive, fitted_t
         est_class, _ = fitted_tree_estimators
         src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        filepath = os.path.join(str(tmpdir), f'{file_name}')
         no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
         output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
@@ -527,7 +545,7 @@ def test_save_graphviz_different_filename_output(file_name, format, interactive,
         est_class, _ = fitted_tree_estimators
         src = visualize_decision_tree(estimator=est_class, filled=True, max_depth=3)
 
-        filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+        filepath = os.path.join(str(tmpdir), f'{file_name}')
         no_output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
         output_ = save_plot(fig=src, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
@@ -553,7 +571,7 @@ def test_save_matplotlib_default_format(file_name, format, interactive, fitted_t
         return fig_
 
     fig = setup_plt()
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+    filepath = os.path.join(str(tmpdir), f'{file_name}')
     no_output_ = save_plot(fig=fig, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
     output_ = save_plot(fig=fig, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 
@@ -579,7 +597,7 @@ def test_save_seaborn_default_format(file_name, format, interactive, fitted_tree
         return fig
 
     fig = setup_plt()
-    filepath = os.path.join(str(tmpdir), f'{file_name}') if file_name else None
+    filepath = os.path.join(str(tmpdir), f'{file_name}')
     no_output_ = save_plot(fig=fig, filepath=filepath, format=format, interactive=interactive, return_filepath=False)
     output_ = save_plot(fig=fig, filepath=filepath, format=format, interactive=interactive, return_filepath=True)
 

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -423,8 +423,7 @@ def test_save_plotly_static_default_format(file_name, format, interactive, decis
 
 @pytest.mark.parametrize("file_name,format,interactive",
                          [
-                             ('test_plot', 'jpeg', False),
-                             (None, 'jpeg', False)
+                             ('test_plot', 'jpeg', False)
                          ])
 def test_save_plotly_static_different_format(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
     if not has_minimal_dependencies:
@@ -439,8 +438,6 @@ def test_save_plotly_static_different_format(file_name, format, interactive, dec
         assert os.path.exists(output_)
         assert isinstance(output_, str)
         assert os.path.basename(output_) == 'test_plot.jpeg'
-        if not file_name:
-            os.remove('test_plot.jpeg')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -450,8 +447,7 @@ def test_save_plotly_static_different_format(file_name, format, interactive, dec
                              ('test_plot.', 'html', True),
                              ('test_plot.png', 'jpeg', True),
                              ('test_plot', None, True),
-                             ('test_plot.html', None, True),
-                             (None, None, True)
+                             ('test_plot.html', None, True)
                          ])
 def test_save_plotly_interactive(file_name, format, interactive, decision_tree_classification_pipeline_class, tmpdir, has_minimal_dependencies):
     if not has_minimal_dependencies:
@@ -466,8 +462,6 @@ def test_save_plotly_interactive(file_name, format, interactive, decision_tree_c
         assert os.path.exists(output_)
         assert isinstance(output_, str)
         assert os.path.basename(output_) == 'test_plot.html'
-        if not file_name:
-            os.remove('test_plot.html')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -475,8 +469,7 @@ def test_save_plotly_interactive(file_name, format, interactive, decision_tree_c
                              ('test_plot', 'png', False),
                              ('test_plot.png', 'png', False),
                              ('test_plot.', 'png', False),
-                             ('test_plot.png', 'jpeg', False),
-                             (None, None, False)
+                             ('test_plot.png', 'jpeg', False)
                          ])
 def test_save_graphviz_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir, has_minimal_dependencies):
     if not has_minimal_dependencies:
@@ -491,8 +484,6 @@ def test_save_graphviz_default_format(file_name, format, interactive, fitted_tre
         assert os.path.exists(output_)
         assert isinstance(output_, str)
         assert os.path.basename(output_) == 'test_plot.png'
-        if not file_name:
-            os.remove('test_plot.png')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",
@@ -554,8 +545,7 @@ def test_save_graphviz_different_filename_output(file_name, format, interactive,
                              ('test_plot', 'png', False),
                              ('test_plot.png', 'png', False),
                              ('test_plot.', 'png', False),
-                             ('test_plot.png', 'jpeg', False),
-                             (None, None, False)
+                             ('test_plot.png', 'jpeg', False)
                          ])
 def test_save_matplotlib_default_format(file_name, format, interactive, fitted_tree_estimators, tmpdir):
     plt = pytest.importorskip("matplotlib.pyplot")
@@ -574,8 +564,6 @@ def test_save_matplotlib_default_format(file_name, format, interactive, fitted_t
     assert os.path.exists(output_)
     assert isinstance(output_, str)
     assert os.path.basename(output_) == 'test_plot.png'
-    if not file_name:
-        os.remove('test_plot.png')
 
 
 @pytest.mark.parametrize("file_name,format,interactive",

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -395,9 +395,9 @@ def _file_path_check(filepath=None, format='png', interactive=False, is_plotly=F
             format_ = extension
         filepath = f'{path_and_name}.{format_}'
         try:
-            saving_folder = os.path.dirname(filepath)
-            if not os.path.exists(saving_folder):   # Creates folder if one is specified
-                os.makedirs(saving_folder)
+            # saving_folder = os.path.dirname(filepath)
+            # if not os.path.exists(saving_folder):   # Creates folder if one is specified
+            #    os.makedirs(saving_folder)
             f = open(filepath, 'w')
             f.close()
         except (IOError, FileNotFoundError):

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -383,6 +383,17 @@ def drop_rows_with_nans(pd_data_1, pd_data_2):
 
 
 def _file_path_check(filepath=None, format='png', interactive=False, is_plotly=False):
+    """ Helper function to check the filepath being passed.
+
+    Arguments:
+        filepath (str or Path, optional): Location to save file.
+        format (str): Extension for figure to be saved as. Defaults to 'png'.
+        interactive (bool, optional): If True and fig is of type plotly.Figure, sets the format to 'html'.
+        is_plotly (bool, optional): Check to see if the fig being passed is of type plotly.Figure.
+
+    Returns:
+        String representing the final filepath the image will be saved to.
+    """
     if filepath:
         filepath = str(filepath)
         path_and_name, extension = os.path.splitext(filepath)
@@ -409,12 +420,17 @@ def save_plot(fig, filepath=None, format='png', interactive=False, return_filepa
     """Saves fig to filepath if specified, or to a default location if not.
 
     Arguments:
-        fig (Figure): Figure to be saved
-        filepath (str or Path, optional): Location to save file
-        format (str): Extension for figure to be saved as. Defaults to 'png'. Ignored if interactive is True.
+        fig (Figure): Figure to be saved.
+        filepath (str or Path, optional): Location to save file.
+        format (str): Extension for figure to be saved as. Ignored if interactive is True and fig
+        is of type plotly.Figure. Defaults to 'png'.
         interactive (bool, optional): If True and fig is of type plotly.Figure, saves the fig as interactive
-        instead of static.
-        return_filepath (bool, optional):
+        instead of static. Defaults to False.
+        return_filepath (bool, optional): Whether to return the final filepath the image is saved to. Defaults to False.
+
+    Returns:
+        String representing the final filepath the image was saved to if return_filepath is set to True.
+        Defaults to None.
     """
     plotly_ = import_or_raise("plotly", error_msg="Cannot find dependency plotly")
     graphviz_ = import_or_raise('graphviz', error_msg='Please install graphviz to visualize trees.')

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -406,9 +406,6 @@ def _file_path_check(filepath=None, format='png', interactive=False, is_plotly=F
             format_ = extension
         filepath = f'{path_and_name}.{format_}'
         try:
-            # saving_folder = os.path.dirname(filepath)
-            # if not os.path.exists(saving_folder):   # Creates folder if one is specified
-            #    os.makedirs(saving_folder)
             f = open(filepath, 'w')
             f.close()
         except (IOError, FileNotFoundError):
@@ -421,11 +418,11 @@ def save_plot(fig, filepath=None, format='png', interactive=False, return_filepa
 
     Arguments:
         fig (Figure): Figure to be saved.
-        filepath (str or Path, optional): Location to save file.
+        filepath (str or Path, optional): Location to save file. Default is with filename "test_plot".
         format (str): Extension for figure to be saved as. Ignored if interactive is True and fig
         is of type plotly.Figure. Defaults to 'png'.
         interactive (bool, optional): If True and fig is of type plotly.Figure, saves the fig as interactive
-        instead of static. Defaults to False.
+        instead of static, and format will be set to 'html'. Defaults to False.
         return_filepath (bool, optional): Whether to return the final filepath the image is saved to. Defaults to False.
 
     Returns:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ xgboost>=0.82,<1.3.0
 catboost>=0.20
 lightgbm>=2.3.1
 graphviz>=0.13
+seaborn>=0.11.0
 category_encoders>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -r core-requirements.txt
 plotly>=4.14.0
-python-kaleido>=0.1.0
+kaleido>=0.1.0
 ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -r core-requirements.txt
 plotly>=4.14.0
+kaleido>=0.1.0
 ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -r core-requirements.txt
-plotly>=4.2.1
+plotly>=4.14.0
+python-kaleido>=0.1.0
 ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -r core-requirements.txt
 plotly>=4.14.0
-kaleido>=0.1.0
 ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20
 lightgbm>=2.3.1
+matplotlib>=3.3.3
 graphviz>=0.13
 seaborn>=0.11.0
 category_encoders>=2.0.0


### PR DESCRIPTION
Fixes #1535 

Allows the user to save an image belonging to plotly.Figure, graphviz.Source, matplotlib.pyplot.Figure, or matplotlib.axes.SubplotBase to their local file system.
