### PR TITLE
Cap scipy<1.6.0

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.1
 pandas>=1.1.0,<1.2.0
-scipy>=1.2.1
+scipy>=1.2.1,<1.6.0
 scikit-learn>=0.23.1,<0.24.0
 scikit-optimize>=0.8.1
 colorama

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Fixes
         * Fix thresholding for pipelines in AutoMLSearch to only threshold binary classification pipelines :pr:`1622` :pr:`1626`
         * Updated ``load_data`` to return Woodwork structures and update default parameter value for ``index`` to ``None`` :pr:`1610`
+        * Pin scipy at < 1.6.0 while we work on adding support :pr:`1629`
     * Changes
     * Documentation Changes
         * Updated docs to include information about ``AutoMLSearch`` callback parameters and methods :pr:`1577`


### PR DESCRIPTION
Latest scipy update breaks main (#1628) so capping scipy so we can address separately.