### PR TITLE
Make it easy to customize automl search data splitter

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -58,7 +58,7 @@ AutoML Utils
     :nosignatures:
 
     get_default_primary_search_objective
-
+    make_data_splitter
 
 .. currentmodule:: evalml.automl.automl_algorithm
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,7 +17,7 @@ Release Notes
         * Added more information to users about ensembling behavior in ``AutoMLSearch`` :pr:`1527`
         * Add woodwork support for more utility and graph methods :pr:`1544`
         * Changed ``DateTimeFeaturizer`` to encode features as int :pr:`1479`
-        * Added Linear Descriminant Analysis transformer for dimensionality reduction :pr:`1331`
+        * Added Linear Discriminant Analysis transformer for dimensionality reduction :pr:`1331`
         * Added multiclass support for ``partial_dependence`` and ``graph_partial_dependence`` :pr:`1554`
         * Added ``TimeSeriesBinaryClassificationPipeline`` and ``TimeSeriesMulticlassClassificationPipeline`` classes :pr:`1528`
         * Added ``make_data_splitter`` method for easier automl data split customization :pr:`1568`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,7 +17,7 @@ Release Notes
         * Added more information to users about ensembling behavior in ``AutoMLSearch`` :pr:`1527`
         * Add woodwork support for more utility and graph methods :pr:`1544`
         * Changed ``DateTimeFeaturizer`` to encode features as int :pr:`1479`
-        * Added ``LDA`` component for dimensionality reduction :pr:`1331`
+        * Added Linear Descriminant Analysis transformer for dimensionality reduction :pr:`1331`
         * Added multiclass support for ``partial_dependence`` and ``graph_partial_dependence`` :pr:`1554`
         * Added ``TimeSeriesBinaryClassificationPipeline`` and ``TimeSeriesMulticlassClassificationPipeline`` classes :pr:`1528`
         * Added ``make_data_splitter`` method for easier automl data split customization :pr:`1568`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,9 +17,10 @@ Release Notes
         * Added more information to users about ensembling behavior in ``AutoMLSearch`` :pr:`1527`
         * Add woodwork support for more utility and graph methods :pr:`1544`
         * Changed ``DateTimeFeaturizer`` to encode features as int :pr:`1479`
-        * Added `Linear Discriminant Analysis Transformer` component for dimensionality reduction :pr:`1331`
+        * Added ``LDA`` component for dimensionality reduction :pr:`1331`
         * Added multiclass support for ``partial_dependence`` and ``graph_partial_dependence`` :pr:`1554`
         * Added ``TimeSeriesBinaryClassificationPipeline`` and ``TimeSeriesMulticlassClassificationPipeline`` classes :pr:`1528`
