### PR TITLE
Update CatBoost estimators to return self in fit rather than underlying model for consistency

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -28,6 +28,7 @@ Release Notes
         * Fixed bug where time series baseline estimators were not receiving ``gap`` and ``max_delay`` in ``AutoMLSearch`` :pr:`1645`
         * Fixed jupyter notebooks to help the RTD buildtime :pr:`1654`
         * Added ``positive_only`` objectives to ``non_core_objectives`` :pr:`1661`
+        * Updated CatBoost estimators to return self in ``.fit()`` rather than the underlying model for consistency :pr:`1701`
     * Changes
         * Added labeling to ``graph_confusion_matrix`` :pr:`1632`
         * Rerunning search for ``AutoMLSearch`` results in a message thrown rather than failing the search, and removed ``has_searched`` property :pr:`1647`

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -70,8 +70,8 @@ class CatBoostClassifier(Estimator):
         if y.nunique() <= 2:
             self._label_encoder = LabelEncoder()
             y = pd.Series(self._label_encoder.fit_transform(y))
-        model = self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
-        return model
+        self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
+        return self
 
     def predict(self, X):
         X = _convert_to_woodwork_structure(X)
@@ -83,6 +83,7 @@ class CatBoostClassifier(Estimator):
             predictions = self._label_encoder.inverse_transform(predictions.astype(np.int64))
         if not isinstance(predictions, pd.Series):
             predictions = pd.Series(predictions)
+        predictions = _convert_to_woodwork_structure(predictions)
         return predictions
 
     @property

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -83,7 +83,6 @@ class CatBoostClassifier(Estimator):
             predictions = self._label_encoder.inverse_transform(predictions.astype(np.int64))
         if not isinstance(predictions, pd.Series):
             predictions = pd.Series(predictions)
-        predictions = _convert_to_woodwork_structure(predictions)
         return predictions
 
     @property

--- a/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
@@ -62,8 +62,8 @@ class CatBoostRegressor(Estimator):
         y = _convert_to_woodwork_structure(y)
         y = _convert_woodwork_types_wrapper(y.to_series())
 
-        model = self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
-        return model
+        self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
+        return self
 
     @property
     def feature_importance(self):

--- a/evalml/tests/component_tests/test_baseline_classifier.py
+++ b/evalml/tests/component_tests/test_baseline_classifier.py
@@ -34,7 +34,8 @@ def test_baseline_binary_mode(data_type, X_y_binary):
         X = ww.DataTable(X)
         y = ww.DataColumn(y)
     clf = BaselineClassifier(strategy="mode")
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, BaselineClassifier)
     assert clf.classes_ == [10, 11]
     np.testing.assert_allclose(clf.predict(X), np.array([10] * X.shape[0]))
     predicted_proba = clf.predict_proba(X)

--- a/evalml/tests/component_tests/test_baseline_regressor.py
+++ b/evalml/tests/component_tests/test_baseline_regressor.py
@@ -26,7 +26,8 @@ def test_baseline_mean(X_y_regression):
     X, y = X_y_regression
     mean = y.mean()
     clf = BaselineRegressor()
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, BaselineRegressor)
     np.testing.assert_allclose(clf.predict(X), np.array([mean] * len(X)))
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -17,7 +17,8 @@ def test_catboost_classifier_random_state_bounds_seed(X_y_binary):
     clf = CatBoostClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound)
     clf.fit(X, y)
     clf = CatBoostClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, CatBoostClassifier)
 
 
 def test_catboost_classifier_random_state_bounds_rng(X_y_binary):

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -17,7 +17,8 @@ def test_catboost_regressor_random_state_bounds_seed(X_y_regression):
     clf = CatBoostRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound)
     clf.fit(X, y)
     clf = CatBoostRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, CatBoostRegressor)
 
 
 def test_catboost_regressor_random_state_bounds_rng(X_y_regression):

--- a/evalml/tests/component_tests/test_decision_tree_classifier.py
+++ b/evalml/tests/component_tests/test_decision_tree_classifier.py
@@ -42,7 +42,9 @@ def test_fit_predict_multi(X_y_multi):
     y_pred_proba_sk = sk_clf.predict_proba(X)
 
     clf = DecisionTreeClassifier()
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, DecisionTreeClassifier)
+
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 

--- a/evalml/tests/component_tests/test_decision_tree_regressor.py
+++ b/evalml/tests/component_tests/test_decision_tree_regressor.py
@@ -23,9 +23,10 @@ def test_fit_predict(X_y_regression):
     y_pred_sk = sk_clf.predict(X)
 
     clf = DecisionTreeRegressor()
-    clf.fit(X, y)
-    y_pred = clf.predict(X)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, DecisionTreeRegressor)
 
+    y_pred = clf.predict(X)
     np.testing.assert_almost_equal(y_pred, y_pred_sk, decimal=5)
 
 

