### PR TITLE
InvalidDataTargetCheck additions

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Added RMSLE, MSLE, and MAPE to core objectives while checking for negative target values in ``invalid_targets_data_check`` :pr:`1574`
+        * Added validation checks for binary problems with regression-like datasets and multiclass problems without true multiclass targets in ``invalid_targets_data_check`` :pr:`1665`
         * Added time series support for ``make_pipeline`` :pr:`1566`
         * Added target name for output of pipeline ``predict`` method :pr:`1578`
         * Added multiclass check to ``InvalidTargetDataCheck`` for two examples per class :pr:`1596`

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -31,7 +31,7 @@ class DataCheckMessageCode(Enum):
     TARGET_MULTICLASS_NOT_ENOUGH_CLASSES = "target_multiclass_not_enough_classes"
     """Message code for target data for a multi classification problem that does not have more than two unique classes."""
 
-    TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING = "target_multiclass_high_unique_class_warning"
+    TARGET_MULTICLASS_HIGH_UNIQUE_CLASS = "target_multiclass_high_unique_class_warning"
     """Message code for target data for a multi classification problem that has an abnormally large number of unique classes relative to the number of target values."""
 
     HIGH_VARIANCE = "high_variance"

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -28,6 +28,12 @@ class DataCheckMessageCode(Enum):
     TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS = "target_multiclass_not_two_examples_per_class"
     """Message code for target data for a multi classification problem that does not have two examples per class."""
 
+    TARGET_MULTICLASS_NOT_ENOUGH_CLASSES = "target_multiclass_not_enough_classes"
+    """Message code for target data for a multi classification problem that does not have more than two unique classes."""
+
+    TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING = "target_multiclass_high_unique_class_warning"
+    """Message code for target data for a multi classification problem that has an abnormally large number of unique classes relative to the number of target values."""
+
     HIGH_VARIANCE = "high_variance"
     """Message code for when high variance is detected for cross-validation."""
 

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -1,5 +1,5 @@
-import woodwork as ww
 import pandas as pd
+import woodwork as ww
 
 from evalml.data_checks import (
     DataCheck,
@@ -16,6 +16,7 @@ from evalml.utils.gen_utils import (
 )
 
 MULTICLASS_CONTINUOUS_THRESHOLD = .05
+
 
 class InvalidTargetDataCheck(DataCheck):
     """Checks if the target data contains missing or invalid values."""
@@ -118,7 +119,7 @@ class InvalidTargetDataCheck(DataCheck):
                     message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_ENOUGH_CLASSES,
                     details=details).to_dict())
 
-            num_class_to_num_value_ratio = len(unique_values)/len(y)
+            num_class_to_num_value_ratio = len(unique_values) / len(y)
             if num_class_to_num_value_ratio >= MULTICLASS_CONTINUOUS_THRESHOLD:
                 details = {"class_to_value_ratio": num_class_to_num_value_ratio}
                 messages["warnings"].append(DataCheckWarning(
@@ -126,7 +127,6 @@ class InvalidTargetDataCheck(DataCheck):
                     data_check_name=self.name,
                     message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
                     details=details).to_dict())
-
 
         if len(value_counts) == 2 and is_supported_type:
             if set(unique_values) != set([0, 1]):

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -15,11 +15,11 @@ from evalml.utils.gen_utils import (
     numeric_and_boolean_ww
 )
 
-MULTICLASS_CONTINUOUS_THRESHOLD = .05
-
 
 class InvalidTargetDataCheck(DataCheck):
     """Checks if the target data contains missing or invalid values."""
