### PR TITLE
Support graphviz version 0.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate curr_py
-              conda install python-graphviz=0.15 -q -y
+              conda install python-graphviz -q -y
       - run:
           name: Install numba (for shap)
           command: |

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added RMSLE, MSLE, and MAPE to core objectives while checking for negative target values in ``invalid_targets_data_check`` :pr:`1574`
         * Added time series support for ``make_pipeline`` :pr:`1566`
         * Added multiclass check to ``InvalidTargetDataCheck`` for two examples per class :pr:`1596`
+        * Support graphviz 0.16 :pr:`1657`
     * Fixes
         * Fixed thresholding for pipelines in ``AutoMLSearch`` to only threshold binary classification pipelines :pr:`1622` :pr:`1626`
         * Updated ``load_data`` to return Woodwork structures and update default parameter value for ``index`` to ``None`` :pr:`1610`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -3,7 +3,7 @@ click==7.1.2
 cloudpickle==1.6.0
 colorama==0.4.4
 featuretools==0.23.0
-graphviz==0.15
+graphviz==0.16
 ipywidgets==7.6.2
 kaleido==0.1.0
 lightgbm==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ xgboost>=0.82,<1.3.0
 catboost>=0.20
 lightgbm>=2.3.1
 matplotlib>=3.3.3
-graphviz>=0.13,<0.16
+graphviz>=0.13
 seaborn>=0.11.1
 category_encoders>=2.0.0


### PR DESCRIPTION
Fixes #1617

New build of the conda version of graphviz 0.16 works with windows, should fix the test errors.