### PR TITLE
Fix bug where Imputer changes index of X

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
         * Updated ``load_data`` to return Woodwork structures and update default parameter value for ``index`` to ``None`` :pr:`1610`
         * Pin scipy at < 1.6.0 while we work on adding support :pr:`1629`
         * Addressed stacked ensemble component for ``scikit-learn`` v0.24 support by setting ``shuffle=True`` for default CV :pr:`1613`
+        * Fix bug where ``Imputer`` reset the index on ``X`` :pr:`1590`
     * Changes
     * Documentation Changes
         * Updated docs to include information about ``AutoMLSearch`` callback parameters and methods :pr:`1577`

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -100,16 +100,19 @@ class Imputer(Transformer):
 
         X_null_dropped = X.copy()
         X_null_dropped.drop(self._all_null_cols, inplace=True, axis=1, errors='ignore')
-        X_null_dropped.reset_index(inplace=True, drop=True)
         if X_null_dropped.empty:
             return X_null_dropped
 
         if self._numeric_cols is not None and len(self._numeric_cols) > 0:
             X_numeric = X_null_dropped[self._numeric_cols]
-            X_null_dropped[X_numeric.columns] = self._numeric_imputer.transform(X_numeric)
+            imputed = self._numeric_imputer.transform(X_numeric)
+            imputed.index = X_null_dropped.index
+            X_null_dropped[X_numeric.columns] = imputed
 
         if self._categorical_cols is not None and len(self._categorical_cols) > 0:
             X_categorical = X_null_dropped[self._categorical_cols]
-            X_null_dropped[X_categorical.columns] = self._categorical_imputer.transform(X_categorical)
+            imputed = self._categorical_imputer.transform(X_categorical)
+            imputed.index = X_null_dropped.index
+            X_null_dropped[X_categorical.columns] = imputed
 
         return X_null_dropped

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -199,32 +199,30 @@ def test_imputer_empty_data(data_type):
     imputer = Imputer()
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
-    assert_frame_equal(transformed, expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False, check_index_type=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed, expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False, check_index_type=False)
 
 
-def test_imputer_resets_index():
-    X = pd.DataFrame({'input_val': np.arange(10), 'target': np.arange(10)})
+def test_imputer_does_not_reset_index():
+    X = pd.DataFrame({'input_val': np.arange(10), 'target': np.arange(10),
+                      'input_cat': ['a'] * 7 + ['b'] * 3})
     X.loc[5, 'input_val'] = np.nan
+    X.loc[5, 'input_cat'] = np.nan
     assert X.index.tolist() == list(range(10))
 
     X.drop(0, inplace=True)
     y = X.pop('target')
-    pd.testing.assert_frame_equal(X,
-                                  pd.DataFrame({'input_val': [1.0, 2, 3, 4, np.nan, 6, 7, 8, 9]},
-                                               dtype=float,
-                                               index=list(range(1, 10))))
 
     imputer = Imputer()
     imputer.fit(X, y=y)
     transformed = imputer.transform(X)
     pd.testing.assert_frame_equal(transformed,
-                                  pd.DataFrame({'input_val': [1.0, 2, 3, 4, 5, 6, 7, 8, 9]},
-                                               dtype=float,
-                                               index=list(range(0, 9))))
+                                  pd.DataFrame({'input_val': [1.0, 2, 3, 4, 5, 6, 7, 8, 9],
+                                                'input_cat': pd.Categorical(['a'] * 6 + ['b'] * 3)},
+                                               index=list(range(1, 10))))
 
 
 def test_imputer_fill_value(imputer_test_data):

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -187,11 +187,11 @@ def test_imputer_empty_data(data_type):
     if data_type == 'pd':
         X = pd.DataFrame()
         y = pd.Series()
-        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
     elif data_type == 'ww':
         X = ww.DataTable(pd.DataFrame())
         y = ww.DataColumn(pd.Series())
-        expected = pd.DataFrame(index=pd.Int64Index([]), columns=pd.Index([]))
+        expected = pd.DataFrame(index=pd.Index([]), columns=pd.Index([]))
     else:
         X = np.array([[]])
         y = np.array([])
@@ -199,11 +199,11 @@ def test_imputer_empty_data(data_type):
     imputer = Imputer()
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
-    assert_frame_equal(transformed, expected, check_dtype=False, check_index_type=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed, expected, check_dtype=False, check_index_type=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_imputer_does_not_reset_index():


### PR DESCRIPTION
### Pull Request Description
Fix #1442 

This has caused two confusing bugs already when the input data have custom indices:
1. TargetEncoder not being able to fit: https://github.com/alteryx/evalml/pull/1401#discussion_r523162379
2. DelayedFeatureTransformer adds nans when X and y have different indices (ran into this during the blitz for time series performance tests)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