+
+    multiclass_continuous_threshold = .05
 
     def __init__(self, problem_type, objective, n_unique=100):
         """Check if the target is invalid for the specified problem type.
@@ -120,7 +120,7 @@ class InvalidTargetDataCheck(DataCheck):
                     details=details).to_dict())
 
             num_class_to_num_value_ratio = len(unique_values) / len(y)
-            if num_class_to_num_value_ratio >= MULTICLASS_CONTINUOUS_THRESHOLD:
+            if num_class_to_num_value_ratio >= self.multiclass_continuous_threshold:
                 details = {"class_to_value_ratio": num_class_to_num_value_ratio}
                 messages["warnings"].append(DataCheckWarning(
                     message="Target has a large number of unique values, could be regression target.",

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -98,7 +98,7 @@ class InvalidTargetDataCheck(DataCheck):
                                                      details=details).to_dict())
 
         if self.problem_type == ProblemTypes.REGRESSION and not pd.api.types.is_numeric_dtype(y.to_series()):
-            messages["errors"].append(DataCheckError(message="Target data type should be floating point for regression type problems.",
+            messages["errors"].append(DataCheckError(message="Target data type should be numeric for regression type problems.",
                                                      data_check_name=self.name,
                                                      message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
                                                      details={}).to_dict())
@@ -123,7 +123,7 @@ class InvalidTargetDataCheck(DataCheck):
             if num_class_to_num_value_ratio >= self.multiclass_continuous_threshold:
                 details = {"class_to_value_ratio": num_class_to_num_value_ratio}
                 messages["warnings"].append(DataCheckWarning(
-                    message="Target has a large number of unique values, could be regression target.",
+                    message="Target has a large number of unique values, could be regression type problem.",
                     data_check_name=self.name,
                     message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
                     details=details).to_dict())

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -15,6 +15,7 @@ from evalml.utils.gen_utils import (
     numeric_and_boolean_ww
 )
 
+MULTICLASS_CONTINUOUS_THRESHOLD = .05
 
 class InvalidTargetDataCheck(DataCheck):
     """Checks if the target data contains missing or invalid values."""
@@ -95,21 +96,37 @@ class InvalidTargetDataCheck(DataCheck):
                                                      message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
                                                      details=details).to_dict())
 
-        # if self.problem_type == ProblemTypes.BINARY
-
         if self.problem_type == ProblemTypes.REGRESSION and not pd.api.types.is_numeric_dtype(y.to_series()):
             messages["errors"].append(DataCheckError(message="Target data type should be floating point for regression type problems.",
                                                      data_check_name=self.name,
                                                      message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
                                                      details={}).to_dict())
 
-        if self.problem_type == ProblemTypes.MULTICLASS and value_counts.min() <= 1:
-            least_populated = value_counts[value_counts <= 1]
-            details = {"least_populated_class_labels": least_populated.index.tolist()}
-            messages["errors"].append(DataCheckError(message="Target does not have at least two instances per class which is required for multiclass classification",
-                                                     data_check_name=self.name,
-                                                     message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
-                                                     details=details).to_dict())
+        if self.problem_type == ProblemTypes.MULTICLASS:
+            if value_counts.min() <= 1:
+                least_populated = value_counts[value_counts <= 1]
+                details = {"least_populated_class_labels": least_populated.index.tolist()}
+                messages["errors"].append(DataCheckError(message="Target does not have at least two instances per class which is required for multiclass classification",
+                                                         data_check_name=self.name,
+                                                         message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
+                                                         details=details).to_dict())
+            if len(unique_values) <= 2:
+                details = {"num_classes": len(unique_values)}
+                messages["errors"].append(DataCheckError(
+                    message="Target does not have more than two classes, which is required for multiclass classification.",
+                    data_check_name=self.name,
+                    message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_ENOUGH_CLASSES,
+                    details=details).to_dict())
+
+            num_class_to_num_value_ratio = len(unique_values)/len(y)
+            if num_class_to_num_value_ratio >= MULTICLASS_CONTINUOUS_THRESHOLD:
+                details = {"class_to_value_ratio": num_class_to_num_value_ratio}
+                messages["warnings"].append(DataCheckWarning(
+                    message="Target has a large number of unique values, could be regression target.",
+                    data_check_name=self.name,
+                    message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+                    details=details).to_dict())
+
 
         if len(value_counts) == 2 and is_supported_type:
             if set(unique_values) != set([0, 1]):

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -92,7 +92,7 @@ class InvalidTargetDataCheck(DataCheck):
                 details = {"target_values": unique_values}
             else:
                 details = {"target_values": unique_values[:min(self.n_unique, len(unique_values))]}
-            messages["errors"].append(DataCheckError(message="Target does not have two unique values which is not supported for binary classification.",
+            messages["errors"].append(DataCheckError(message="Binary class targets require exactly two unique values.",
                                                      data_check_name=self.name,
                                                      message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
                                                      details=details).to_dict())

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import woodwork as ww
 
 from evalml.data_checks import (
@@ -97,7 +96,7 @@ class InvalidTargetDataCheck(DataCheck):
                                                      message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
                                                      details=details).to_dict())
 
-        if self.problem_type == ProblemTypes.REGRESSION and not pd.api.types.is_numeric_dtype(y.to_series()):
+        if self.problem_type == ProblemTypes.REGRESSION and "numeric" not in y.semantic_tags:
             messages["errors"].append(DataCheckError(message="Target data type should be numeric for regression type problems.",
                                                      data_check_name=self.name,
                                                      message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
@@ -114,7 +113,7 @@ class InvalidTargetDataCheck(DataCheck):
             if len(unique_values) <= 2:
                 details = {"num_classes": len(unique_values)}
                 messages["errors"].append(DataCheckError(
-                    message="Target does not have more than two classes, which is required for multiclass classification.",
+                    message="Target has two or less classes, which is too few for multiclass problems.  Consider changing to binary.",
                     data_check_name=self.name,
                     message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_ENOUGH_CLASSES,
                     details=details).to_dict())

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -125,7 +125,7 @@ class InvalidTargetDataCheck(DataCheck):
                 messages["warnings"].append(DataCheckWarning(
                     message="Target has a large number of unique values, could be regression target.",
                     data_check_name=self.name,
-                    message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+                    message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
                     details=details).to_dict())
 
         if len(value_counts) == 2 and is_supported_type:

--- a/evalml/data_checks/no_variance_data_check.py
+++ b/evalml/data_checks/no_variance_data_check.py
@@ -47,8 +47,8 @@ class NoVarianceDataCheck(DataCheck):
 
         elif count_unique == 2 and not self._dropnan and any_nulls:
             return DataCheckWarning(message=f"{column_name} has two unique values including nulls. "
-                                            "Consider encoding the nulls for "
-                                            "this column to be useful for machine learning.",
+                                    "Consider encoding the nulls for "
+                                    "this column to be useful for machine learning.",
                                     data_check_name=self.name,
                                     message_code=DataCheckMessageCode.NO_VARIANCE_WITH_NULL,
                                     details={"column": column_name})

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -144,7 +144,7 @@ def test_default_data_checks_classification(input_type):
     data_checks = DataChecks(DefaultDataChecks._DEFAULT_DATA_CHECK_CLASSES,
                              {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                          "objective": get_default_primary_search_objective("multiclass")}})
-    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3] + high_class_to_sample_ratio, "errors": [messages[3]] + min_2_class_count + messages[4:] }
+    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3] + high_class_to_sample_ratio, "errors": [messages[3]] + min_2_class_count + messages[4:]}
 
 
 @pytest.mark.parametrize("input_type", ["pd", "ww"])

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -135,7 +135,7 @@ def test_default_data_checks_classification(input_type):
     high_class_to_sample_ratio = [DataCheckWarning(
         message="Target has a large number of unique values, could be regression target.",
         data_check_name="InvalidTargetDataCheck",
-        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={'class_to_value_ratio': 0.6}).to_dict()]
     # multiclass
     data_checks = DefaultDataChecks("multiclass", get_default_primary_search_objective("multiclass"))

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -75,7 +75,7 @@ messages = [DataCheckWarning(message="Column 'all_null' is 95.0% or more null",
             DataCheckError(message="1 row(s) (20.0%) of target values are null",
                            data_check_name="InvalidTargetDataCheck",
                            message_code=DataCheckMessageCode.TARGET_HAS_NULL,
-                           details={"num_null_rows": 1, "pct_null_rows": 20}).to_dict(),
+                           details={"num_null_rows": 1, "pct_null_rows": 20.0}).to_dict(),
             DataCheckError(message="lots_of_null has 1 unique value.",
                            data_check_name="NoVarianceDataCheck",
                            message_code=DataCheckMessageCode.NO_VARIANCE,
@@ -132,14 +132,19 @@ def test_default_data_checks_classification(input_type):
                                         data_check_name="InvalidTargetDataCheck",
                                         message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
                                         details={"least_populated_class_labels": [2.0, 1.0]}).to_dict()]
+    high_class_to_sample_ratio = [DataCheckWarning(
+        message="Target has a large number of unique values, could be regression target.",
+        data_check_name="InvalidTargetDataCheck",
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+        details={'class_to_value_ratio': 0.6}).to_dict()]
     # multiclass
     data_checks = DefaultDataChecks("multiclass", get_default_primary_search_objective("multiclass"))
-    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3], "errors": [messages[3]] + min_2_class_count + messages[4:] + imbalance}
+    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3] + high_class_to_sample_ratio, "errors": [messages[3]] + min_2_class_count + messages[4:] + imbalance}
 
     data_checks = DataChecks(DefaultDataChecks._DEFAULT_DATA_CHECK_CLASSES,
                              {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                          "objective": get_default_primary_search_objective("multiclass")}})
-    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3], "errors": [messages[3]] + min_2_class_count + messages[4:]}
+    assert data_checks.validate(X, y_multiclass) == {"warnings": messages[:3] + high_class_to_sample_ratio, "errors": [messages[3]] + min_2_class_count + messages[4:] }
 
 
 @pytest.mark.parametrize("input_type", ["pd", "ww"])

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -133,7 +133,7 @@ def test_default_data_checks_classification(input_type):
                                         message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
                                         details={"least_populated_class_labels": [2.0, 1.0]}).to_dict()]
     high_class_to_sample_ratio = [DataCheckWarning(
-        message="Target has a large number of unique values, could be regression target.",
+        message="Target has a large number of unique values, could be regression type problem.",
         data_check_name="InvalidTargetDataCheck",
         message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={'class_to_value_ratio': 0.6}).to_dict()]

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -50,17 +50,19 @@ def test_invalid_target_data_check_numeric_binary_classification_error():
     X = pd.DataFrame()
     invalid_targets_check = InvalidTargetDataCheck("binary", get_default_primary_search_objective("binary"))
     assert invalid_targets_check.validate(X, y=pd.Series([1, 5, 1, 5, 1, 1])) == {
-        "warnings": [DataCheckWarning(message="Numerical binary classification target classes must be [0, 1], got [1, 5] instead",
-                                      data_check_name=invalid_targets_data_check_name,
-                                      message_code=DataCheckMessageCode.TARGET_BINARY_INVALID_VALUES,
-                                      details={"target_values": [1, 5]}).to_dict()],
+        "warnings": [DataCheckWarning(
+            message="Numerical binary classification target classes must be [0, 1], got [1, 5] instead",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_INVALID_VALUES,
+            details={"target_values": [1, 5]}).to_dict()],
         "errors": []
     }
     assert invalid_targets_check.validate(X, y=pd.Series([0, 5, np.nan, np.nan])) == {
-        "warnings": [DataCheckWarning(message="Numerical binary classification target classes must be [0, 1], got [5.0, 0.0] instead",
-                                      data_check_name=invalid_targets_data_check_name,
-                                      message_code=DataCheckMessageCode.TARGET_BINARY_INVALID_VALUES,
-                                      details={"target_values": [5.0, 0.0]}).to_dict()],
+        "warnings": [DataCheckWarning(
+            message="Numerical binary classification target classes must be [0, 1], got [5.0, 0.0] instead",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_INVALID_VALUES,
+            details={"target_values": [5.0, 0.0]}).to_dict()],
         "errors": [DataCheckError(message="2 row(s) (50.0%) of target values are null",
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
@@ -68,10 +70,11 @@ def test_invalid_target_data_check_numeric_binary_classification_error():
     }
     assert invalid_targets_check.validate(X, y=pd.Series([0, 1, 1, 0, 1, 2])) == {
         "warnings": [],
-        "errors": [DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": [1, 0, 2]}).to_dict()]
+        "errors": [DataCheckError(
+            message="Target does not have two unique values which is not supported for binary classification.",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+            details={"target_values": [1, 0, 2]}).to_dict()]
     }
 
 
@@ -111,14 +114,16 @@ def test_invalid_target_data_check_invalid_pandas_data_types_error(pd_type):
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
         "errors": [DataCheckError(message="Target is unsupported {} type. Valid Woodwork logical types include: {}"
-                                  .format("Datetime", ", ".join([ltype.type_string for ltype in numeric_and_boolean_ww])),
+                                  .format("Datetime",
+                                          ", ".join([ltype.type_string for ltype in numeric_and_boolean_ww])),
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
                                   details={"unsupported_type": "datetime"}).to_dict(),
-                   DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": unique_values}).to_dict()]
+                   DataCheckError(
+                       message="Target does not have two unique values which is not supported for binary classification.",
+                       data_check_name=invalid_targets_data_check_name,
+                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                       details={"target_values": unique_values}).to_dict()]
     }
 
 
@@ -136,10 +141,11 @@ def test_invalid_target_data_input_formats():
     messages = invalid_targets_check.validate(X, pd.Series())
     assert messages == {
         "warnings": [],
-        "errors": [DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": []}).to_dict()]
+        "errors": [DataCheckError(
+            message="Target does not have two unique values which is not supported for binary classification.",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+            details={"target_values": []}).to_dict()]
     }
     #  test Woodwork
     messages = invalid_targets_check.validate(X, pd.Series([None, None, None, 0]))
@@ -149,10 +155,11 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": [0]}).to_dict()]
+                   DataCheckError(
+                       message="Target does not have two unique values which is not supported for binary classification.",
+                       data_check_name=invalid_targets_data_check_name,
+                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                       details={"target_values": [0]}).to_dict()]
     }
 
     #  test list
@@ -163,10 +170,11 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": [0]}).to_dict()]
+                   DataCheckError(
+                       message="Target does not have two unique values which is not supported for binary classification.",
+                       data_check_name=invalid_targets_data_check_name,
+                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                       details={"target_values": [0]}).to_dict()]
     }
 
     # test np.array
@@ -177,10 +185,11 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": [0]}).to_dict()]
+                   DataCheckError(
+                       message="Target does not have two unique values which is not supported for binary classification.",
+                       data_check_name=invalid_targets_data_check_name,
+                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                       details={"target_values": [0]}).to_dict()]
     }
 
 
@@ -193,10 +202,11 @@ def test_invalid_target_data_check_n_unique():
     unique_values = y.value_counts().index.tolist()[:100]  # n_unique defaults to 100
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(
+            message="Target does not have two unique values which is not supported for binary classification.",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+            details={"target_values": unique_values}).to_dict()]
     }
 
     # Test number of unique values < n_unique
@@ -204,26 +214,30 @@ def test_invalid_target_data_check_n_unique():
     unique_values = y.value_counts().index.tolist()
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(
+            message="Target does not have two unique values which is not supported for binary classification.",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+            details={"target_values": unique_values}).to_dict()]
     }
 
     # Test n_unique is None
-    invalid_targets_check = InvalidTargetDataCheck("binary", get_default_primary_search_objective("binary"), n_unique=None)
+    invalid_targets_check = InvalidTargetDataCheck("binary", get_default_primary_search_objective("binary"),
+                                                   n_unique=None)
     y = pd.Series(range(150))
     unique_values = y.value_counts().index.tolist()
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(message="Target does not have two unique values which is not supported for binary classification",
-                                  data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                                  details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(
+            message="Target does not have two unique values which is not supported for binary classification",
+            data_check_name=invalid_targets_data_check_name,
+            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+            details={"target_values": unique_values}).to_dict()]
     }
 
 
-@pytest.mark.parametrize("objective", ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
+@pytest.mark.parametrize("objective",
+                         ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
 def test_invalid_target_data_check_invalid_labels_for_nonnegative_objective_names(objective):
     X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100]})
     y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1])
@@ -297,7 +311,8 @@ def test_invalid_target_data_check_invalid_labels_for_objectives(time_series_cor
             }
 
 
-@pytest.mark.parametrize("objective", ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
+@pytest.mark.parametrize("objective",
+                         ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
 def test_invalid_target_data_check_valid_labels_for_nonnegative_objectives(objective):
     X = pd.DataFrame({'column_one': [100, 100, 200, 300, 100, 200, 100]})
     y = pd.Series([2, 2, 3, 3, 1, 1, 1])
@@ -314,3 +329,65 @@ def test_invalid_target_data_check_initialize_with_none_objective():
     with pytest.raises(DataCheckInitError, match="Encountered the following error"):
         DataChecks([InvalidTargetDataCheck], {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                                          "objective": None}})
+
+
+def test_invalid_target_data_check_regression_problem_nonnumeric_data():
+    """
+    For regression, error if the problem type was not "numeric"
+    For binary, error if the problem type was "categorical" (but first we should confirm that if a categorical column has only two unique values (other than nan) woodwork will label it as binary, not as "categorical"
+    For multiclass, error if the problem type was binary
+    For multiclass, warn if the problem type had a high number of unique values--perhaps set a max cap at over 5%.
+    """
+
+    X = pd.DataFrame()
+    y_categorical = pd.Series(["Peace", "Is", "A", "Lie"])
+    y_mixed_cat_numeric = pd.Series(["Peace", 2, "A", 4])
+    y_integer = pd.Series([1, 2, 3, 4])
+    y_float = pd.Series([1.1, 2.2, 3.3, 4.4])
+    y_numeric = pd.Series([1, 2.2, 3, 4.4])
+
+    data_check_error = DataCheckError(
+        message=f"Target data type should be floating point for regression type problems.",
+        data_check_name=invalid_targets_data_check_name,
+        message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
+        details={}).to_dict()
+
+    invalid_targets_check = InvalidTargetDataCheck("regression", get_default_primary_search_objective("regression"))
+    assert invalid_targets_check.validate(X, y=y_categorical) == {"warnings": [], "errors": [data_check_error]}
+    assert invalid_targets_check.validate(X, y=y_mixed_cat_numeric) == {"warnings": [], "errors": [data_check_error]}
+    assert invalid_targets_check.validate(X, y=y_integer) == {"warnings": [], "errors": []}
+    assert invalid_targets_check.validate(X, y=y_float) == {"warnings": [], "errors": []}
+    assert invalid_targets_check.validate(X, y=y_numeric) == {"warnings": [], "errors": []}
+
+
+# def test_invalid_target_data_check_binary_problem_nonbinarycategorical_data():
+#     """
+#     For binary, error if the problem type was "categorical" (but first we should confirm that if a categorical column
+#     has only two unique values (other than nan) woodwork will label it as binary, not as "categorical"
+#     """
+#
+#     X = pd.DataFrame()
+#     y_categorical_multiclass = pd.Series(["Peace", "Is", "A", "Lie"])
+#     y_categorical_binary = pd.Series(["Peace", "Lie", "Peace", "Lie", "Peace", "Peace", "Lie"])
+#
+#     data_check_error = DataCheckError(
+#         message=f"Target does not have two unique values which is not supported for binary classification.",
+#         data_check_name=invalid_targets_data_check_name,
+#         message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+#         details={"target_values": set(y_categorical_multiclass)}).to_dict()
+#
+#     invalid_targets_check = InvalidTargetDataCheck("binary", get_default_primary_search_objective("binary"))
+#     assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": [data_check_error]}
+#     assert invalid_targets_check.validate(X, y=y_categorical_binary) == {"warnings": [], "errors": [data_check_error]}
+#
+#     invalid_targets_check = InvalidTargetDataCheck("multiclass", get_default_primary_search_objective("multiclass"))
+#     assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": []}
+#     assert invalid_targets_check.validate(X, y=y_categorical_binary) == {"warnings": [], "errors": []}
+
+
+def test_invalid_target_data_check_multiclass_problem_binary_data():
+    pass
+
+
+def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
+    pass

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -70,11 +70,10 @@ def test_invalid_target_data_check_numeric_binary_classification_error():
     }
     assert invalid_targets_check.validate(X, y=pd.Series([0, 1, 1, 0, 1, 2])) == {
         "warnings": [],
-        "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification.",
-            data_check_name=invalid_targets_data_check_name,
-            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-            details={"target_values": [1, 0, 2]}).to_dict()]
+        "errors": [DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": [1, 0, 2]}).to_dict()]
     }
 
 
