### PR TITLE
Limiting fraud dataset to speed up doc builds

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
         * Addressed stacked ensemble component for ``scikit-learn`` v0.24 support by setting ``shuffle=True`` for default CV :pr:`1613`
         * Fix bug where ``Imputer`` reset the index on ``X`` :pr:`1590`
         * Fixed AutoMLSearch stacktrace when a cutom objective was passed in as a primary objective or additional objective :pr:`1575`
-        * Limit ``load_fraud`` dataset loaded into ``automl.ipynb`` :pr:``
+        * Limit ``load_fraud`` dataset loaded into ``automl.ipynb`` :pr:`1646`
     * Changes
     * Documentation Changes
         * Updated docs to include information about ``AutoMLSearch`` callback parameters and methods :pr:`1577`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Addressed stacked ensemble component for ``scikit-learn`` v0.24 support by setting ``shuffle=True`` for default CV :pr:`1613`
         * Fix bug where ``Imputer`` reset the index on ``X`` :pr:`1590`
         * Fixed AutoMLSearch stacktrace when a cutom objective was passed in as a primary objective or additional objective :pr:`1575`
+        * Limit ``load_fraud`` dataset loaded into ``automl.ipynb`` :pr:``
     * Changes
     * Documentation Changes
         * Updated docs to include information about ``AutoMLSearch`` callback parameters and methods :pr:`1577`

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "__Note:__ To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
     "\n",
-    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you’d like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method as follows. The `infer_feature_types` utility method takes pandas or numpy input and converts it to a Woodwork data structure. It takes in a `feature_types` parameter which can be used to specify what types specific columns should be. In the example below, we specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
+    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you\u2019d like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method as follows. The `infer_feature_types` utility method takes pandas or numpy input and converts it to a Woodwork data structure. It takes in a `feature_types` parameter which can be used to specify what types specific columns should be. In the example below, we specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
    ]
   },
   {
@@ -466,7 +466,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -47,7 +47,7 @@
    "source": [
     "__Note:__ To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
     "\n",
-    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you\u2019d like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method as follows. The `infer_feature_types` utility method takes pandas or numpy input and converts it to a Woodwork data structure. It takes in a `feature_types` parameter which can be used to specify what types specific columns should be. In the example below, we specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
+    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you’d like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method as follows. The `infer_feature_types` utility method takes pandas or numpy input and converts it to a Woodwork data structure. It takes in a `feature_types` parameter which can be used to specify what types specific columns should be. In the example below, we specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
    ]
   },
   {
@@ -58,7 +58,7 @@
    "source": [
     "import evalml\n",
     "from evalml.utils import infer_feature_types\n",
-    "X, y = evalml.demos.load_fraud(return_pandas=True)\n",
+    "X, y = evalml.demos.load_fraud(n_rows=1000, return_pandas=True)\n",
     "X = infer_feature_types(X, feature_types={'provider': 'categorical'})"
    ]
   },
@@ -211,9 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "## start_iteration_callback example function\n",
@@ -232,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "## add_result_callback example function\n",
@@ -425,9 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "X, y = evalml.demos.load_breast_cancer()\n",
@@ -472,7 +466,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Testing to see whether or not limiting the fraud dataset will cause the doc builds to pass

Notebook builds passed [here](https://readthedocs.com/projects/feature-labs-inc-evalml/builds/523373/) and [here](https://readthedocs.com/projects/feature-labs-inc-evalml/builds/523322/), and doc example is [here](https://evalml.alteryx.com/en/bc_fix_notebooks/user_guide/automl.html)