### PR TITLE
Time Series Binary Thresholding support

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added "dataframe" output format for prediction explanations :pr:`1781`
         * Updated LightGBM estimators to handle ``pandas.MultiIndex`` :pr:`1770`
         * Sped up permutation importance for some pipelines :pr:`1762`
+        * Confirmed support for threshold tuning for binary time series classification problems :pr:``
     * Fixes
     * Changes
     * Documentation Changes
@@ -14,6 +15,7 @@ Release Notes
         * Moving some prs to the right section of the release notes :pr:`1789`
         * Tweak README.md. :pr:`1800`
         * Fixed back arrow on install page docs :pr:`1795`
+    * Testing Changes
 
 **v0.18.1 Feb. 1, 2021**
     * Enhancements

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
         * Added "dataframe" output format for prediction explanations :pr:`1781`
         * Updated LightGBM estimators to handle ``pandas.MultiIndex`` :pr:`1770`
         * Sped up permutation importance for some pipelines :pr:`1762`
-        * Confirmed support for threshold tuning for binary time series classification problems :pr:``
+        * Confirmed support for threshold tuning for binary time series classification problems :pr:`1803`
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -765,3 +765,31 @@ def test_automl_time_series_classification_pickle_generated_pipeline(mock_binary
     for i, row in a.rankings.iterrows():
         assert a.get_pipeline(row['id']).__class__ == pipeline
         assert pickle.loads(pickle.dumps(a.get_pipeline(row['id'])))
+
+
+@pytest.mark.parametrize("objective", ['F1', 'Log Loss Binary'])
+@pytest.mark.parametrize("optimize", [True, False])
+@patch('evalml.objectives.BinaryClassificationObjective.optimize_threshold')
+@patch('evalml.pipelines.TimeSeriesBinaryClassificationPipeline.predict_proba')
+@patch('evalml.pipelines.TimeSeriesBinaryClassificationPipeline.score')
+@patch('evalml.pipelines.TimeSeriesBinaryClassificationPipeline.fit')
+def test_automl_time_series_classification_threshold(mock_binary_fit, mock_binary_score, mock_predict_proba, mock_optimize_threshold,
+                                                     optimize, objective, X_y_binary):
+    X, y = X_y_binary
+    mock_binary_score.return_value = {objective: 0.4}
+    problem_type = 'time series binary'
+
+    configuration = {"gap": 0, "max_delay": 0, 'delay_target': False, 'delay_features': True}
+
+    mock_optimize_threshold.return_value = 0.62
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type=problem_type,
+                          problem_configuration=configuration, objective=objective, optimize_thresholds=optimize,
+                          max_batches=2)
+    automl.search()
+    assert isinstance(automl.data_splitter, TimeSeriesSplit)
+    if optimize and objective == 'F1':
+        mock_optimize_threshold.assert_called()
+        assert automl.best_pipeline.threshold == 0.62
+    else:
+        mock_optimize_threshold.assert_not_called()
+        assert automl.best_pipeline.threshold == 0.5


### PR DESCRIPTION
fix #1624 

Adding test to check for ts binary thresholding support. `split_data` already handles splitting TS data. 