### PR TITLE
Release v0.18.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,14 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+**v0.18.0 Jan. 26, 2021**
+    * Enhancements
         * Added RMSLE, MSLE, and MAPE to core objectives while checking for negative target values in ``invalid_targets_data_check`` :pr:`1574`
         * Added validation checks for binary problems with regression-like datasets and multiclass problems without true multiclass targets in ``invalid_targets_data_check`` :pr:`1665`
         * Added time series support for ``make_pipeline`` :pr:`1566`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.17.0'
+__version__ = '0.18.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.17.0',
+    version='0.18.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.18.0 Jan. 26, 2021
### Enhancements
- Added RMSLE, MSLE, and MAPE to core objectives while checking for negative target values in ``invalid_targets_data_check`` #1574
- Added validation checks for binary problems with regression-like datasets and multiclass problems without true multiclass targets in ``invalid_targets_data_check`` #1665
- Added time series support for ``make_pipeline`` #1566
- Added target name for output of pipeline ``predict`` method #1578
- Added multiclass check to ``InvalidTargetDataCheck`` for two examples per class #1596
- Support graphviz 0.16 #1657
- Enhanced time series pipelines to accept empty features #1651
- Added KNN Classifier to estimators. #1650
- Added support for list inputs for objectives #1663
- Added support for ``AutoMLSearch`` to handle time series classification pipelines #1666
- Enhanced ``DelayedFeaturesTransformer`` to encode categorical features and targets before delaying them #1691
- Added 2-way dependence plots. #1690
- Added ability to directly iterate through components within Pipelines #1583
### Fixes
- Fixed inconsistent attributes and added Exceptions to docs #1673
- Fixed ``TargetLeakageDataCheck`` to use Woodwork ``mutual_information`` rather than using Pandas' Pearson Correlation #1616
- Fixed thresholding for pipelines in ``AutoMLSearch`` to only threshold binary classification pipelines #1622 #1626
- Updated ``load_data`` to return Woodwork structures and update default parameter value for ``index`` to ``None`` #1610
- Pinned scipy at < 1.6.0 while we work on adding support #1629
- Fixed data check message formatting in ``AutoMLSearch`` #1633
- Addressed stacked ensemble component for ``scikit-learn`` v0.24 support by setting ``shuffle=True`` for default CV #1613
- Fixed bug where ``Imputer`` reset the index on ``X`` #1590
- Fixed ``AutoMLSearch`` stacktrace when a cutom objective was passed in as a primary objective or additional objective #1575
- Fixed custom index bug for ``MAPE`` objective #1641
- Fixed index bug for ``TextFeaturizer`` and ``LSA`` components #1644
- Limited ``load_fraud`` dataset loaded into ``automl.ipynb`` #1646
- ``add_to_rankings`` updates ``AutoMLSearch.best_pipeline`` when necessary #1647
- Fixed bug where time series baseline estimators were not receiving ``gap`` and ``max_delay`` in ``AutoMLSearch`` #1645
- Fixed jupyter notebooks to help the RTD buildtime #1654
- Added ``positive_only`` objectives to ``non_core_objectives`` #1661
- Fixed stacking argument ``n_jobs`` for IterativeAlgorithm #1706
- Updated CatBoost estimators to return self in ``.fit()`` rather than the underlying model for consistency #1701
- Added ability to initialize pipeline parameters in ``AutoMLSearch`` constructor #1676
- Make AutoMLSearch pipelines pickle-able #1721
### Changes
- Added labeling to ``graph_confusion_matrix`` #1632
- Rerunning search for ``AutoMLSearch`` results in a message thrown rather than failing the search, and removed ``has_searched`` property #1647
- Changed tuner class to allow and ignore single parameter values as input #1686
- Capped LightGBM version limit to remove bug in docs #1711
- Removed support for `np.random.RandomState` in EvalML #1727
### Documentation Changes
- Update Model Understanding in the user guide to include ``visualize_decision_tree`` #1678
- Updated docs to include information about ``AutoMLSearch`` callback parameters and methods #1577
- Updated docs to prompt users to install graphiz on Mac #1656
- Added ``infer_feature_types`` to the ``start.ipynb`` guide #1700
- Added multicollinearity data check to API reference and docs #1707
### Testing Changes
.. warning::
### Breaking Changes
- Removed ``has_searched`` property from ``AutoMLSearch`` #1647
- Removed support for `np.random.RandomState` in EvalML. Rather than passing ``np.random.RandomState`` as component and pipeline random_state values, we use int random_seed #1727