@@ -119,11 +118,10 @@ def test_invalid_target_data_check_invalid_pandas_data_types_error(pd_type):
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
                                   details={"unsupported_type": "datetime"}).to_dict(),
-                   DataCheckError(
-                       message="Target does not have two unique values which is not supported for binary classification.",
-                       data_check_name=invalid_targets_data_check_name,
-                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                       details={"target_values": unique_values}).to_dict()]
+                   DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": unique_values}).to_dict()]
     }
 
 
@@ -141,11 +139,10 @@ def test_invalid_target_data_input_formats():
     messages = invalid_targets_check.validate(X, pd.Series())
     assert messages == {
         "warnings": [],
-        "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification.",
-            data_check_name=invalid_targets_data_check_name,
-            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-            details={"target_values": []}).to_dict()]
+        "errors": [DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": []}).to_dict()]
     }
     #  test Woodwork
     messages = invalid_targets_check.validate(X, pd.Series([None, None, None, 0]))
@@ -155,11 +152,10 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(
-                       message="Target does not have two unique values which is not supported for binary classification.",
-                       data_check_name=invalid_targets_data_check_name,
-                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                       details={"target_values": [0]}).to_dict()]
+                   DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": [0]}).to_dict()]
     }
 
     #  test list
@@ -170,11 +166,10 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(
-                       message="Target does not have two unique values which is not supported for binary classification.",
-                       data_check_name=invalid_targets_data_check_name,
-                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                       details={"target_values": [0]}).to_dict()]
+                   DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": [0]}).to_dict()]
     }
 
     # test np.array
