### PR TITLE
Component iteration in pipelines

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
         * Added support for list inputs for objectives :pr:`1663`
         * Added support for ``AutoMLSearch`` to handle time series classification pipelines :pr:`1666`
         * Enhanced ``DelayedFeaturesTransformer`` to encode categorical features and targets before delaying them :pr:`1691`
-        * Added direct iteration through components in pipelines :pr:`1583`
+        * Added ability to directly iterate through components within Pipelines :pr:`1571`
     * Fixes
         * Fixed inconsistent attributes and added Exceptions to docs :pr:`1673`
         * Fixed ``TargetLeakageDataCheck`` to use Woodwork ``mutual_information`` rather than using Pandas' Pearson Correlation :pr:`1616`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
         * Added support for list inputs for objectives :pr:`1663`
         * Added support for ``AutoMLSearch`` to handle time series classification pipelines :pr:`1666`
         * Enhanced ``DelayedFeaturesTransformer`` to encode categorical features and targets before delaying them :pr:`1691`
-        * Added ability to directly iterate through components within Pipelines :pr:`1571`
+        * Added ability to directly iterate through components within Pipelines :pr:`1583`
     * Fixes
         * Fixed inconsistent attributes and added Exceptions to docs :pr:`1673`
         * Fixed ``TargetLeakageDataCheck`` to use Woodwork ``mutual_information`` rather than using Pandas' Pearson Correlation :pr:`1616`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Added support for list inputs for objectives :pr:`1663`
         * Added support for ``AutoMLSearch`` to handle time series classification pipelines :pr:`1666`
         * Enhanced ``DelayedFeaturesTransformer`` to encode categorical features and targets before delaying them :pr:`1691`
+        * Integrated ``ComponentGraph`` class into Pipelines for full non-linear pipeline support :pr:`1543`
     * Fixes
         * Fixed inconsistent attributes and added Exceptions to docs :pr:`1673`
         * Fixed ``TargetLeakageDataCheck`` to use Woodwork ``mutual_information`` rather than using Pandas' Pearson Correlation :pr:`1616`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -113,7 +113,6 @@ Release Notes
         * Updated minimal dependencies: ``numpy>=1.19.1``, ``pandas>=1.1.0``, ``scikit-learn>=0.23.1``, ``scikit-optimize>=0.8.1``
         * Updated ``AutoMLSearch.best_pipeline`` to return a trained pipeline. Pass in ``train_best_pipeline=False`` to AutoMLSearch in order to return an untrained pipeline.
         * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
