### PR TITLE
Release v0.17.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,14 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.17.0 Dec. 29, 2020**
+    * Enhancements
         * Added ``save_plot`` that allows for saving figures from different backends :pr:`1588`
         * Added ``LightGBM Regressor`` to regression components :pr:`1459`
         * Added ``visualize_decision_tree`` for tree visualization with ``decision_tree_data_from_estimator`` and ``decision_tree_data_from_pipeline`` to reformat tree structure output :pr:`1511`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.16.1'
+__version__ = '0.17.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.16.1',
+    version='0.17.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.17.0 Dec. 29, 2020
### Enhancements
- Added ``save_plot`` that allows for saving figures from different backends #1588
- Added ``LightGBM Regressor`` to regression components #1459
- Added ``visualize_decision_tree`` for tree visualization with ``decision_tree_data_from_estimator`` and ``decision_tree_data_from_pipeline`` to reformat tree structure output #1511
- Added `DFS Transformer` component into transformer components #1454
- Added ``MAPE`` to the standard metrics for time series problems and update objectives #1510
- Added ``graph_prediction_vs_actual_over_time`` and ``get_prediction_vs_actual_over_time_data`` to the model understanding module for time series problems #1483
- Added a ``ComponentGraph`` class that will support future pipelines as directed acyclic graphs #1415
- Updated data checks to accept ``Woodwork`` data structures #1481
- Added parameter to ``InvalidTargetDataCheck`` to show only top unique values rather than all unique values #1485
- Added multicollinearity data check #1515
- Added baseline pipeline and components for time series regression problems #1496
- Added more information to users about ensembling behavior in ``AutoMLSearch`` #1527
- Add woodwork support for more utility and graph methods #1544
- Changed ``DateTimeFeaturizer`` to encode features as int #1479
- Return trained pipelines from ``AutoMLSearch.best_pipeline`` #1547
- Added utility method so that users can set feature types without having to learn about Woodwork directly #1555
- Added Linear Discriminant Analysis transformer for dimensionality reduction #1331
- Added multiclass support for ``partial_dependence`` and ``graph_partial_dependence`` #1554
- Added ``TimeSeriesBinaryClassificationPipeline`` and ``TimeSeriesMulticlassClassificationPipeline`` classes #1528
- Added ``make_data_splitter`` method for easier automl data split customization #1568
- Integrated ``ComponentGraph`` class into Pipelines for full non-linear pipeline support #1543
- Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` #1597
- Update ``split_data`` helper args #1597
- Add problem type utils ``is_regression``, ``is_classification``, ``is_timeseries`` #1597
- Rename ``AutoMLSearch`` ``data_split`` arg to ``data_splitter`` #1569
### Fixes
- Fix Windows CI jobs: install ``numba`` via conda, required for ``shap`` #1490
- Added custom-index support for `reset-index-get_prediction_vs_actual_over_time_data` #1494
- Fix ``generate_pipeline_code`` to account for boolean and None differences between Python and JSON #1524 #1531
- Set max value for plotly and xgboost versions while we debug CI failures with newer versions #1532
- Undo version pinning for plotly #1533
- Fix ReadTheDocs build by updating the version of ``setuptools`` #1561
- Set ``random_state`` of data splitter in AutoMLSearch to take int to keep consistency in the resulting splits #1579
- Pin sklearn version while we work on adding support #1594
- Pin pandas at <1.2.0 while we work on adding support #1609
- Pin graphviz at < 0.16 while we work on adding support #1609
### Changes
- Reverting ``save_graph`` #1550 to resolve kaleido build issues #1585
- Update circleci badge to apply to ``main`` #1489
- Added script to generate github markdown for releases #1487
- Updated dependencies to fix ``ImportError: cannot import name 'MaskedArray' from 'sklearn.utils.fixes'`` error and to address Woodwork and Featuretool dependencies #1540
- Made ``get_prediction_vs_actual_data()`` a public method #1553
- Updated ``Woodwork`` version requirement to v0.0.7 #1560
- Move data splitters from ``evalml.automl.data_splitters`` to ``evalml.preprocessing.data_splitters`` #1597
- Rename "# Testing" in automl log output to "# Validation" #1597
### Documentation Changes
- Added partial dependence methods to API reference #1537
- Updated documentation for confusion matrix methods #1611
### Testing Changes
- Set ``n_jobs=1`` in most unit tests to reduce memory #1505
### Breaking Changes
- Updated minimal dependencies: ``numpy>=1.19.1``, ``pandas>=1.1.0``, ``scikit-learn>=0.23.1``, ``scikit-optimize>=0.8.1``
- Updated ``AutoMLSearch.best_pipeline`` to return a trained pipeline. Pass in ``train_best_pipeline=False`` to AutoMLSearch in order to return an untrained pipeline.
- Pipeline component instances can no longer be iterated through using ``Pipeline.component_graph`` #1543
- Update ``AutoMLSearch`` constructor to take training data instead of ``search`` and ``add_to_leaderboard`` #1597
- Update ``split_data`` helper args #1597
- Move data splitters from ``evalml.automl.data_splitters`` to ``evalml.preprocessing.data_splitters`` #1597
- Rename ``AutoMLSearch`` ``data_split`` arg to ``data_splitter`` #1569