@@ -185,11 +180,10 @@ def test_invalid_target_data_input_formats():
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_HAS_NULL,
                                   details={"num_null_rows": 3, "pct_null_rows": 75}).to_dict(),
-                   DataCheckError(
-                       message="Target does not have two unique values which is not supported for binary classification.",
-                       data_check_name=invalid_targets_data_check_name,
-                       message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-                       details={"target_values": [0]}).to_dict()]
+                   DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": [0]}).to_dict()]
     }
 
 
@@ -202,11 +196,10 @@ def test_invalid_target_data_check_n_unique():
     unique_values = y.value_counts().index.tolist()[:100]  # n_unique defaults to 100
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification.",
-            data_check_name=invalid_targets_data_check_name,
-            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-            details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": unique_values}).to_dict()]
     }
 
     # Test number of unique values < n_unique
@@ -214,11 +207,10 @@ def test_invalid_target_data_check_n_unique():
     unique_values = y.value_counts().index.tolist()
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification.",
-            data_check_name=invalid_targets_data_check_name,
-            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-            details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": unique_values}).to_dict()]
     }
 
     # Test n_unique is None
@@ -228,11 +220,10 @@ def test_invalid_target_data_check_n_unique():
     unique_values = y.value_counts().index.tolist()
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
-        "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification.",
-            data_check_name=invalid_targets_data_check_name,
-            message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-            details={"target_values": unique_values}).to_dict()]
+        "errors": [DataCheckError(message="Binary class targets require exactly two unique values.",
+                                  data_check_name=invalid_targets_data_check_name,
+                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+                                  details={"target_values": unique_values}).to_dict()]
     }
 
 