-        * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
         * Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` :pr:`1597`
         * Update ``split_data`` helper args :pr:`1597`
         * Move data splitters from ``evalml.automl.data_splitters`` to ``evalml.preprocessing.data_splitters`` :pr:`1597`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -50,6 +50,8 @@ Release Notes
 
     **Breaking Changes**
         * Removed ``has_searched`` property from ``AutoMLSearch`` :pr:`1647`
+        * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
+
 
 **v0.17.0 Dec. 29, 2020**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,7 +14,7 @@ Release Notes
         * Added support for list inputs for objectives :pr:`1663`
         * Added support for ``AutoMLSearch`` to handle time series classification pipelines :pr:`1666`
         * Enhanced ``DelayedFeaturesTransformer`` to encode categorical features and targets before delaying them :pr:`1691`
-        * Integrated ``ComponentGraph`` class into Pipelines for full non-linear pipeline support :pr:`1543`
+        * Added direct iteration through components in pipelines :pr:`1583`
     * Fixes
         * Fixed inconsistent attributes and added Exceptions to docs :pr:`1673`
         * Fixed ``TargetLeakageDataCheck`` to use Woodwork ``mutual_information`` rather than using Pandas' Pearson Correlation :pr:`1616`
@@ -50,7 +50,6 @@ Release Notes
 
     **Breaking Changes**
         * Removed ``has_searched`` property from ``AutoMLSearch`` :pr:`1647`
-        * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
 
 
 **v0.17.0 Dec. 29, 2020**
@@ -113,6 +112,7 @@ Release Notes
     **Breaking Changes**
         * Updated minimal dependencies: ``numpy>=1.19.1``, ``pandas>=1.1.0``, ``scikit-learn>=0.23.1``, ``scikit-optimize>=0.8.1``
         * Updated ``AutoMLSearch.best_pipeline`` to return a trained pipeline. Pass in ``train_best_pipeline=False`` to AutoMLSearch in order to return an untrained pipeline.
+        * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
         * Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` :pr:`1543`
         * Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` :pr:`1597`
         * Update ``split_data`` helper args :pr:`1597`

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -311,6 +311,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Alternatively, you can index directly into the pipeline to get a component"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_component = cp[0]\n",
+    "print(first_component.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nonlinear_cp['Final Estimator']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Pipeline Estimator\n",
     "\n",
     "EvalML enforces that the last component of a linear pipeline is an estimator. You can access this estimator directly by using `pipeline.estimator`."

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -352,6 +352,12 @@ class ComponentGraph:
             raise ValueError('The given graph has more than one final (childless) component')
         return compute_order
 
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            return self.get_component(self.compute_order[index])
+        else:
+            return self.get_component(index)
+
     def __iter__(self):
         self._i = 0
         return self

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -28,6 +28,7 @@ class ComponentGraph:
             self.component_instances[component_name] = component_class
         self.compute_order = self.generate_order(self.component_dict)
         self.input_feature_names = {}
+        self._i = 0
 
     @classmethod
     def from_list(cls, component_list, random_state=0):
@@ -365,4 +366,5 @@ class ComponentGraph:
             self._i += 1
             return self.get_component(self.compute_order[self._i - 1])
         else:
+            self._i = 0
             raise StopIteration

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -132,13 +132,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
     def __getitem__(self, index):
         if isinstance(index, slice):
             raise NotImplementedError('Slicing pipelines is currently not supported.')
-        elif isinstance(index, int):
-            component_name = self.component_graph[index]
-            if not isinstance(component_name, str):
-                component_name = component_name.name
-            return self.get_component(component_name)
-        else:
-            return self.get_component(index)
+        return self._component_graph[index]
 
     def __setitem__(self, index, value):
         raise NotImplementedError('Setting pipeline components is not supported.')

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -498,3 +498,9 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
 
         parameters_repr = ' '.join([f"'{component}':{{{repr_component(parameters)}}}," for component, parameters in self.parameters.items()])
         return f'{(type(self).__name__)}(parameters={{{parameters_repr}}})'
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._component_graph)

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -195,7 +195,7 @@ def generate_pipeline_code(element):
     if isinstance(element.component_graph, dict):
         raise ValueError("Code generation for nonlinear pipelines is not supported yet")
 
-    component_graph_string = ',\n\t\t'.join([com.__class__.__name__ if com.__class__ not in all_components() else "'{}'".format(com.name) for com in element._component_graph])
+    component_graph_string = ',\n\t\t'.join([com.__class__.__name__ if com.__class__ not in all_components() else "'{}'".format(com.name) for com in element])
     code_strings.append("from {} import {}".format(element.__class__.__bases__[0].__module__, element.__class__.__bases__[0].__name__))
     # check for other attributes associated with pipeline (ie name, custom_hyperparameters)
     pipeline_list = []

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -21,10 +21,7 @@ from evalml.pipelines import (
     TimeSeriesRegressionPipeline
 )
 from evalml.pipelines.components import (
-    DecisionTreeClassifier,
-    DecisionTreeRegressor,
     Estimator,
-    LogisticRegressionClassifier,
     StackedEnsembleClassifier,
     StackedEnsembleRegressor
 )
@@ -463,29 +460,6 @@ def stackable_regressors(helper_functions):
                 estimator_class.model_family != ModelFamily.ENSEMBLE):
             stackable_regressors.append(helper_functions.safe_init_component_with_njobs_1(estimator_class))
     return stackable_regressors
-
-
-@pytest.fixture
-def tree_estimators():
-    est_classifier_class = DecisionTreeClassifier()
-    est_regressor_class = DecisionTreeRegressor()
-    return est_classifier_class, est_regressor_class
-
-
-@pytest.fixture
-def fitted_tree_estimators(tree_estimators, X_y_binary, X_y_regression):
-    est_clf, est_reg = tree_estimators
-    X_b, y_b = X_y_binary
-    X_r, y_r = X_y_regression
-    est_clf.fit(X_b, y_b)
-    est_reg.fit(X_r, y_r)
-    return est_clf, est_reg
-
-
-@pytest.fixture
-def logit_estimator():
-    est_class = LogisticRegressionClassifier()
-    return est_class
 
 
 @pytest.fixture

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -463,6 +463,29 @@ def stackable_regressors(helper_functions):
 
 
 @pytest.fixture
+def tree_estimators():
+    est_classifier_class = DecisionTreeClassifier()
+    est_regressor_class = DecisionTreeRegressor()
+    return est_classifier_class, est_regressor_class
+
+
+@pytest.fixture
+def fitted_tree_estimators(tree_estimators, X_y_binary, X_y_regression):
+    est_clf, est_reg = tree_estimators
+    X_b, y_b = X_y_binary
+    X_r, y_r = X_y_regression
+    est_clf.fit(X_b, y_b)
+    est_reg.fit(X_r, y_r)
+    return est_clf, est_reg
+
+
+@pytest.fixture
+def logit_estimator():
+    est_class = LogisticRegressionClassifier()
+    return est_class
+
+
+@pytest.fixture
 def helper_functions():
     class Helpers:
         @staticmethod

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -21,7 +21,10 @@ from evalml.pipelines import (
     TimeSeriesRegressionPipeline
 )
 from evalml.pipelines.components import (
+    DecisionTreeClassifier,
+    DecisionTreeRegressor,
     Estimator,
+    LogisticRegressionClassifier,
     StackedEnsembleClassifier,
     StackedEnsembleRegressor
 )

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -27,6 +27,7 @@ from evalml.pipelines.components import (
     DateTimeFeaturizer,
     DelayedFeatureTransformer,
     DropNullColumns,
+    ElasticNetClassifier,
     Estimator,
     Imputer,
     LinearRegressor,
@@ -2339,6 +2340,7 @@ def test_generate_code_pipeline_custom():
     assert pipeline == expected_code
 
 
+<<<<<<< HEAD
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS, ProblemTypes.REGRESSION,
                                           ProblemTypes.TIME_SERIES_REGRESSION, ProblemTypes.TIME_SERIES_BINARY, ProblemTypes.TIME_SERIES_MULTICLASS])
 def test_predict_has_input_target_name(problem_type, X_y_binary, X_y_multi, X_y_regression, ts_data,
@@ -2374,3 +2376,42 @@ def test_predict_has_input_target_name(problem_type, X_y_binary, X_y_multi, X_y_
     else:
         predictions = clf.predict(X)
     assert predictions.name == "test target name"
+
+def test_linear_pipeline_iteration(logistic_regression_binary_pipeline_class):
+    expected_order = [Imputer(), OneHotEncoder(), StandardScaler(), LogisticRegressionClassifier()]
+
+    pipeline = logistic_regression_binary_pipeline_class({})
+    order = [c for c in pipeline]
+    order_again = [c for c in pipeline]
+
+    assert order == expected_order
+    assert order_again == expected_order
+
+    expected_order_params = [Imputer(numeric_impute_strategy='median'), OneHotEncoder(top_n=2), StandardScaler(), LogisticRegressionClassifier()]
+
+    pipeline = logistic_regression_binary_pipeline_class({'One Hot Encoder': {'top_n': 2}, 'Imputer': {'numeric_impute_strategy': 'median'}})
+    order_params = [c for c in pipeline]
+    order_again_params = [c for c in pipeline]
+
+    assert order_params == expected_order_params
+    assert order_again_params == expected_order_params
+
+
+def test_nonlinear_pipeline_iteration(nonlinear_binary_pipeline_class):
+    expected_order = [Imputer(), OneHotEncoder(), ElasticNetClassifier(), OneHotEncoder(), RandomForestClassifier(), LogisticRegressionClassifier()]
+
+    pipeline = nonlinear_binary_pipeline_class({})
+    order = [c for c in pipeline]
+    order_again = [c for c in pipeline]
+
+    assert order == expected_order
+    assert order_again == expected_order
+
+    expected_order_params = [Imputer(), OneHotEncoder(top_n=2), ElasticNetClassifier(), OneHotEncoder(top_n=5), RandomForestClassifier(), LogisticRegressionClassifier()]
+
+    pipeline = nonlinear_binary_pipeline_class({'OneHot_ElasticNet': {'top_n': 2}, 'OneHot_RandomForest': {'top_n': 5}})
+    order_params = [c for c in pipeline]
+    order_again_params = [c for c in pipeline]
+
+    assert order_params == expected_order_params
+    assert order_again_params == expected_order_params

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1881,6 +1881,57 @@ def test_nonlinear_pipeline_equality(pipeline_class):
         'Imputer': {
             "categorical_impute_strategy": "most_frequent",
             "numeric_impute_strategy": "mean",
+        }
+    }
+
+    different_parameters = {
+        'Imputer': {
+            "categorical_impute_strategy": "constant",
+            "numeric_impute_strategy": "mean",
+        }
+    }
+
+    class MockPipeline(pipeline_class):
+        name = "Mock Pipeline"
+        component_graph = ['Imputer', final_estimator]
+
+        def fit(self, X, y=None):
+            return self
+    # Test self-equality
+    mock_pipeline = MockPipeline(parameters={})
+    assert mock_pipeline == mock_pipeline
+
+    # Test defaults
+    assert MockPipeline(parameters={}) == MockPipeline(parameters={})
+
+    # Test random_state
+    assert MockPipeline(parameters={}, random_state=10) == MockPipeline(parameters={}, random_state=10)
+    assert MockPipeline(parameters={}, random_state=10) != MockPipeline(parameters={}, random_state=0)
+
+    # Test parameters
+    assert MockPipeline(parameters=parameters) != MockPipeline(parameters=different_parameters)
+
+    # Test fitted equality
+    X = pd.DataFrame({})
+    mock_pipeline.fit(X)
+    assert mock_pipeline != MockPipeline(parameters={})
+
+    mock_pipeline_equal = MockPipeline(parameters={})
+    mock_pipeline_equal.fit(X)
+    assert mock_pipeline == mock_pipeline_equal
+
+
+@pytest.mark.parametrize("pipeline_class", [BinaryClassificationPipeline, MulticlassClassificationPipeline, RegressionPipeline])
+def test_nonlinear_pipeline_equality(pipeline_class):
+    if pipeline_class in [BinaryClassificationPipeline, MulticlassClassificationPipeline]:
+        final_estimator = 'Random Forest Classifier'
+    else:
+        final_estimator = 'Random Forest Regressor'
+
+    parameters = {
+        'Imputer': {
+            "categorical_impute_strategy": "most_frequent",
+            "numeric_impute_strategy": "mean",
         },
         'OHE_1': {
             'top_n': 5

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2447,3 +2447,21 @@ def test_nonlinear_getitem(nonlinear_binary_pipeline_class):
     assert pipeline['OneHot_RandomForest'] == OneHotEncoder(top_n=4)
     assert pipeline['Random Forest'] == RandomForestClassifier()
     assert pipeline['Logistic Regression'] == LogisticRegressionClassifier()
+
+
+def test_get_component(logistic_regression_binary_pipeline_class, nonlinear_binary_pipeline_class):
+    pipeline = logistic_regression_binary_pipeline_class({'One Hot Encoder': {'top_n': 4}})
+
+    assert pipeline.get_component('Imputer') == Imputer()
+    assert pipeline.get_component('One Hot Encoder') == OneHotEncoder(top_n=4)
+    assert pipeline.get_component('Standard Scaler') == StandardScaler()
+    assert pipeline.get_component('Logistic Regression Classifier') == LogisticRegressionClassifier()
+
+    pipeline = nonlinear_binary_pipeline_class({'OneHot_RandomForest': {'top_n': 4}})
+
+    assert pipeline.get_component('Imputer') == Imputer()
+    assert pipeline.get_component('OneHot_ElasticNet') == OneHotEncoder()
+    assert pipeline.get_component('Elastic Net') == ElasticNetClassifier()
+    assert pipeline.get_component('OneHot_RandomForest') == OneHotEncoder(top_n=4)
+    assert pipeline.get_component('Random Forest') == RandomForestClassifier()
+    assert pipeline.get_component('Logistic Regression') == LogisticRegressionClassifier()

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -1882,57 +1882,6 @@ def test_nonlinear_pipeline_equality(pipeline_class):
         'Imputer': {
             "categorical_impute_strategy": "most_frequent",
             "numeric_impute_strategy": "mean",
-        }
-    }
-
-    different_parameters = {
-        'Imputer': {
-            "categorical_impute_strategy": "constant",
-            "numeric_impute_strategy": "mean",
-        }
-    }
-
-    class MockPipeline(pipeline_class):
-        name = "Mock Pipeline"
-        component_graph = ['Imputer', final_estimator]
-
-        def fit(self, X, y=None):
-            return self
-    # Test self-equality
-    mock_pipeline = MockPipeline(parameters={})
-    assert mock_pipeline == mock_pipeline
-
-    # Test defaults
-    assert MockPipeline(parameters={}) == MockPipeline(parameters={})
-
-    # Test random_state
-    assert MockPipeline(parameters={}, random_state=10) == MockPipeline(parameters={}, random_state=10)
-    assert MockPipeline(parameters={}, random_state=10) != MockPipeline(parameters={}, random_state=0)
-
-    # Test parameters
-    assert MockPipeline(parameters=parameters) != MockPipeline(parameters=different_parameters)
-
-    # Test fitted equality
-    X = pd.DataFrame({})
-    mock_pipeline.fit(X)
-    assert mock_pipeline != MockPipeline(parameters={})
-
-    mock_pipeline_equal = MockPipeline(parameters={})
-    mock_pipeline_equal.fit(X)
-    assert mock_pipeline == mock_pipeline_equal
-
-
-@pytest.mark.parametrize("pipeline_class", [BinaryClassificationPipeline, MulticlassClassificationPipeline, RegressionPipeline])
-def test_nonlinear_pipeline_equality(pipeline_class):
-    if pipeline_class in [BinaryClassificationPipeline, MulticlassClassificationPipeline]:
-        final_estimator = 'Random Forest Classifier'
-    else:
-        final_estimator = 'Random Forest Regressor'
-
-    parameters = {
-        'Imputer': {
-            "categorical_impute_strategy": "most_frequent",
-            "numeric_impute_strategy": "mean",
         },
         'OHE_1': {
             'top_n': 5
@@ -2375,6 +2324,7 @@ def test_predict_has_input_target_name(problem_type, X_y_binary, X_y_multi, X_y_
     else:
         predictions = clf.predict(X)
     assert predictions.name == "test target name"
+
 
 def test_linear_pipeline_iteration(logistic_regression_binary_pipeline_class):
     expected_order = [Imputer(), OneHotEncoder(), StandardScaler(), LogisticRegressionClassifier()]

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2340,7 +2340,6 @@ def test_generate_code_pipeline_custom():
     assert pipeline == expected_code
 
 
-<<<<<<< HEAD
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS, ProblemTypes.REGRESSION,
                                           ProblemTypes.TIME_SERIES_REGRESSION, ProblemTypes.TIME_SERIES_BINARY, ProblemTypes.TIME_SERIES_MULTICLASS])
 def test_predict_has_input_target_name(problem_type, X_y_binary, X_y_multi, X_y_regression, ts_data,

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -547,7 +547,7 @@ def test_describe(caplog, logistic_regression_binary_pipeline_class):
     assert "Model Family: Linear" in out
     assert "Number of features: " not in out
 
-    for component in lrp._component_graph:
+    for component in lrp:
         if component.hyperparameter_ranges:
             for parameter in component.hyperparameter_ranges:
                 assert parameter in out
@@ -563,7 +563,7 @@ def test_describe_nonlinear(caplog, nonlinear_binary_pipeline_class):
     assert "Model Family: Linear" in out
     assert "Number of features: " not in out
 
-    for component in nbpl._component_graph:
+    for component in nbpl:
         if component.hyperparameter_ranges:
             for parameter in component.hyperparameter_ranges:
                 assert parameter in out
@@ -581,7 +581,7 @@ def test_describe_fitted(X_y_binary, caplog, logistic_regression_binary_pipeline
     assert "Model Family: Linear" in out
     assert "Number of features: {}".format(X.shape[1]) in out
 
-    for component in lrp._component_graph:
+    for component in lrp:
         if component.hyperparameter_ranges:
             for parameter in component.hyperparameter_ranges:
                 assert parameter in out
@@ -599,7 +599,7 @@ def test_describe_nonlinear_fitted(X_y_binary, caplog, nonlinear_binary_pipeline
     assert "Model Family: Linear" in out
     assert "Number of features: 2" in out
 
-    for component in nbpl._component_graph:
+    for component in nbpl:
         if component.hyperparameter_ranges:
             for parameter in component.hyperparameter_ranges:
                 assert parameter in out
@@ -780,7 +780,7 @@ def test_multi_format_creation(X_y_binary):
 
     clf = TestPipeline(parameters=parameters)
     correct_components = [Imputer, OneHotEncoder, StandardScaler, LogisticRegressionClassifier]
-    for component, correct_components in zip(clf._component_graph, correct_components):
+    for component, correct_components in zip(clf, correct_components):
         assert isinstance(component, correct_components)
     assert clf.model_family == ModelFamily.LINEAR_MODEL
 
@@ -808,7 +808,7 @@ def test_multiple_feature_selectors(X_y_binary):
 
     clf = TestPipeline(parameters={"Logistic Regression Classifier": {"n_jobs": 1}})
     correct_components = [Imputer, OneHotEncoder, RFClassifierSelectFromModel, StandardScaler, RFClassifierSelectFromModel, LogisticRegressionClassifier]
-    for component, correct_components in zip(clf._component_graph, correct_components):
+    for component, correct_components in zip(clf, correct_components):
         assert isinstance(component, correct_components)
     assert clf.model_family == ModelFamily.LINEAR_MODEL
 

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -386,8 +386,8 @@ def test_make_pipeline_from_components(X_y_binary, logistic_regression_binary_pi
     est = RandomForestClassifier(random_state=7)
     pipeline = make_pipeline_from_components([imp, est], ProblemTypes.BINARY, custom_name='My Pipeline',
                                              random_state=15)
-    assert [c.__class__ for c in pipeline._component_graph] == [Imputer, RandomForestClassifier]
-    assert [check_random_state_equality(c.random_state, np.random.RandomState(15)) for c in pipeline._component_graph]
+    assert [c.__class__ for c in pipeline] == [Imputer, RandomForestClassifier]
+    assert [check_random_state_equality(c.random_state, np.random.RandomState(15)) for c in pipeline]
     assert pipeline.problem_type == ProblemTypes.BINARY
     assert pipeline.custom_name == 'My Pipeline'
     expected_parameters = {
@@ -411,7 +411,7 @@ def test_make_pipeline_from_components(X_y_binary, logistic_regression_binary_pi
         parameters = {'bar': 'baz'}
     random_state = np.random.RandomState(42)
     pipeline = make_pipeline_from_components([DummyEstimator(random_state=3)], ProblemTypes.BINARY, random_state=random_state)
-    components_list = [c for c in pipeline._component_graph]
+    components_list = [c for c in pipeline]
     assert len(components_list) == 1
     assert isinstance(components_list[0], DummyEstimator)
     assert check_random_state_equality(components_list[0].random_state, random_state)
@@ -422,7 +422,7 @@ def test_make_pipeline_from_components(X_y_binary, logistic_regression_binary_pi
     X, y = X_y_binary
     pipeline = logistic_regression_binary_pipeline_class(parameters={"Logistic Regression Classifier": {"n_jobs": 1}},
                                                          random_state=np.random.RandomState(42))
-    component_instances = [c for c in pipeline._component_graph]
+    component_instances = [c for c in pipeline]
     new_pipeline = make_pipeline_from_components(component_instances, ProblemTypes.BINARY)
     pipeline.fit(X, y)
     predictions = pipeline.predict(X)

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2415,3 +2415,35 @@ def test_nonlinear_pipeline_iteration(nonlinear_binary_pipeline_class):
 
     assert order_params == expected_order_params
     assert order_again_params == expected_order_params
+
+
+def test_linear_getitem(logistic_regression_binary_pipeline_class):
+    pipeline = logistic_regression_binary_pipeline_class({'One Hot Encoder': {'top_n': 4}})
+
+    assert pipeline[0] == Imputer()
+    assert pipeline[1] == OneHotEncoder(top_n=4)
+    assert pipeline[2] == StandardScaler()
+    assert pipeline[3] == LogisticRegressionClassifier()
+
+    assert pipeline['Imputer'] == Imputer()
+    assert pipeline['One Hot Encoder'] == OneHotEncoder(top_n=4)
+    assert pipeline['Standard Scaler'] == StandardScaler()
+    assert pipeline['Logistic Regression Classifier'] == LogisticRegressionClassifier()
+
+
+def test_nonlinear_getitem(nonlinear_binary_pipeline_class):
+    pipeline = nonlinear_binary_pipeline_class({'OneHot_RandomForest': {'top_n': 4}})
+
+    assert pipeline[0] == Imputer()
+    assert pipeline[1] == OneHotEncoder()
+    assert pipeline[2] == ElasticNetClassifier()
+    assert pipeline[3] == OneHotEncoder(top_n=4)
+    assert pipeline[4] == RandomForestClassifier()
+    assert pipeline[5] == LogisticRegressionClassifier()
+
+    assert pipeline['Imputer'] == Imputer()
+    assert pipeline['OneHot_ElasticNet'] == OneHotEncoder()
+    assert pipeline['Elastic Net'] == ElasticNetClassifier()
+    assert pipeline['OneHot_RandomForest'] == OneHotEncoder(top_n=4)
+    assert pipeline['Random Forest'] == RandomForestClassifier()
+    assert pipeline['Logistic Regression'] == LogisticRegressionClassifier()


### PR DESCRIPTION
Closes #1571 

~Obviously I'm not going to get this in before I leave today, but I had the time so I did what I could~

### Context since this is an old branch:
This PR addresses a breaking change made in #1543. Prior to #1543, the documented way to iterate through component instances was `[c for c in pipeline.component_graph]`. However, #1543 made it so that the `component_graph` attribute only lists the classes, not the instances. Rather than having users iterate through the private `_component_graph` attribute, we add a "public" accessor by making the pipelines iterable.

This PR accomplishes that by:
1. Adding `__iter__` and `__next__` method to pipelines (as opposed to relying on `__getitem__`)
2. Updating how we iterate through pipelines in code and docs. Let me know if I missed a spot hehe