### PR TITLE
AutoMLSearch: rename "data_split" to "data_splitter"

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` :pr:`1597`
         * Update ``split_data`` helper args :pr:`1597`
         * Add problem type utils ``is_regression``, ``is_classification``, ``is_timeseries`` :pr:`1597`
+        * Rename ``AutoMLSearch`` ``data_split`` arg to ``data_splitter`` :pr:`1569`
     * Fixes
         * Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` :pr:`1490`
         * Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` :pr:`1494`
@@ -59,6 +60,7 @@ Release Notes
         * Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` :pr:`1597`
         * Update ``split_data`` helper args :pr:`1597`
         * Move data splitters from ``evalml.automl.data_splitters`` to ``evalml.preprocessing.data_splitters`` :pr:`1597`
+        * Rename ``AutoMLSearch`` ``data_split`` arg to ``data_splitter`` :pr:`1569`
 
 
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -265,7 +265,7 @@ class AutoMLSearch:
         self.y_train = _convert_to_woodwork_structure(y_train)
 
         default_data_splitter = make_data_splitter(self.X_train, self.y_train, self.problem_type, self.problem_configuration,
-                                                n_splits=3, shuffle=True, random_state=self.random_seed)
+                                                   n_splits=3, shuffle=True, random_state=self.random_seed)
         self.data_splitter = self.data_splitter or default_data_splitter
 
     def _validate_objective(self, objective):

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -81,7 +81,7 @@ class AutoMLSearch:
                  max_time=None,
                  patience=None,
                  tolerance=None,
-                 data_split=None,
+                 data_splitter=None,
                  allowed_pipelines=None,
                  allowed_model_families=None,
                  start_iteration_callback=None,
@@ -136,7 +136,7 @@ class AutoMLSearch:
                 to `multiclass` or `regression` depending on the problem type. Note that if allowed_pipelines is provided,
                 this parameter will be ignored.
 
-            data_split (sklearn.model_selection.BaseCrossValidator): Data splitting method to use. Defaults to StratifiedKFold.
+            data_splitter (sklearn.model_selection.BaseCrossValidator): Data splitting method to use. Defaults to StratifiedKFold.
 
             tuner_class: The tuner class to use. Defaults to SKOptTuner.
 
@@ -186,7 +186,7 @@ class AutoMLSearch:
         self.start_iteration_callback = start_iteration_callback
         self.add_result_callback = add_result_callback
         self.error_callback = error_callback or log_error_callback
-        self.data_split = data_split
+        self.data_splitter = data_splitter
         self.verbose = verbose
         self.optimize_thresholds = optimize_thresholds
         self.ensembling = ensembling
@@ -194,7 +194,7 @@ class AutoMLSearch:
             objective = get_default_primary_search_objective(self.problem_type.value)
         objective = get_objective(objective, return_instance=False)
         self.objective = self._validate_objective(objective)
-        if self.data_split is not None and not issubclass(self.data_split.__class__, BaseCrossValidator):
+        if self.data_splitter is not None and not issubclass(self.data_splitter.__class__, BaseCrossValidator):
             raise ValueError("Not a valid data splitter")
         if not objective.is_defined_for_problem_type(self.problem_type):
             raise ValueError("Given objective {} is not compatible with a {} problem.".format(self.objective.name, self.problem_type.value))
@@ -264,9 +264,9 @@ class AutoMLSearch:
         self.X_train = _convert_to_woodwork_structure(X_train)
         self.y_train = _convert_to_woodwork_structure(y_train)
 