+        * Added ``make_data_splitter`` method for easier automl data split customization :pr:`1568`
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`

--- a/evalml/automl/__init__.py
+++ b/evalml/automl/__init__.py
@@ -1,3 +1,3 @@
 from .automl_search import AutoMLSearch
-from .utils import get_default_primary_search_objective
+from .utils import get_default_primary_search_objective, make_data_splitter
 from .data_splitters import TrainingValidationSplit, TimeSeriesSplit

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -8,10 +8,7 @@ import cloudpickle
 import numpy as np
 import pandas as pd
 import woodwork as ww
-from sklearn.model_selection import (
-    BaseCrossValidator,
-    train_test_split
-)
+from sklearn.model_selection import BaseCrossValidator, train_test_split
 
 from .pipeline_search_plots import PipelineSearchPlots
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -23,7 +23,10 @@ from evalml.automl.data_splitters import (
     TimeSeriesSplit,
     TrainingValidationSplit
 )
-from evalml.automl.utils import get_default_primary_search_objective
+from evalml.automl.utils import (
+    get_default_primary_search_objective,
+    make_data_splitter
+)
 from evalml.data_checks import (
     AutoMLDataChecks,
     DataChecks,
@@ -372,23 +375,15 @@ class AutoMLSearch:
             else:
                 leading_char = ""
 
-    def _set_data_split(self, X):
+    def _set_data_split(self, X, y):
         """Sets the data split method for AutoMLSearch
 
         Arguments:
-            X (DataFrame): Input dataframe to split
+            X (pd.DataFrame, ww.DataTable): The input training data of shape [n_samples, n_features].
+            y (pd.Series, ww.DataColumn): The target training data of length [n_samples].
         """
-        if self.problem_type == ProblemTypes.REGRESSION:
-            default_data_split = KFold(n_splits=3, random_state=self.random_state, shuffle=True)
-        elif self.problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-            default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state, shuffle=True)
-        elif self.problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
-            default_data_split = TimeSeriesSplit(n_splits=3, gap=self.problem_configuration['gap'],
-                                                 max_delay=self.problem_configuration['max_delay'])
-
-        if X.shape[0] > self._LARGE_DATA_ROW_THRESHOLD:
-            default_data_split = TrainingValidationSplit(test_size=self._LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
-
+        default_data_split = make_data_splitter(X, y, self.problem_type, self.problem_configuration,
+                                                n_splits=3, shuffle=True, random_state=self.random_state)
         self.data_split = self.data_split or default_data_split
 
     def search(self, X, y, data_checks="auto", show_iteration_plot=True):
@@ -431,7 +426,7 @@ class AutoMLSearch:
             logger.warning("`y` passed was not a DataColumn. EvalML will try to convert the input as a Woodwork DataTable and types will be inferred. To control this behavior, please pass in a Woodwork DataTable instead.")
             y = _convert_to_woodwork_structure(y)
 
-        self._set_data_split(X)
+        self._set_data_split(X, y)
 
         data_checks = self._validate_data_checks(data_checks)
         self._data_check_results = data_checks.validate(_convert_woodwork_types_wrapper(X.to_dataframe()), _convert_woodwork_types_wrapper(y.to_series()))
@@ -899,7 +894,7 @@ class AutoMLSearch:
         if not isinstance(y, pd.Series):
             y = pd.Series(y)
 
-        self._set_data_split(X)
+        self._set_data_split(X, y)
 
         pipeline_rows = self.full_rankings[self.full_rankings['pipeline_name'] == pipeline.name]
         for parameter in pipeline_rows['parameters']:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -10,8 +10,6 @@ import pandas as pd
 import woodwork as ww
 from sklearn.model_selection import (
     BaseCrossValidator,
-    KFold,
-    StratifiedKFold,
     train_test_split
 )
 
@@ -19,10 +17,6 @@ from .pipeline_search_plots import PipelineSearchPlots
 
 from evalml.automl.automl_algorithm import IterativeAlgorithm
 from evalml.automl.callbacks import log_error_callback
-from evalml.automl.data_splitters import (
-    TimeSeriesSplit,
-    TrainingValidationSplit
-)
 from evalml.automl.utils import (
     get_default_primary_search_objective,
     make_data_splitter

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -77,8 +77,6 @@ logger = get_logger(__file__)
 class AutoMLSearch:
     """Automated Pipeline search."""
     _MAX_NAME_LEN = 40
-    _LARGE_DATA_ROW_THRESHOLD = int(1e5)
-    _LARGE_DATA_PERCENT_VALIDATION = 0.75
 
     # Necessary for "Plotting" documentation, since Sphinx does not work well with instance attributes.
     plot = PipelineSearchPlots

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -7,7 +7,6 @@ from evalml.automl.data_splitters import (
 from evalml.objectives import get_objective
 from evalml.problem_types import ProblemTypes, handle_problem_types
 
-
 _LARGE_DATA_ROW_THRESHOLD = int(1e5)
 
 _LARGE_DATA_PERCENT_VALIDATION = 0.75

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -9,7 +9,9 @@ from evalml.problem_types import ProblemTypes, handle_problem_types
 
 
 _LARGE_DATA_ROW_THRESHOLD = int(1e5)
+
 _LARGE_DATA_PERCENT_VALIDATION = 0.75
+
 
 def get_default_primary_search_objective(problem_type):
     """Get the default primary search objective for a problem type.

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -38,8 +38,8 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         problem_type (ProblemType): the type of machine learning problem.
         problem_configuration (dict, None): Additional parameters needed to configure the search. For example,
             in time series problems, values should be passed in for the gap and max_delay variables.
-        n_splits (int, None): the number of CV splits, if applicable.
-        shuffle (bool): whether or not to shuffle the data before splitting, if applicable.
+        n_splits (int, None): the number of CV splits, if applicable. Default 3.
+        shuffle (bool): whether or not to shuffle the data before splitting, if applicable. Default True.
         random_state (int, np.random.RandomState): The random seed/state. Defaults to 0.
 
     Returns:

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -46,6 +46,7 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         sklearn.model_selection.BaseCrossValidator: data splitting method.
     """
     classification = False
+    problem_type = handle_problem_types(problem_type)
     if problem_type == ProblemTypes.REGRESSION:
         data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
@@ -56,8 +57,6 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
             raise ValueError("problem_configuration is required for time series problem types")
         data_split = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
                                      max_delay=problem_configuration.get('max_delay'))
-    else:
-        raise ValueError(f"Unsupported problem_type {problem_type}")
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
         data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, stratify=classification, shuffle=True)
     return data_split

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -44,9 +44,11 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
     Returns:
         sklearn.model_selection.BaseCrossValidator: data splitting method.
     """
+    classification = False
     if problem_type == ProblemTypes.REGRESSION:
         data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
+        classification = True
         data_split = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
         if not problem_configuration:
@@ -56,5 +58,5 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
     else:
         raise ValueError(f"Unsupported problem_type {problem_type}")
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
-        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
+        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, stratify=classification, shuffle=True)
     return data_split

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -45,12 +45,10 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
     Returns:
         sklearn.model_selection.BaseCrossValidator: data splitting method.
     """
-    classification = False
     problem_type = handle_problem_types(problem_type)
     if problem_type == ProblemTypes.REGRESSION:
         data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-        classification = True
         data_split = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
         if not problem_configuration:
@@ -58,5 +56,5 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         data_split = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
                                      max_delay=problem_configuration.get('max_delay'))
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
-        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, stratify=classification, shuffle=True)
+        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
     return data_split

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -1,5 +1,12 @@
+from sklearn.model_selection import KFold, StratifiedKFold
+
+from evalml.automl import AutoMLSearch
+from evalml.automl.data_splitters import (
+    TimeSeriesSplit,
+    TrainingValidationSplit
+)
 from evalml.objectives import get_objective
-from evalml.problem_types import handle_problem_types
+from evalml.problem_types import ProblemTypes, handle_problem_types
 
 
 def get_default_primary_search_objective(problem_type):
@@ -17,3 +24,35 @@ def get_default_primary_search_objective(problem_type):
                       'regression': 'R2',
                       'time series regression': 'R2'}[problem_type.value]
     return get_objective(objective_name, return_instance=True)
+
+
+def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=3, shuffle=True, random_state=0):
+    """Given the training data and ML problem parameters, compute a data splitting method to use during AutoML search.
+
+    Arguments:
+        X (pd.DataFrame, ww.DataTable): The input training data of shape [n_samples, n_features].
+        y (pd.Series, ww.DataColumn): The target training data of length [n_samples].
+        problem_type (ProblemType): the type of machine learning problem.
+        problem_configuration (dict, None): Additional parameters needed to configure the search. For example,
+            in time series problems, values should be passed in for the gap and max_delay variables.
+        n_splits (int, None): the number of CV splits, if applicable.
+        shuffle (bool): whether or not to shuffle the data before splitting, if applicable.
+        random_state (int, np.random.RandomState): The random seed/state. Defaults to 0.
+
+    Returns:
+        sklearn.model_selection.BaseCrossValidator: data splitting method.
+    """
+    if problem_type == ProblemTypes.REGRESSION:
+        data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
+    elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
+        data_split = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
+    elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+        if not problem_configuration:
+            raise ValueError("problem_configuration is required for time series problem types")
+        data_split = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
+                                     max_delay=problem_configuration.get('max_delay'))
+    else:
+        raise ValueError(f"Unsupported problem_type {problem_type}")
+    if X.shape[0] > AutoMLSearch._LARGE_DATA_ROW_THRESHOLD:
+        data_split = TrainingValidationSplit(test_size=AutoMLSearch._LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
+    return data_split

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -46,11 +46,14 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         sklearn.model_selection.BaseCrossValidator: data splitting method.
     """
     problem_type = handle_problem_types(problem_type)
+    data_split = None
     if problem_type == ProblemTypes.REGRESSION:
         data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
         data_split = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
-    elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+    elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION,
+                          ProblemTypes.TIME_SERIES_BINARY,
+                          ProblemTypes.TIME_SERIES_MULTICLASS]:
         if not problem_configuration:
             raise ValueError("problem_configuration is required for time series problem types")
         data_split = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -1,6 +1,5 @@
 from sklearn.model_selection import KFold, StratifiedKFold
 
-from evalml.automl import AutoMLSearch
 from evalml.automl.data_splitters import (
     TimeSeriesSplit,
     TrainingValidationSplit
@@ -8,6 +7,9 @@ from evalml.automl.data_splitters import (
 from evalml.objectives import get_objective
 from evalml.problem_types import ProblemTypes, handle_problem_types
 
+
+_LARGE_DATA_ROW_THRESHOLD = int(1e5)
+_LARGE_DATA_PERCENT_VALIDATION = 0.75
 
 def get_default_primary_search_objective(problem_type):
     """Get the default primary search objective for a problem type.
@@ -53,6 +55,6 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
                                      max_delay=problem_configuration.get('max_delay'))
     else:
         raise ValueError(f"Unsupported problem_type {problem_type}")
-    if X.shape[0] > AutoMLSearch._LARGE_DATA_ROW_THRESHOLD:
-        data_split = TrainingValidationSplit(test_size=AutoMLSearch._LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
+    if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
+        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
     return data_split

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -10,11 +10,7 @@ import woodwork as ww
 from sklearn.model_selection import KFold, StratifiedKFold
 
 from evalml import AutoMLSearch
-from evalml.automl import (
-    TimeSeriesSplit,
-    TrainingValidationSplit,
-    get_default_primary_search_objective
-)
+from evalml.automl import TimeSeriesSplit, TrainingValidationSplit
 from evalml.automl.callbacks import (
     log_and_save_error_callback,
     log_error_callback,
@@ -31,13 +27,7 @@ from evalml.data_checks import (
 from evalml.demos import load_breast_cancer, load_wine
 from evalml.exceptions import AutoMLSearchException, PipelineNotFoundError
 from evalml.model_family import ModelFamily
-from evalml.objectives import (
-    R2,
-    CostBenefitMatrix,
-    FraudCost,
-    LogLossBinary,
-    LogLossMulticlass
-)
+from evalml.objectives import CostBenefitMatrix, FraudCost
 from evalml.objectives.utils import get_core_objectives, get_objective
 from evalml.pipelines import (
     BinaryClassificationPipeline,
@@ -1518,17 +1508,6 @@ def test_data_split_multi(X_y_multi):
 
     y[5] = 0
     automl.search(X, y, data_checks="disabled")
-
-
-def test_get_default_primary_search_objective():
-    assert isinstance(get_default_primary_search_objective("binary"), LogLossBinary)
-    assert isinstance(get_default_primary_search_objective(ProblemTypes.BINARY), LogLossBinary)
-    assert isinstance(get_default_primary_search_objective("multiclass"), LogLossMulticlass)
-    assert isinstance(get_default_primary_search_objective(ProblemTypes.MULTICLASS), LogLossMulticlass)
-    assert isinstance(get_default_primary_search_objective("regression"), R2)
-    assert isinstance(get_default_primary_search_objective(ProblemTypes.REGRESSION), R2)
-    with pytest.raises(KeyError, match="Problem type 'auto' does not exist"):
-        get_default_primary_search_objective("auto")
 
 
 @patch('evalml.tuners.skopt_tuner.SKOptTuner.add')

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -18,6 +18,10 @@ from evalml.automl.callbacks import (
     raise_error_callback,
     silent_error_callback
 )
+from evalml.automl.utils import (
+    _LARGE_DATA_PERCENT_VALIDATION,
+    _LARGE_DATA_ROW_THRESHOLD
+)
 from evalml.data_checks import (
     DataCheck,
     DataCheckError,
@@ -646,17 +650,17 @@ def test_large_dataset_split_size(mock_fit, mock_score):
     mock_score.return_value = {automl.objective.name: 1.234}
     assert automl.data_split is None
 
-    under_max_rows = automl._LARGE_DATA_ROW_THRESHOLD - 1
+    under_max_rows = _LARGE_DATA_ROW_THRESHOLD - 1
     X, y = generate_fake_dataset(under_max_rows)
     automl.search(X, y)
     assert isinstance(automl.data_split, StratifiedKFold)
 
     automl.data_split = None
-    over_max_rows = automl._LARGE_DATA_ROW_THRESHOLD + 1
+    over_max_rows = _LARGE_DATA_ROW_THRESHOLD + 1
     X, y = generate_fake_dataset(over_max_rows)
     automl.search(X, y)
     assert isinstance(automl.data_split, TrainingValidationSplit)
-    assert automl.data_split.test_size == (automl._LARGE_DATA_PERCENT_VALIDATION)
+    assert automl.data_split.test_size == (_LARGE_DATA_PERCENT_VALIDATION)
 
 
 def test_data_split_shuffle():

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -51,3 +51,43 @@ def test_make_data_splitter_default(problem_type, large_data):
         assert data_splitter.n_splits == 3
         assert data_splitter.gap == 1
         assert data_splitter.max_delay == 7
+
+
+def test_make_data_splitter_parameters():
+    n = 10
+    X = pd.DataFrame({'col_0': list(range(n)),
+                      'target': list(range(n))})
+    y = X.pop('target')
+
+    data_splitter = make_data_splitter(X, y, ProblemTypes.REGRESSION, n_splits=5, shuffle=False)
+    assert isinstance(data_splitter, KFold)
+    assert data_splitter.n_splits == 5
+    assert not data_splitter.shuffle
+
+    data_splitter = make_data_splitter(X, y, ProblemTypes.BINARY, n_splits=5, shuffle=False)
+    assert isinstance(data_splitter, StratifiedKFold)
+    assert data_splitter.n_splits == 5
+    assert not data_splitter.shuffle
+
+    data_splitter = make_data_splitter(X, y, ProblemTypes.MULTICLASS, n_splits=5, shuffle=False)
+    assert isinstance(data_splitter, StratifiedKFold)
+    assert data_splitter.n_splits == 5
+    assert not data_splitter.shuffle
+
+    data_splitter = make_data_splitter(X, y, ProblemTypes.TIME_SERIES_REGRESSION, problem_configuration={'gap': 1, 'max_delay': 7}, n_splits=5, shuffle=False)
+    assert isinstance(data_splitter, TimeSeriesSplit)
+    assert data_splitter.n_splits == 5
+    assert data_splitter.gap == 1
+    assert data_splitter.max_delay == 7
+
+
+def test_make_data_splitter_error():
+    n = 10
+    X = pd.DataFrame({'col_0': list(range(n)),
+                      'target': list(range(n))})
+    y = X.pop('target')
+
+    with pytest.raises(ValueError, match="problem_configuration is required for time series problem types"):
+        make_data_splitter(X, y, ProblemTypes.TIME_SERIES_REGRESSION, n_splits=5, shuffle=False)
+    with pytest.raises(KeyError, match="Problem type 'XYZ' does not exist"):
+        make_data_splitter(X, y, 'XYZ', n_splits=5, shuffle=False)

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -1,9 +1,9 @@
 import pandas as pd
+import pytest
 from sklearn.model_selection import KFold, StratifiedKFold
 
-from evalml.automl.utils import make_data_splitter
+from evalml.automl.utils import make_data_splitter, _LARGE_DATA_ROW_THRESHOLD, _LARGE_DATA_PERCENT_VALIDATION
 
-from evalml import AutoMLSearch
 from evalml.automl.data_splitters import (
     TimeSeriesSplit,
     TrainingValidationSplit
@@ -11,10 +11,40 @@ from evalml.automl.data_splitters import (
 from evalml.problem_types import ProblemTypes
 
 
-def test_make_data_splitter():
-    X = pd.DataFrame({'col_0': list(range(10)),
-                      'target': list(range(10))})
+@pytest.mark.parametrize("problem_type", ProblemTypes.all_problem_types)
+@pytest.mark.parametrize("large_data", [False, True])
+def test_make_data_splitter_default(problem_type, large_data):
+    n = 10
+    if large_data:
+        n = _LARGE_DATA_ROW_THRESHOLD + 1
+    X = pd.DataFrame({'col_0': list(range(n)),
+                      'target': list(range(n))})
     y = X.pop('target')
-    data_splitter = make_data_splitter(X, y, ProblemTypes.REGRESSION)
-    assert isinstance(data_splitter, KFold)
-    assert data_splitter.n_splits == 3
+
+    problem_configuration = None
+    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+        problem_configuration = {'gap': 1, 'max_delay': 7}
+
+    data_splitter = make_data_splitter(X, y, problem_type, problem_configuration=problem_configuration)
+    if large_data:
+        assert isinstance(data_splitter, TrainingValidationSplit)
+        assert data_splitter.shuffle
+        assert data_splitter.test_size == _LARGE_DATA_PERCENT_VALIDATION
+        assert data_splitter.stratify == (problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
+        return
+
+    if problem_type == ProblemTypes.REGRESSION:
+        assert isinstance(data_splitter, KFold)
+        assert data_splitter.n_splits == 3
+        assert data_splitter.shuffle
+
+    if problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
+        assert isinstance(data_splitter, StratifiedKFold)
+        assert data_splitter.n_splits == 3
+        assert data_splitter.shuffle
+
+    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+        assert isinstance(data_splitter, TimeSeriesSplit)
+        assert data_splitter.n_splits == 3
+        assert data_splitter.gap == 1
+        assert data_splitter.max_delay == 7

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from sklearn.model_selection import KFold, StratifiedKFold
+
+from automl.utils import make_data_splitter
+
+from evalml import AutoMLSearch
+from evalml.automl.data_splitters import (
+    TimeSeriesSplit,
+    TrainingValidationSplit
+)
+
+
+def test_make_data_splitter():
+    X = pd.DataFrame({'col_0': list(range(10)),
+                      'target': list(range(10))})
+    y = X.pop('target')
+    data_splitter = make_data_splitter(X, y, 'regression')
+    assert isinstance(data_splitter, KFold)
+    assert data_splitter.n_splits == 3

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -1,19 +1,20 @@
 import pandas as pd
 from sklearn.model_selection import KFold, StratifiedKFold
 
-from automl.utils import make_data_splitter
+from evalml.automl.utils import make_data_splitter
 
 from evalml import AutoMLSearch
 from evalml.automl.data_splitters import (
     TimeSeriesSplit,
     TrainingValidationSplit
 )
+from evalml.problem_types import ProblemTypes
 
 
 def test_make_data_splitter():
     X = pd.DataFrame({'col_0': list(range(10)),
                       'target': list(range(10))})
     y = X.pop('target')
-    data_splitter = make_data_splitter(X, y, 'regression')
+    data_splitter = make_data_splitter(X, y, ProblemTypes.REGRESSION)
     assert isinstance(data_splitter, KFold)
     assert data_splitter.n_splits == 3

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -46,7 +46,7 @@ def test_make_data_splitter_default(problem_type, large_data):
         assert isinstance(data_splitter, TrainingValidationSplit)
         assert data_splitter.shuffle
         assert data_splitter.test_size == _LARGE_DATA_PERCENT_VALIDATION
-        assert data_splitter.stratify == (problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
+        assert data_splitter.stratify is None
         assert data_splitter.random_state == 0
         return
 

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -2,11 +2,14 @@ import pandas as pd
 import pytest
 from sklearn.model_selection import KFold, StratifiedKFold
 
-from evalml.automl.utils import make_data_splitter, _LARGE_DATA_ROW_THRESHOLD, _LARGE_DATA_PERCENT_VALIDATION
-
 from evalml.automl.data_splitters import (
     TimeSeriesSplit,
     TrainingValidationSplit
+)
+from evalml.automl.utils import (
+    _LARGE_DATA_PERCENT_VALIDATION,
+    _LARGE_DATA_ROW_THRESHOLD,
+    make_data_splitter
 )
 from evalml.problem_types import ProblemTypes
 

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -38,7 +38,9 @@ def test_make_data_splitter_default(problem_type, large_data):
     y = X.pop('target')
 
     problem_configuration = None
-    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION,
+                        ProblemTypes.TIME_SERIES_BINARY,
+                        ProblemTypes.TIME_SERIES_MULTICLASS]:
         problem_configuration = {'gap': 1, 'max_delay': 7}
 
     data_splitter = make_data_splitter(X, y, problem_type, problem_configuration=problem_configuration)
@@ -62,7 +64,9 @@ def test_make_data_splitter_default(problem_type, large_data):
         assert data_splitter.shuffle
         assert data_splitter.random_state == 0
 
-    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
+    if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION,
+                        ProblemTypes.TIME_SERIES_BINARY,
+                        ProblemTypes.TIME_SERIES_MULTICLASS]:
         assert isinstance(data_splitter, TimeSeriesSplit)
         assert data_splitter.n_splits == 3
         assert data_splitter.gap == 1
@@ -94,11 +98,12 @@ def test_make_data_splitter_parameters():
     assert not data_splitter.shuffle
     assert data_splitter.random_state == random_state
 
-    data_splitter = make_data_splitter(X, y, ProblemTypes.TIME_SERIES_REGRESSION, problem_configuration={'gap': 1, 'max_delay': 7}, n_splits=5, shuffle=False)
-    assert isinstance(data_splitter, TimeSeriesSplit)
-    assert data_splitter.n_splits == 5
-    assert data_splitter.gap == 1
-    assert data_splitter.max_delay == 7
+    for problem_type in [ProblemTypes.TIME_SERIES_REGRESSION, ProblemTypes.TIME_SERIES_BINARY, ProblemTypes.TIME_SERIES_MULTICLASS]:
+        data_splitter = make_data_splitter(X, y, problem_type, problem_configuration={'gap': 1, 'max_delay': 7}, n_splits=5, shuffle=False)
+        assert isinstance(data_splitter, TimeSeriesSplit)
+        assert data_splitter.n_splits == 5
+        assert data_splitter.gap == 1
+        assert data_splitter.max_delay == 7
 
 
 def test_make_data_splitter_error():

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -34,17 +34,20 @@ def test_make_data_splitter_default(problem_type, large_data):
         assert data_splitter.shuffle
         assert data_splitter.test_size == _LARGE_DATA_PERCENT_VALIDATION
         assert data_splitter.stratify == (problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
+        assert data_splitter.random_state == 0
         return
 
     if problem_type == ProblemTypes.REGRESSION:
         assert isinstance(data_splitter, KFold)
         assert data_splitter.n_splits == 3
         assert data_splitter.shuffle
+        assert data_splitter.random_state == 0
 
     if problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
         assert isinstance(data_splitter, StratifiedKFold)
         assert data_splitter.n_splits == 3
         assert data_splitter.shuffle
+        assert data_splitter.random_state == 0
 
     if problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
         assert isinstance(data_splitter, TimeSeriesSplit)
@@ -58,21 +61,25 @@ def test_make_data_splitter_parameters():
     X = pd.DataFrame({'col_0': list(range(n)),
                       'target': list(range(n))})
     y = X.pop('target')
+    random_state = 42
 
-    data_splitter = make_data_splitter(X, y, ProblemTypes.REGRESSION, n_splits=5, shuffle=False)
+    data_splitter = make_data_splitter(X, y, ProblemTypes.REGRESSION, n_splits=5, shuffle=False, random_state=random_state)
     assert isinstance(data_splitter, KFold)
     assert data_splitter.n_splits == 5
     assert not data_splitter.shuffle
+    assert data_splitter.random_state == random_state
 
-    data_splitter = make_data_splitter(X, y, ProblemTypes.BINARY, n_splits=5, shuffle=False)
+    data_splitter = make_data_splitter(X, y, ProblemTypes.BINARY, n_splits=5, shuffle=False, random_state=random_state)
     assert isinstance(data_splitter, StratifiedKFold)
     assert data_splitter.n_splits == 5
     assert not data_splitter.shuffle
+    assert data_splitter.random_state == random_state
 
-    data_splitter = make_data_splitter(X, y, ProblemTypes.MULTICLASS, n_splits=5, shuffle=False)
+    data_splitter = make_data_splitter(X, y, ProblemTypes.MULTICLASS, n_splits=5, shuffle=False, random_state=random_state)
     assert isinstance(data_splitter, StratifiedKFold)
     assert data_splitter.n_splits == 5
     assert not data_splitter.shuffle
+    assert data_splitter.random_state == random_state
 
     data_splitter = make_data_splitter(X, y, ProblemTypes.TIME_SERIES_REGRESSION, problem_configuration={'gap': 1, 'max_delay': 7}, n_splits=5, shuffle=False)
     assert isinstance(data_splitter, TimeSeriesSplit)

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -9,9 +9,22 @@ from evalml.automl.data_splitters import (
 from evalml.automl.utils import (
     _LARGE_DATA_PERCENT_VALIDATION,
     _LARGE_DATA_ROW_THRESHOLD,
+    get_default_primary_search_objective,
     make_data_splitter
 )
+from evalml.objectives import R2, LogLossBinary, LogLossMulticlass
 from evalml.problem_types import ProblemTypes
+
+
+def test_get_default_primary_search_objective():
+    assert isinstance(get_default_primary_search_objective("binary"), LogLossBinary)
+    assert isinstance(get_default_primary_search_objective(ProblemTypes.BINARY), LogLossBinary)
+    assert isinstance(get_default_primary_search_objective("multiclass"), LogLossMulticlass)
+    assert isinstance(get_default_primary_search_objective(ProblemTypes.MULTICLASS), LogLossMulticlass)
+    assert isinstance(get_default_primary_search_objective("regression"), R2)
+    assert isinstance(get_default_primary_search_objective(ProblemTypes.REGRESSION), R2)
+    with pytest.raises(KeyError, match="Problem type 'auto' does not exist"):
+        get_default_primary_search_objective("auto")
 
 
 @pytest.mark.parametrize("problem_type", ProblemTypes.all_problem_types)


### PR DESCRIPTION
Fix #1567 

Usage: configure automl search to use a different number of folds (splits) in CV
```python
random_state = 42
data_split = make_data_splitter(X, y, problem_type, n_splits=5, random_state=random_state)
automl = AutoMLSearch(problem_type=problem_type, data_split=data_split, random_state=random_state, ...)
...
```

Usage: disable shuffling
```python
random_state = 42
data_split = make_data_splitter(X, y, problem_type, shuffle=False, random_state=random_state)
automl = AutoMLSearch(problem_type=problem_type, data_split=data_split, random_state=random_state, ...)
...
```

I suppose we could simply add `n_splits` and `shuffle` to `AutoMLSearch.__init__`, but I wanted to keep us flexible on this a while longer. We'll be adding more heuristics to the data splitting logic here at some point and its nice exposing that.

Hmm, perhaps we need to rename "data_split" to "data_splitter" as well.