### PR TITLE
Pin sklearn version

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.19.1
 pandas>=1.1.0
 scipy>=1.2.1
-scikit-learn>=0.23.1
+scikit-learn>=0.23.1,<0.24.0
 scikit-optimize>=0.8.1
 colorama
 cloudpickle>=0.2.2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -29,6 +29,7 @@ Release Notes
         * Undo version pinning for plotly :pr:`1533`
         * Fix ReadTheDocs build by updating the version of ``setuptools`` :pr:`1561`
         * Set ``random_state`` of data splitter in AutoMLSearch to take int to keep consistency in the resulting splits :pr:`1579`
+        * Pin sklearn version while we work on adding support :pr:`1594`
     * Changes
         * Reverting ``save_graph`` :pr:`1550` to resolve kaleido build issues :pr:`1585`
         * Update circleci badge to apply to ``main`` :pr:`1489`


### PR DESCRIPTION
Update-deps bot shows that upgrading to sklearn 0.24.0 breaks the stacked ensembler.

#1592 tracks the bugfix which will unblock usage of sklearn 0.24.0. Then #1593 tracks un-capping the sklearn version.