### PR TITLE
Moving some prs from 0.18.1 release notes to future release section.

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
     * Documentation Changes
         * Added section on conda to the contributing guide :pr:`1771`
         * Updated release process to reflect freezing `main` before perf tests :pr:`1787`
+        * Moving some prs to the right section of the release notes :pr:`1789`
 
 **v0.18.1 Feb. 1, 2021**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,6 @@ Release Notes
         * Added section on conda to the contributing guide :pr:`1771`
         * Updated release process to reflect freezing `main` before perf tests :pr:`1787`
 
-
 **v0.18.1 Feb. 1, 2021**
     * Enhancements
         * Added ``graph_t_sne`` as a visualization tool for high dimensional data :pr:`1731`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,9 +4,13 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Added "dataframe" output format for prediction explanations :pr:`1781`
+        * Updated LightGBM estimators to handle ``pandas.MultiIndex`` :pr:`1770`
     * Fixes
     * Changes
     * Documentation Changes
+        * Added section on conda to the contributing guide :pr:`1771`
+        * Updated release process to reflect freezing `main` before perf tests :pr:`1787`
+
 
 **v0.18.1 Feb. 1, 2021**
     * Enhancements
@@ -15,7 +19,6 @@ Release Notes
         * Added support for ``scikit-learn`` ``v0.24.0`` :pr:`1733`
         * Added support for ``scipy`` ``v1.6.0`` :pr:`1752`
         * Added SVM Classifier and Regressor to estimators :pr:`1714` :pr:`1761`
-        * Updated LightGBM estimators to handle ``pandas.MultiIndex`` :pr:`1770`
     * Fixes
         * Addressed bug with ``partial_dependence`` and categorical data with more categories than grid resolution :pr:`1748`
         * Removed ``random_state`` arg from ``get_pipelines`` in ``AutoMLSearch`` :pr:`1719`
@@ -29,8 +32,6 @@ Release Notes
     * Documentation Changes
         * Add Twitter and Github link to documentation toolbar :pr:`1754`
         * Added Open Graph info to documentation :pr:`1758`
-        * Added section on conda to the contributing guide :pr:`1771`
-        * Updated release process to reflect freezing `main` before perf tests :pr:`1787`
     * Testing Changes
 
 .. warning::


### PR DESCRIPTION
### Pull Request Description
I think some prs were incorrectly added to the 0.18.1 release notes. Moving them to the "Future Release" section. Let me know if I'm mistaken!

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