-        default_data_split = make_data_splitter(self.X_train, self.y_train, self.problem_type, self.problem_configuration,
+        default_data_splitter = make_data_splitter(self.X_train, self.y_train, self.problem_type, self.problem_configuration,
                                                 n_splits=3, shuffle=True, random_state=self.random_seed)
-        self.data_split = self.data_split or default_data_split
+        self.data_splitter = self.data_splitter or default_data_splitter
 
     def _validate_objective(self, objective):
         non_core_objectives = get_non_core_objectives()
@@ -304,7 +304,7 @@ class AutoMLSearch:
             f"Allowed Pipelines: \n{_print_list(self.allowed_pipelines or [])}\n"
             f"Patience: {self.patience}\n"
             f"Tolerance: {self.tolerance}\n"
-            f"Data Splitting: {self.data_split}\n"
+            f"Data Splitting: {self.data_splitter}\n"
             f"Tuner: {self.tuner_class.__name__}\n"
             f"Start Iteration Callback: {_get_funct_name(self.start_iteration_callback)}\n"
             f"Add Result Callback: {_get_funct_name(self.add_result_callback)}\n"
@@ -609,7 +609,7 @@ class AutoMLSearch:
         logger.info("\tStarting cross validation")
         X_pd = _convert_woodwork_types_wrapper(self.X_train.to_dataframe())
         y_pd = _convert_woodwork_types_wrapper(self.y_train.to_series())
-        for i, (train, valid) in enumerate(self.data_split.split(X_pd, y_pd)):
+        for i, (train, valid) in enumerate(self.data_splitter.split(X_pd, y_pd)):
 
             if pipeline.model_family == ModelFamily.ENSEMBLE and i > 0:
                 # Stacked ensembles do CV internally, so we do not run CV here for performance reasons.

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -46,18 +46,18 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         sklearn.model_selection.BaseCrossValidator: data splitting method.
     """
     problem_type = handle_problem_types(problem_type)
-    data_split = None
+    data_splitter = None
     if problem_type == ProblemTypes.REGRESSION:
-        data_split = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
+        data_splitter = KFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-        data_split = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
+        data_splitter = StratifiedKFold(n_splits=n_splits, random_state=random_state, shuffle=shuffle)
     elif problem_type in [ProblemTypes.TIME_SERIES_REGRESSION,
                           ProblemTypes.TIME_SERIES_BINARY,
                           ProblemTypes.TIME_SERIES_MULTICLASS]:
         if not problem_configuration:
             raise ValueError("problem_configuration is required for time series problem types")
-        data_split = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
+        data_splitter = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
                                      max_delay=problem_configuration.get('max_delay'))
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
-        data_split = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
-    return data_split
+        data_splitter = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
+    return data_splitter

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -57,7 +57,7 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
         if not problem_configuration:
             raise ValueError("problem_configuration is required for time series problem types")
         data_splitter = TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
-                                     max_delay=problem_configuration.get('max_delay'))
+                                        max_delay=problem_configuration.get('max_delay'))
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
         data_splitter = TrainingValidationSplit(test_size=_LARGE_DATA_PERCENT_VALIDATION, shuffle=True)
     return data_splitter

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1918,8 +1918,8 @@ def test_automl_time_series_regression(mock_fit, mock_score, X_y_regression):
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 def test_automl_data_splitter_consistent(mock_binary_score, mock_binary_fit, mock_multi_score, mock_multi_fit,
-                                      mock_regression_score, mock_regression_fit, problem_type,
-                                      X_y_binary, X_y_multi, X_y_regression):
+                                         mock_regression_score, mock_regression_fit, problem_type,
+                                         X_y_binary, X_y_multi, X_y_regression):
     if problem_type == ProblemTypes.BINARY:
         X, y = X_y_binary
 

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -65,17 +65,17 @@ def test_get_pipeline_none(X_y_binary):
         automl.describe_pipeline(0)
 
 
-def test_data_split(X_y_binary):
+def test_data_splitter(X_y_binary):
     X, y = X_y_binary
     cv_folds = 5
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', data_split=StratifiedKFold(cv_folds), max_iterations=1,
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', data_splitter=StratifiedKFold(cv_folds), max_iterations=1,
                           n_jobs=1)
     automl.search()
 
     assert isinstance(automl.rankings, pd.DataFrame)
     assert len(automl.results['pipeline_results'][0]["cv_data"]) == cv_folds
 
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', data_split=TimeSeriesSplit(cv_folds), max_iterations=1,
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', data_splitter=TimeSeriesSplit(cv_folds), max_iterations=1,
                           n_jobs=1)
     automl.search()
 


### PR DESCRIPTION
Came up in #1568 , seemed like a nice clarification to make.

How I made this PR (on mac):
```bash
git grep -il "data_split" . | xargs sed -i '' -e "s/data_split/data_splitter/g"
git grep -il "data_splitterter" . | xargs sed -i '' -e "s/data_splitterter/data_splitter/g"
```