@@ -371,7 +362,7 @@ def test_invalid_target_data_check_regression_problem_nonnumeric_data():
 #     y_categorical_binary = pd.Series(["Peace", "Lie", "Peace", "Lie", "Peace", "Peace", "Lie"])
 #
 #     # data_check_error = DataCheckError(
-#     #     message=f"Target does not have two unique values which is not supported for binary classification.",
+#     #     message=f"Binary class targets require exactly two unique values.",
 #     #     data_check_name=invalid_targets_data_check_name,
 #     #     message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
 #     #     details={"target_values": set(y_categorical_multiclass)}).to_dict()

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -229,7 +229,7 @@ def test_invalid_target_data_check_n_unique():
     assert invalid_targets_check.validate(X, y) == {
         "warnings": [],
         "errors": [DataCheckError(
-            message="Target does not have two unique values which is not supported for binary classification",
+            message="Target does not have two unique values which is not supported for binary classification.",
             data_check_name=invalid_targets_data_check_name,
             message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
             details={"target_values": unique_values}).to_dict()]

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -331,7 +331,7 @@ def test_invalid_target_data_check_regression_problem_nonnumeric_data():
     y_numeric = pd.Series([1, 2.2, 3, 4.4])
 
     data_check_error = DataCheckError(
-        message=f"Target data type should be floating point for regression type problems.",
+        message=f"Target data type should be numeric for regression type problems.",
         data_check_name=invalid_targets_data_check_name,
         message_code=DataCheckMessageCode.TARGET_UNSUPPORTED_TYPE,
         details={}).to_dict()
@@ -366,7 +366,7 @@ def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
 
     y_multiclass_high_classes = pd.Series(list(range(0, 100)) * 3)  # 100 classes, 300 samples, .33 class.sample ratio
     data_check_error = DataCheckWarning(
-        message=f"Target has a large number of unique values, could be regression target.",
+        message=f"Target has a large number of unique values, could be regression type problem.",
         data_check_name=invalid_targets_data_check_name,
         message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={"class_to_value_ratio": 1 / 3}).to_dict()
@@ -375,7 +375,7 @@ def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
 
     y_multiclass_med_classes = pd.Series(list(range(0, 5)) * 20)  # 5 classes, 100 samples, .05 class/sample ratio
     data_check_error = DataCheckWarning(
-        message=f"Target has a large number of unique values, could be regression target.",
+        message=f"Target has a large number of unique values, could be regression type problem.",
         data_check_name=invalid_targets_data_check_name,
         message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={"class_to_value_ratio": .05}).to_dict()

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -344,20 +344,6 @@ def test_invalid_target_data_check_regression_problem_nonnumeric_data():
     assert invalid_targets_check.validate(X, y=y_numeric) == {"warnings": [], "errors": []}
 
 
-def test_invalid_target_data_check_binary_problem_nonbinarycategorical_data():
-    X = pd.DataFrame()
-    invalid_targets_check = InvalidTargetDataCheck("multiclass", get_default_primary_search_objective("multiclass"))
-
-    y_binary = pd.Series([0, 1, 1, 1, 1, 0])
-
-    data_check_error = DataCheckError(
-        message=f"Binary class targets require exactly two unique values.",
-        data_check_name=invalid_targets_data_check_name,
-        message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-        details={"target_values": set(y_binary)}).to_dict()
-
-
-
 def test_invalid_target_data_check_multiclass_problem_binary_data():
     X = pd.DataFrame()
     y_multiclass = pd.Series([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3] * 25)
@@ -385,16 +371,16 @@ def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
         message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
         details={"class_to_value_ratio": 1 / 3}).to_dict()
     assert invalid_targets_check.validate(X, y=y_multiclass_high_classes) == {"warnings": [data_check_error],
-                                                                                   "errors": []}
+                                                                              "errors": []}
 
