### PR TITLE
Set random_state arg in Data Splitter

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,7 @@ Release Notes
         * Set max value for plotly and xgboost versions while we debug CI failures with newer versions :pr:`1532`
         * Undo version pinning for plotly :pr:`1533`
         * Fix ReadTheDocs build by updating the version of ``setuptools`` :pr:`1561`
+        * Set ``random_state`` of data splitter in AutoMLSearch to take int to keep consistency in the resulting splits :pr:``
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,7 +26,7 @@ Release Notes
         * Set max value for plotly and xgboost versions while we debug CI failures with newer versions :pr:`1532`
         * Undo version pinning for plotly :pr:`1533`
         * Fix ReadTheDocs build by updating the version of ``setuptools`` :pr:`1561`
-        * Set ``random_state`` of data splitter in AutoMLSearch to take int to keep consistency in the resulting splits :pr:``
+        * Set ``random_state`` of data splitter in AutoMLSearch to take int to keep consistency in the resulting splits :pr:`1579`
     * Changes
         * Update circleci badge to apply to ``main`` :pr:`1489`
         * Added script to generate github markdown for releases :pr:`1487`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -55,7 +55,7 @@ from evalml.pipelines.components.utils import get_estimators
 from evalml.pipelines.utils import make_pipeline
 from evalml.problem_types import ProblemTypes, handle_problem_types
 from evalml.tuners import SKOptTuner
-from evalml.utils import convert_to_seconds, get_random_state
+from evalml.utils import convert_to_seconds, get_random_seed, get_random_state
 from evalml.utils.gen_utils import (
     _convert_to_woodwork_structure,
     _convert_woodwork_types_wrapper
@@ -237,6 +237,7 @@ class AutoMLSearch:
             'errors': []
         }
         self.random_state = get_random_state(random_state)
+        self.random_seed = get_random_seed(self.random_state)
         self.n_jobs = n_jobs
 
         self.plot = None
@@ -379,9 +380,9 @@ class AutoMLSearch:
             X (DataFrame): Input dataframe to split
         """
         if self.problem_type == ProblemTypes.REGRESSION:
-            default_data_split = KFold(n_splits=3, random_state=self.random_state, shuffle=True)
+            default_data_split = KFold(n_splits=3, random_state=self.random_seed, shuffle=True)
         elif self.problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-            default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_state, shuffle=True)
+            default_data_split = StratifiedKFold(n_splits=3, random_state=self.random_seed, shuffle=True)
         elif self.problem_type in [ProblemTypes.TIME_SERIES_REGRESSION]:
             default_data_split = TimeSeriesSplit(n_splits=3, gap=self.problem_configuration['gap'],
                                                  max_delay=self.problem_configuration['max_delay'])

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1904,3 +1904,36 @@ def test_automl_time_series_regression(mock_fit, mock_score, X_y_regression):
             continue
         assert result['parameters']['Delayed Feature Transformer'] == configuration
         assert result['parameters']['pipeline'] == configuration
+
+
+@pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS, ProblemTypes.REGRESSION])
+@patch('evalml.pipelines.RegressionPipeline.fit')
+@patch('evalml.pipelines.RegressionPipeline.score')
+@patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
+@patch('evalml.pipelines.MulticlassClassificationPipeline.score')
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+@patch('evalml.pipelines.BinaryClassificationPipeline.score')
+def test_automl_data_split_consistent(mock_binary_score, mock_binary_fit, mock_multi_score, mock_multi_fit,
+                                      mock_regression_score, mock_regression_fit, problem_type,
+                                      X_y_binary, X_y_multi, X_y_regression):
+    if problem_type == ProblemTypes.BINARY:
+        X, y = X_y_binary
+
+    elif problem_type == ProblemTypes.MULTICLASS:
+        X, y = X_y_multi
+
+    elif problem_type == ProblemTypes.REGRESSION:
+        X, y = X_y_regression
+
+    data_splits = []
+    random_state = [0, 0, 1]
+    for state in random_state:
+        a = AutoMLSearch(problem_type=problem_type, random_state=state, max_iterations=1)
+        a.search(X, y)
+        data_splits.append([[set(train), set(test)] for train, test in a.data_split.split(X, y)])
+    # append split from last random state again, should be referencing same datasplit object
+    data_splits.append([[set(train), set(test)] for train, test in a.data_split.split(X, y)])
+
+    assert data_splits[0] == data_splits[1]
+    assert data_splits[1] != data_splits[2]
+    assert data_splits[2] == data_splits[3]


### PR DESCRIPTION
fix #1471 

By passing in an int rather than `np.random.RandomState`, we can ensure the resulting datasplits are equivalent so that the AutoMLSearch algorithm can accurately compare model performances. 