--- a/evalml/tests/component_tests/test_en_classifier.py
+++ b/evalml/tests/component_tests/test_en_classifier.py
@@ -55,7 +55,9 @@ def test_fit_predict_multi(X_y_multi):
     y_pred_proba_sk = sk_clf.predict_proba(X)
 
     clf = ElasticNetClassifier()
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, ElasticNetClassifier)
+
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 

--- a/evalml/tests/component_tests/test_en_regressor.py
+++ b/evalml/tests/component_tests/test_en_regressor.py
@@ -40,9 +40,10 @@ def test_fit_predict(X_y_regression):
     y_pred_sk = sk_clf.predict(X)
 
     clf = ElasticNetRegressor()
-    clf.fit(X, y)
-    y_pred = clf.predict(X)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, ElasticNetRegressor)
 
+    y_pred = clf.predict(X)
     np.testing.assert_almost_equal(y_pred, y_pred_sk, decimal=5)
 
 

--- a/evalml/tests/component_tests/test_et_classifier.py
+++ b/evalml/tests/component_tests/test_et_classifier.py
@@ -42,7 +42,9 @@ def test_fit_predict_multi(X_y_multi):
     y_pred_proba_sk = sk_clf.predict_proba(X)
 
     clf = ExtraTreesClassifier()
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, ExtraTreesClassifier)
+
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 

--- a/evalml/tests/component_tests/test_et_regressor.py
+++ b/evalml/tests/component_tests/test_et_regressor.py
@@ -23,9 +23,10 @@ def test_fit_predict(X_y_regression):
     y_pred_sk = sk_clf.predict(X)
 
     clf = ExtraTreesRegressor()
-    clf.fit(X, y)
-    y_pred = clf.predict(X)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, ExtraTreesRegressor)
 
+    y_pred = clf.predict(X)
     np.testing.assert_almost_equal(y_pred, y_pred_sk, decimal=5)
 
 

--- a/evalml/tests/component_tests/test_knn_classifier.py
+++ b/evalml/tests/component_tests/test_knn_classifier.py
@@ -25,7 +25,9 @@ def test_fit_predict_binary(X_y_binary):
     y_pred_proba_sk = sk_clf.predict_proba(X)
 
     clf = KNeighborsClassifier()
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, KNeighborsClassifier)
+
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -31,7 +31,8 @@ def test_lightgbm_classifier_random_state_bounds_seed(X_y_binary):
     X = pd.DataFrame(X, columns=col_names)
     y = pd.Series(y)
     clf = LightGBMClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound, n_jobs=1)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, LightGBMClassifier)
     clf = LightGBMClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound, n_jobs=1)
     clf.fit(X, y)
 

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -29,7 +29,8 @@ def test_lightgbm_regressor_random_state_bounds_seed(X_y_regression):
     X = pd.DataFrame(X, columns=col_names)
     y = pd.Series(y)
     clf = LightGBMRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, LightGBMRegressor)
     clf = LightGBMRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound)
     clf.fit(X, y)
 

--- a/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
+++ b/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
@@ -59,7 +59,10 @@ def test_stacked_ensemble_init_with_multiple_same_estimators(X_y_binary, logisti
         'n_jobs': 1
     }
     assert clf.parameters == expected_parameters
-    clf.fit(X, y)
+
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, StackedEnsembleClassifier)
+
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
     assert not np.isnan(y_pred).all()

--- a/evalml/tests/component_tests/test_stacked_ensemble_regressor.py
+++ b/evalml/tests/component_tests/test_stacked_ensemble_regressor.py
@@ -60,7 +60,10 @@ def test_stacked_ensemble_init_with_multiple_same_estimators(X_y_regression, lin
         'n_jobs': 1
     }
     assert clf.parameters == expected_parameters
-    clf.fit(X, y)
+
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, StackedEnsembleRegressor)
+
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
     assert not np.isnan(y_pred).all()

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -19,7 +19,8 @@ def test_xgboost_classifier_random_state_bounds_seed(X_y_binary):
     X = pd.DataFrame(X, columns=col_names)
     y = pd.Series(y)
     clf = XGBoostClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, XGBoostClassifier)
     clf = XGBoostClassifier(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound)
     clf.fit(X, y)
 

--- a/evalml/tests/component_tests/test_xgboost_regressor.py
+++ b/evalml/tests/component_tests/test_xgboost_regressor.py
@@ -17,7 +17,8 @@ def test_xgboost_regressor_random_state_bounds_seed(X_y_regression):
     X = pd.DataFrame(X, columns=col_names)
     y = pd.Series(y)
     clf = XGBoostRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.min_bound)
-    clf.fit(X, y)
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, XGBoostRegressor)
     clf = XGBoostRegressor(n_estimators=1, max_depth=1, random_state=SEED_BOUNDS.max_bound)
     clf.fit(X, y)
 


### PR DESCRIPTION
Updates CatBoost estimators to return self in fit rather than underlying model for consistency. Our other estimators return self, catboost should too.

This fell out of work I've been doing w/ components and pipelines returning Woodwork and general cleanup of EvalML 😛 