-    y_multiclass_med_classes = pd.Series(list(range(0,5)) * 20) # 5 classes, 100 samples, .05 class/sample ratio
+    y_multiclass_med_classes = pd.Series(list(range(0, 5)) * 20)  # 5 classes, 100 samples, .05 class/sample ratio
     data_check_error = DataCheckWarning(
         message=f"Target has a large number of unique values, could be regression target.",
         data_check_name=invalid_targets_data_check_name,
         message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
         details={"class_to_value_ratio": .05}).to_dict()
     assert invalid_targets_check.validate(X, y=y_multiclass_med_classes) == {"warnings": [data_check_error],
-                                                                                   "errors": []}
+                                                                             "errors": []}
 
     y_multiclass_low_classes = pd.Series(list(range(0, 3)) * 100)  # 2 classes, 300 samples, .01 class/sample ratio
     assert invalid_targets_check.validate(X, y=y_multiclass_low_classes) == {"warnings": [], "errors": []}

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -84,7 +84,7 @@ def test_invalid_target_data_check_multiclass_two_examples_per_class():
     expected_message = "Target does not have at least two instances per class which is required for multiclass classification"
 
     # with 1 class not having min 2 instances
-    assert invalid_targets_check.validate(X, y=pd.Series([0, 1, 1, 2, 2])) == {
+    assert invalid_targets_check.validate(X, y=pd.Series([0] + [1] * 19 + [2] * 80)) == {
         "warnings": [],
         "errors": [DataCheckError(message=expected_message,
                                   data_check_name=invalid_targets_data_check_name,
@@ -92,12 +92,12 @@ def test_invalid_target_data_check_multiclass_two_examples_per_class():
                                   details={"least_populated_class_labels": [0]}).to_dict()]
     }
     # with 2 classes not having min 2 instances
-    assert invalid_targets_check.validate(X, y=pd.Series([0, 1, 1, 2, 2, 3])) == {
+    assert invalid_targets_check.validate(X, y=pd.Series([0] + [1] + [2] * 98)) == {
         "warnings": [],
         "errors": [DataCheckError(message=expected_message,
                                   data_check_name=invalid_targets_data_check_name,
                                   message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
-                                  details={"least_populated_class_labels": [3, 0]}).to_dict()]
+                                  details={"least_populated_class_labels": [1, 0]}).to_dict()]
     }
 
 
