### PR TITLE
Move thresholding pipelines in release notes

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Fix thresholding for pipelines in AutoMLSearch to only threshold binary classification pipelines :pr:`1622` :pr:``
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -47,7 +48,6 @@ Release Notes
         * Pin sklearn version while we work on adding support :pr:`1594`
         * Pin pandas at <1.2.0 while we work on adding support :pr:`1609`
         * Pin graphviz at < 0.16 while we work on adding support :pr:`1609`
-        * Fix thresholding for pipelines in AutoMLSearch to only threshold binary classification pipelines :pr:`1622`
     * Changes
         * Reverting ``save_graph`` :pr:`1550` to resolve kaleido build issues :pr:`1585`
         * Update circleci badge to apply to ``main`` :pr:`1489`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Fix thresholding for pipelines in AutoMLSearch to only threshold binary classification pipelines :pr:`1622` :pr:``
+        * Fix thresholding for pipelines in AutoMLSearch to only threshold binary classification pipelines :pr:`1622` :pr:`1626`
     * Changes
     * Documentation Changes
     * Testing Changes


### PR DESCRIPTION
Fixing the release notes to put the thresholding pipelines PR into the `future releases` section of the release notes