### PR TITLE
Release v0.18.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,11 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+**v0.18.1 Feb. 1, 2021**
+    * Enhancements
         * Added ``graph_t_sne`` as a visualization tool for high dimensional data :pr:`1731`
         * Added the ability to see the linear coefficients of features in linear models terms :pr:`1738`
         * Added support for ``scikit-learn`` ``v0.24.0`` :pr:`1733`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.18.0'
+__version__ = '0.18.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.18.0',
+    version='0.18.1',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.18.1 Feb. 1, 2021
### Enhancements
- Added ``graph_t_sne`` as a visualization tool for high dimensional data #1731
- Added the ability to see the linear coefficients of features in linear models terms #1738
- Added support for ``scikit-learn`` ``v0.24.0`` #1733
- Added support for ``scipy`` ``v1.6.0`` #1752
- Added SVM Classifier and Regressor to estimators #1714 #1761
### Fixes
- Addressed bug with ``partial_dependence`` and categorical data with more categories than grid resolution #1748
- Removed ``random_state`` arg from ``get_pipelines`` in ``AutoMLSearch`` #1719
- Pinned pyzmq at less than 22.0.0 till we add support #1756
- Remove ``ProphetRegressor`` from main as windows tests were flaky #1764
### Changes
- Updated components and pipelines to return ``Woodwork`` data structures #1668
- Updated `clone()` for pipelines and components to copy over random state automatically #1753
- Dropped support for Python version 3.6 #1751
### Documentation Changes
- Add Twitter and Github link to documentation toolbar #1754
- Added Open Graph info to documentation #1758
### Testing Changes
### Breaking Changes
- Components and pipelines return ``Woodwork`` data structures instead of ``pandas`` data structures #1668
- Python 3.6 will not be actively supported due to discontinued support from EvalML dependencies.