@@ -239,8 +239,8 @@ def test_invalid_target_data_check_n_unique():
 @pytest.mark.parametrize("objective",
                          ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
 def test_invalid_target_data_check_invalid_labels_for_nonnegative_objective_names(objective):
-    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100]})
-    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1])
+    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100] * 25})
+    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1] * 25)
 
     data_checks = DataChecks([InvalidTargetDataCheck], {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                                                    "objective": objective}})
@@ -270,8 +270,8 @@ def test_invalid_target_data_check_invalid_labels_for_nonnegative_objective_name
 
 @pytest.mark.parametrize("objective", [RootMeanSquaredLogError(), MeanSquaredLogError(), MAPE()])
 def test_invalid_target_data_check_invalid_labels_for_nonnegative_objective_instances(objective):
-    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100]})
-    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1])
+    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100] * 25})
+    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1] * 25)
 
     data_checks = DataChecks([InvalidTargetDataCheck], {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                                                    "objective": objective}})
@@ -287,8 +287,8 @@ def test_invalid_target_data_check_invalid_labels_for_nonnegative_objective_inst
 
 
 def test_invalid_target_data_check_invalid_labels_for_objectives(time_series_core_objectives):
-    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100]})
-    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1])
+    X = pd.DataFrame({'column_one': [100, 200, 100, 200, 200, 100, 200, 100] * 25})
+    y = pd.Series([2, 2, 3, 3, -1, -1, 1, 1] * 25)
 
     for objective in time_series_core_objectives:
         if not objective.positive_only:
