### PR TITLE
Add Open Graph Info to Docs HTML

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,23 +9,23 @@
   }}();
 </script> -->
 
+<title>EvalML - Alteryx Open Source AutoML Library</title>
+<meta name="description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
 
-{% set image = 'https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png' %}
-{% set description = 'Automated feature engineering in Python' %}
-{% if meta is defined %}
-    {% if meta.description is defined %}
-        {% set description = meta.description %}
-    {% endif %}
-{% endif %}
+<!-- Facebook Meta Tags -->
+<meta property="og:url" content="https://evalml.alteryx.com/en/stable/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="EvalML - Alteryx Open Source AutoML Library">
+<meta property="og:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
+<meta property="og:image" content="https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png">
 
-<meta property="og:title" content="{{ title|striptags|e }}{{ titlesuffix }}">
-<meta content="{{description}}" />
-<meta property="og:description" content="{{description}}">
-<meta property="og:image" content="{{image}}">
-<meta property="twitter:image" content="{{image}}">
+<!-- Twitter Meta Tags -->
 <meta name="twitter:card" content="summary_large_image">
-
-
+<meta property="twitter:domain" content="evalml.alteryx.com">
+<meta property="twitter:url" content="https://evalml.alteryx.com/en/stable/">
+<meta name="twitter:title" content="EvalML - Alteryx Open Source AutoML Library">
+<meta name="twitter:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
+<meta name="twitter:image" content="https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png">
 
 {% endblock %}
 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -9,6 +9,24 @@
   }}();
 </script> -->
 
+
+{% set image = 'https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png' %}
+{% set description = 'Automated feature engineering in Python' %}
+{% if meta is defined %}
+    {% if meta.description is defined %}
+        {% set description = meta.description %}
+    {% endif %}
+{% endif %}
+
+<meta property="og:title" content="{{ title|striptags|e }}{{ titlesuffix }}">
+<meta content="{{description}}" />
+<meta property="og:description" content="{{description}}">
+<meta property="og:image" content="{{image}}">
+<meta property="twitter:image" content="{{image}}">
+<meta name="twitter:card" content="summary_large_image">
+
+
+
 {% endblock %}
 
 {%- block footer %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -10,13 +10,13 @@
 </script> -->
 
 <title>EvalML - Alteryx Open Source AutoML Library</title>
-<meta name="description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
+<meta name="description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML documentation">
 
 <!-- Facebook Meta Tags -->
 <meta property="og:url" content="https://evalml.alteryx.com/en/stable/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="EvalML - Alteryx Open Source AutoML Library">
-<meta property="og:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
+<meta property="og:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML documentation">
 <meta property="og:image" content="https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png">
 
 <!-- Twitter Meta Tags -->
@@ -24,7 +24,7 @@
 <meta property="twitter:domain" content="evalml.alteryx.com">
 <meta property="twitter:url" content="https://evalml.alteryx.com/en/stable/">
 <meta name="twitter:title" content="EvalML - Alteryx Open Source AutoML Library">
-<meta name="twitter:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML 0.17.0 documentation">
+<meta name="twitter:description" content="EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions. — EvalML documentation">
 <meta name="twitter:image" content="https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png">
 
 {% endblock %}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
     * Changes
         * Updated components and pipelines to return ``Woodwork`` data structures :pr:`1668`
     * Documentation Changes
+        * Added Open Graph info to documentation :pr:`1758`
     * Testing Changes
 
 


### PR DESCRIPTION
Closes #1722.

Uploaded Open Graph photo to https://featurelabs-static.s3.amazonaws.com/OpenSource_OpenGraph_1200x630px-evalml.png to match where Featuretools' equivalent is :D

See the update preview here: https://www.opengraph.xyz/url/https:%2F%2Fevalml.alteryx.com%2Fen%2F1722_open_graph_info%2F/
🥳 

![image](https://user-images.githubusercontent.com/5422235/106204992-cfd31e00-618b-11eb-9751-89df5e2bf4f3.png)

Note: I had to activate and set public this branch to view this. Will remove after this is merged!