### PR TITLE
Fix Automl custom objective stack trace

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Pin scipy at < 1.6.0 while we work on adding support :pr:`1629`
         * Addressed stacked ensemble component for ``scikit-learn`` v0.24 support by setting ``shuffle=True`` for default CV :pr:`1613`
         * Fix bug where ``Imputer`` reset the index on ``X`` :pr:`1590`
+        * Fixed AutoMLSearch stacktrace when a cutom objective was passed in as a primary objective or additional objective :pr:`1575`
     * Changes
     * Documentation Changes
         * Updated docs to include information about ``AutoMLSearch`` callback parameters and methods :pr:`1577`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -31,7 +31,6 @@ from evalml.exceptions import (
 )
 from evalml.model_family import ModelFamily
 from evalml.objectives import (
-    get_all_objective_names,
     get_core_objectives,
     get_non_core_objectives,
     get_objective
@@ -211,6 +210,7 @@ class AutoMLSearch:
             additional_objectives = [get_objective(o) for o in additional_objectives]
         additional_objectives = [self._validate_objective(obj) for obj in additional_objectives]
         self.additional_objectives = additional_objectives
+        self.objective_name_to_class = {o.name: o for o in [self.objective] + self.additional_objectives}
 
         if not isinstance(max_time, (int, float, str, type(None))):
             raise TypeError(f"Parameter max_time must be a float, int, string or None. Received {type(max_time)} with value {str(max_time)}..")
@@ -631,15 +631,17 @@ class AutoMLSearch:
         return False
 
     @staticmethod
-    def _get_mean_cv_scores_for_all_objectives(cv_data):
+    def _get_mean_cv_scores_for_all_objectives(cv_data, objective_name_to_class):
         scores = defaultdict(int)
-        objective_names = set([name.lower() for name in get_all_objective_names()])
         n_folds = len(cv_data)
         for fold_data in cv_data:
             for field, value in fold_data['all_objective_scores'].items():
-                if field.lower() in objective_names:
+                # The 'all_objective_scores' field contains scores for all objectives
+                # but also fields like "# Training" and "# Testing", so we want to exclude them since
+                # they are not scores
+                if field in objective_name_to_class:
                     scores[field] += value
-        return {objective_name: float(score) / n_folds for objective_name, score in scores.items()}
+        return {objective: float(score) / n_folds for objective, score in scores.items()}
 
     def _compute_cv_scores(self, pipeline):
         start = time.time()
@@ -716,9 +718,10 @@ class AutoMLSearch:
         cv_score = cv_scores.mean()
 
         percent_better_than_baseline = {}
-        mean_cv_all_objectives = self._get_mean_cv_scores_for_all_objectives(cv_data)
+        mean_cv_all_objectives = self._get_mean_cv_scores_for_all_objectives(cv_data, self.objective_name_to_class)
         for obj_name in mean_cv_all_objectives:
-            objective_class = get_objective(obj_name)
+            objective_class = self.objective_name_to_class[obj_name]
+
             # In the event add_to_rankings is called before search _baseline_cv_scores will be empty so we will return
             # nan for the base score.
             percent_better = objective_class.calculate_percent_difference(mean_cv_all_objectives[obj_name],
@@ -736,7 +739,6 @@ class AutoMLSearch:
         if high_variance_cv_check_results["warnings"]:
             logger.warning(high_variance_cv_check_results["warnings"][0]["message"])
             high_variance_cv = True
-
         self._results['pipeline_results'][pipeline_id] = {
             "id": pipeline_id,
             "pipeline_name": pipeline_name,
@@ -785,7 +787,7 @@ class AutoMLSearch:
                 parameters = pipeline.parameters
 
                 if baseline:
-                    self._baseline_cv_scores = self._get_mean_cv_scores_for_all_objectives(evaluation_results["cv_data"])
+                    self._baseline_cv_scores = self._get_mean_cv_scores_for_all_objectives(evaluation_results["cv_data"], self.objective_name_to_class)
 
                 logger.debug('Adding results for pipeline {}\nparameters {}\nevaluation_results {}'.format(pipeline.name, parameters, evaluation_results))
                 self._add_result(trained_pipeline=pipeline,

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1289,15 +1289,18 @@ def test_percent_better_than_baseline_computed_for_all_objectives(mock_time_seri
         if CustomClassificationObjective.is_defined_for_problem_type(problem_type_enum):
             additional_objectives = [CustomClassificationObjective()]
         else:
-            additional_objectives = [CustomRegressionObjective()]
+            additional_objectives = [CustomRegressionObjective(), "Root Mean Squared Error"]
 
     core_objectives = get_core_objectives(problem_type)
     if additional_objectives:
         core_objectives = [get_default_primary_search_objective(problem_type_enum)] + additional_objectives
-    mock_scores = {obj.name: i for i, obj in enumerate(core_objectives)}
-    mock_baseline_scores = {obj.name: i + 1 for i, obj in enumerate(core_objectives)}
-    answer = {obj.name: obj.calculate_percent_difference(mock_scores[obj.name],
-                                                         mock_baseline_scores[obj.name]) for obj in core_objectives}
+    mock_scores = {get_objective(obj).name: i for i, obj in enumerate(core_objectives)}
+    mock_baseline_scores = {get_objective(obj).name: i + 1 for i, obj in enumerate(core_objectives)}
+    answer = {}
+    for obj in core_objectives:
+        obj_class = get_objective(obj)
+        answer[obj_class.name] = obj_class.calculate_percent_difference(mock_scores[obj_class.name],
+                                                                        mock_baseline_scores[obj_class.name])
 
     mock_score_1 = MagicMock(return_value=mock_scores)
     DummyPipeline.score = mock_score_1

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1305,7 +1305,7 @@ def test_percent_better_than_baseline_computed_for_all_objectives(mock_time_seri
     DummyPipeline.score = mock_score_1
 
     # specifying problem_configuration for all problem types for conciseness
-    automl = AutoMLSearch(problem_type=problem_type, max_iterations=2,
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type=problem_type, max_iterations=2,
                           allowed_pipelines=[DummyPipeline],
                           objective="auto", problem_configuration={'gap': 1, 'max_delay': 1},
                           additional_objectives=additional_objectives)

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import woodwork as ww
-from sklearn import metrics
 from sklearn.model_selection import KFold, StratifiedKFold
 
 from evalml import AutoMLSearch
@@ -1164,7 +1163,7 @@ class CustomClassificationObjective(ObjectiveBase):
     problem_types = [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]
 
     def objective_function(self, y_true, y_predicted, X=None):
-        return metrics.accuracy_score(y_true, y_predicted)
+        """Not implementing since mocked in our tests."""
 
 
 class CustomRegressionObjective(ObjectiveBase):
@@ -1176,7 +1175,7 @@ class CustomRegressionObjective(ObjectiveBase):
     problem_types = [ProblemTypes.REGRESSION, ProblemTypes.TIME_SERIES_REGRESSION]
 
     def objective_function(self, y_true, y_predicted, X=None):
-        return R2().objective_function(y_true, y_predicted, X=X)
+        """Not implementing since mocked in our tests."""
 
 
 @pytest.mark.parametrize("objective,pipeline_scores,baseline_score,problem_type_value",

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -35,7 +35,7 @@ from evalml.exceptions import (
     PipelineNotYetFittedError
 )
 from evalml.model_family import ModelFamily
-from evalml.objectives import R2, CostBenefitMatrix, FraudCost, ObjectiveBase
+from evalml.objectives import CostBenefitMatrix, FraudCost, ObjectiveBase
 from evalml.objectives.utils import get_core_objectives, get_objective
 from evalml.pipelines import (
     BinaryClassificationPipeline,

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -15,8 +15,8 @@ from evalml.objectives import (
     get_objective
 )
 from evalml.objectives.objective_base import ObjectiveBase
+from evalml.objectives.utils import _all_objectives_dict
 from evalml.problem_types import ProblemTypes
-from evalml.utils.gen_utils import _get_subclasses
 
 
 def test_create_custom_objective():
@@ -34,7 +34,7 @@ def test_create_custom_objective():
         MockNoObjectiveFunctionObjective()
 
 
-@pytest.mark.parametrize("obj", _get_subclasses(ObjectiveBase))
+@pytest.mark.parametrize("obj", _all_objectives_dict().values())
 def test_get_objective_works_for_names_of_defined_objectives(obj):
     assert get_objective(obj.name) == obj
     assert get_objective(obj.name.lower()) == obj


### PR DESCRIPTION
### Pull Request Description
Fixes #1572 

The issue is that `_compute_cv_scores` stores the objective scores in a dict keyed by the objective name (str). When we go to compute "percent better than baseline", we have to map the string name to an objective class. We were doing this mapping with `get_objective` which doesn't doesn't know about the class definition of a custom objective. 

The fix is to create a name to class mapping when AutoMLSearch is created.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