@@ -314,8 +314,8 @@ def test_invalid_target_data_check_invalid_labels_for_objectives(time_series_cor
 @pytest.mark.parametrize("objective",
                          ['Root Mean Squared Log Error', 'Mean Squared Log Error', 'Mean Absolute Percentage Error'])
 def test_invalid_target_data_check_valid_labels_for_nonnegative_objectives(objective):
-    X = pd.DataFrame({'column_one': [100, 100, 200, 300, 100, 200, 100]})
-    y = pd.Series([2, 2, 3, 3, 1, 1, 1])
+    X = pd.DataFrame({'column_one': [100, 100, 200, 300, 100, 200, 100] * 25})
+    y = pd.Series([2, 2, 3, 3, 1, 1, 1] * 25)
 
     data_checks = DataChecks([InvalidTargetDataCheck], {"InvalidTargetDataCheck": {"problem_type": "multiclass",
                                                                                    "objective": objective}})
@@ -367,27 +367,64 @@ def test_invalid_target_data_check_regression_problem_nonnumeric_data():
 #     """
 #
 #     X = pd.DataFrame()
-#     y_categorical_multiclass = pd.Series(["Peace", "Is", "A", "Lie"])
+#     # y_categorical_multiclass = pd.Series(["Peace", "Is", "A", "Lie"])
 #     y_categorical_binary = pd.Series(["Peace", "Lie", "Peace", "Lie", "Peace", "Peace", "Lie"])
 #
-#     data_check_error = DataCheckError(
-#         message=f"Target does not have two unique values which is not supported for binary classification.",
-#         data_check_name=invalid_targets_data_check_name,
-#         message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
-#         details={"target_values": set(y_categorical_multiclass)}).to_dict()
+#     # data_check_error = DataCheckError(
+#     #     message=f"Target does not have two unique values which is not supported for binary classification.",
+#     #     data_check_name=invalid_targets_data_check_name,
+#     #     message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_UNIQUE_VALUES,
+#     #     details={"target_values": set(y_categorical_multiclass)}).to_dict()
 #
 #     invalid_targets_check = InvalidTargetDataCheck("binary", get_default_primary_search_objective("binary"))
-#     assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": [data_check_error]}
-#     assert invalid_targets_check.validate(X, y=y_categorical_binary) == {"warnings": [], "errors": [data_check_error]}
+#     # assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": [data_check_error]}
+#     # import pdb; pdb.set_trace()
+#     assert invalid_targets_check.validate(X, y=y_categorical_binary) == {"warnings": [], "errors": []}
 #
 #     invalid_targets_check = InvalidTargetDataCheck("multiclass", get_default_primary_search_objective("multiclass"))
-#     assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": []}
+#     # assert invalid_targets_check.validate(X, y=y_categorical_multiclass) == {"warnings": [], "errors": []}
 #     assert invalid_targets_check.validate(X, y=y_categorical_binary) == {"warnings": [], "errors": []}
 
 
 def test_invalid_target_data_check_multiclass_problem_binary_data():
-    pass
+    """
+    For multiclass, error if the problem type was binary
+    For multiclass, warn if the problem type had a high number of unique values--perhaps set a max cap at over 5%.
+    """
+    X = pd.DataFrame()
+    y_multiclass = pd.Series([1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3] * 25)
+    y_binary = pd.Series([0, 1, 1, 1, 0, 0] * 25)
+
+    data_check_error = DataCheckError(
+        message=f"Target does not have more than two classes, which is required for multiclass classification.",
+        data_check_name=invalid_targets_data_check_name,
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_ENOUGH_CLASSES,
+        details={"num_classes": len(set(y_binary))}).to_dict()
+
+    invalid_targets_check = InvalidTargetDataCheck("multiclass", get_default_primary_search_objective("regression"))
+    assert invalid_targets_check.validate(X, y=y_multiclass) == {"warnings": [], "errors": []}
+    assert invalid_targets_check.validate(X, y=y_binary) == {"warnings": [], "errors": [data_check_error]}
 
 
 def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
-    pass
+    """
+    For multiclass, error if the problem type was binary
+    For multiclass, warn if the problem type had a high number of unique values--perhaps set a max cap at over 5%.
+    """
+    X = pd.DataFrame()
+    y_multiclass_very_high_classes = pd.Series(
+        list(range(0, 100)) * 3)  # 100 classes, 300 samples, .33 class.sample ratio
+    # y_multiclass_high_classes = pd.Series(list(range(0,5)) * 20) # 5 classes, 100 samples, .05 class/sample ratio
+    y_multiclass_low_classes = pd.Series(list(range(0, 3)) * 100)  # 2 classes, 300 samples, .01 class/sample ratio
+
+    data_check_error = DataCheckWarning(
+        message=f"Target has a large number of unique values, could be regression target.",
+        data_check_name=invalid_targets_data_check_name,
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+        details={"class_to_value_ratio": 1 / 3}).to_dict()
+
+    invalid_targets_check = InvalidTargetDataCheck("multiclass", get_default_primary_search_objective("multiclass"))
+    # import pdb; pdb.set_trace()
+    assert invalid_targets_check.validate(X, y=y_multiclass_very_high_classes) == {"warnings": [data_check_error],
+                                                                                   "errors": []}
+    assert invalid_targets_check.validate(X, y=y_multiclass_low_classes) == {"warnings": [], "errors": []}

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -368,7 +368,7 @@ def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
     data_check_error = DataCheckWarning(
         message=f"Target has a large number of unique values, could be regression target.",
         data_check_name=invalid_targets_data_check_name,
-        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={"class_to_value_ratio": 1 / 3}).to_dict()
     assert invalid_targets_check.validate(X, y=y_multiclass_high_classes) == {"warnings": [data_check_error],
                                                                               "errors": []}
@@ -377,7 +377,7 @@ def test_invalid_target_data_check_multiclass_problem_almostcontinuous_data():
     data_check_error = DataCheckWarning(
         message=f"Target has a large number of unique values, could be regression target.",
         data_check_name=invalid_targets_data_check_name,
-        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS_WARNING,
+        message_code=DataCheckMessageCode.TARGET_MULTICLASS_HIGH_UNIQUE_CLASS,
         details={"class_to_value_ratio": .05}).to_dict()
     assert invalid_targets_check.validate(X, y=y_multiclass_med_classes) == {"warnings": [data_check_error],
                                                                              "errors": []}

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -1284,7 +1284,7 @@ def test_visualize_decision_trees_wrong_format(fitted_tree_estimators, tmpdir):
     est_class, _ = fitted_tree_estimators
     filepath = os.path.join(str(tmpdir), 'test_0.xyz')
     with pytest.raises(ValueError, match=f"Unknown format 'xyz'. Make sure your format is one of the following: "
-                                         f"{graphviz.backend.FORMATS}"):
+                       f"{graphviz.backend.FORMATS}"):
         visualize_decision_tree(estimator=est_class, filepath=filepath)
 
 


### PR DESCRIPTION
- [x] For regression, error if the problem type was not "numeric"

- [ ] For binary, error if the problem type was "categorical" (but first we should confirm that if a categorical column has only two unique values (other than nan) woodwork will label it as binary, not as "categorical" (this was a little unclear - I think this already is the case and is tested.)

- [x] For multiclass, error if the problem type was binary

- [x] For multiclass, warn if the problem type had a high number of unique values--perhaps set a max cap at over 5%.

addresses [Issue #1548 ](https://github.com/alteryx/evalml/issues/1548)