### PR TITLE
Updating percent better than baseline computation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,8 +5,10 @@ Release Notes
     * Enhancements
         * Updated estimators to keep track of input feature names during ``fit()`` :pr:`1794`
         * Updated ``visualize_decision_tree`` to include feature names in output :pr:`1813`
+        * Added ``is_bounded_like_percentage`` property for objectives. If true, the ``calculate_percent_difference`` method will return the absolute difference rather than relative difference :pr:`1809`
     * Fixes
     * Changes
+        * Modified ``calculate_percent_difference`` so that division by 0 is now inf rather than nan :pr:`1809`
     * Documentation Changes
     * Testing Changes
 
@@ -19,10 +21,8 @@ Release Notes
         * Sped up permutation importance for some pipelines :pr:`1762`
         * Added sparsity data check :pr:`1797`
         * Confirmed support for threshold tuning for binary time series classification problems :pr:`1803`
-        * Added ``is_bounded_like_percentage`` property for objectives. If true, the ``calculate_percent_difference`` method will return the absolute difference rather than relative difference :pr:`1809`
     * Fixes
     * Changes
-        * Modified ``calculate_percent_difference`` so that division by 0 is now inf rather than nan :pr:`1809`
     * Documentation Changes
         * Added section on conda to the contributing guide :pr:`1771`
         * Updated release process to reflect freezing `main` before perf tests :pr:`1787`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,8 +19,10 @@ Release Notes
         * Sped up permutation importance for some pipelines :pr:`1762`
         * Added sparsity data check :pr:`1797`
         * Confirmed support for threshold tuning for binary time series classification problems :pr:`1803`
+        * Added ``is_bounded_like_percentage`` property for objectives. If true, the ``calculate_percent_difference`` method will return the absolute difference rather than relative difference :pr:`1809`
     * Fixes
     * Changes
+        * Modified ``calculate_percent_difference`` so that division by 0 is now inf rather than nan :pr:`1809`
     * Documentation Changes
         * Added section on conda to the contributing guide :pr:`1771`
         * Updated release process to reflect freezing `main` before perf tests :pr:`1787`

--- a/evalml/objectives/cost_benefit_matrix.py
+++ b/evalml/objectives/cost_benefit_matrix.py
@@ -14,6 +14,8 @@ class CostBenefitMatrix(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = np.inf
+    # Range (-Inf, Inf)
+    is_bounded_like_percentage = False
 
     def __init__(self, true_positive, true_negative, false_positive, false_negative):
         """Create instance of CostBenefitMatrix.

--- a/evalml/objectives/cost_benefit_matrix.py
+++ b/evalml/objectives/cost_benefit_matrix.py
@@ -14,8 +14,7 @@ class CostBenefitMatrix(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = np.inf
-    # Range (-Inf, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range (-Inf, Inf)
 
     def __init__(self, true_positive, true_negative, false_positive, false_negative):
         """Create instance of CostBenefitMatrix.

--- a/evalml/objectives/fraud_cost.py
+++ b/evalml/objectives/fraud_cost.py
@@ -8,6 +8,7 @@ class FraudCost(BinaryClassificationObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    is_bounded_like_percentage = True
 
     def __init__(self, retry_percentage=.5, interchange_fee=.02,
                  fraud_payout_percentage=1.0, amount_col='amount'):

--- a/evalml/objectives/lead_scoring.py
+++ b/evalml/objectives/lead_scoring.py
@@ -9,6 +9,8 @@ class LeadScoring(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = math.inf
+    # Range (-Inf, Inf)
+    is_bounded_like_percentage = False
 
     def __init__(self, true_positives=1, false_positives=-1):
         """Create instance.

--- a/evalml/objectives/lead_scoring.py
+++ b/evalml/objectives/lead_scoring.py
@@ -9,8 +9,7 @@ class LeadScoring(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = math.inf
-    # Range (-Inf, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range (-Inf, Inf)
 
     def __init__(self, true_positives=1, false_positives=-1):
         """Create instance.

--- a/evalml/objectives/standard_metrics.py
+++ b/evalml/objectives/standard_metrics.py
@@ -263,8 +263,7 @@ class LogLossBinary(BinaryClassificationObjective):
     greater_is_better = False
     score_needs_proba = True
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.log_loss(y_true, y_predicted)
@@ -276,8 +275,7 @@ class LogLossMulticlass(MulticlassClassificationObjective):
     greater_is_better = False
     score_needs_proba = True
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.log_loss(y_true, y_predicted)
@@ -289,8 +287,7 @@ class MCCBinary(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
-    # Range [-1, 1]
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [-1, 1]1
 
     def objective_function(self, y_true, y_predicted, X=None):
         with warnings.catch_warnings():
@@ -305,8 +302,7 @@ class MCCMulticlass(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
-    # Range [-1, 1]
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [-1, 1]
 
     def objective_function(self, y_true, y_predicted, X=None):
         with warnings.catch_warnings():
@@ -321,8 +317,7 @@ class RootMeanSquaredError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_error(y_true, y_predicted, squared=False)
@@ -337,8 +332,7 @@ class RootMeanSquaredLogError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return np.sqrt(metrics.mean_squared_log_error(y_true, y_predicted))
@@ -358,8 +352,7 @@ class MeanSquaredLogError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_log_error(y_true, y_predicted)
@@ -376,8 +369,7 @@ class R2(RegressionObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1
-    # Range (-Inf, 1]
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range (-Inf, 1]
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.r2_score(y_true, y_predicted)
@@ -389,8 +381,7 @@ class MAE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = True
+    is_bounded_like_percentage = True  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_absolute_error(y_true, y_predicted)
@@ -405,8 +396,7 @@ class MAPE(TimeSeriesRegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         if (y_true == 0).any():
@@ -431,8 +421,7 @@ class MSE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_error(y_true, y_predicted)
@@ -444,8 +433,7 @@ class MedianAE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.median_absolute_error(y_true, y_predicted)
@@ -457,8 +445,7 @@ class MaxError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
-    # Range [0, Inf)
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range [0, Inf)
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.max_error(y_true, y_predicted)
@@ -470,8 +457,7 @@ class ExpVariance(RegressionObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
-    # Range (-Inf, 1]
-    is_bounded_like_percentage = False
+    is_bounded_like_percentage = False  # Range (-Inf, 1]
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.explained_variance_score(y_true, y_predicted)

--- a/evalml/objectives/standard_metrics.py
+++ b/evalml/objectives/standard_metrics.py
@@ -20,6 +20,7 @@ class AccuracyBinary(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.accuracy_score(y_true, y_predicted)
@@ -31,6 +32,7 @@ class AccuracyMulticlass(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.accuracy_score(y_true, y_predicted)
@@ -42,6 +44,7 @@ class BalancedAccuracyBinary(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.balanced_accuracy_score(y_true, y_predicted)
@@ -53,6 +56,7 @@ class BalancedAccuracyMulticlass(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.balanced_accuracy_score(y_true, y_predicted)
@@ -64,6 +68,7 @@ class F1(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.f1_score(y_true, y_predicted, zero_division=0.0)
@@ -75,6 +80,7 @@ class F1Micro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.f1_score(y_true, y_predicted, average='micro', zero_division=0.0)
@@ -86,6 +92,7 @@ class F1Macro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.f1_score(y_true, y_predicted, average='macro', zero_division=0.0)
@@ -97,6 +104,7 @@ class F1Weighted(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.f1_score(y_true, y_predicted, average='weighted', zero_division=0.0)
@@ -108,6 +116,7 @@ class Precision(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.precision_score(y_true, y_predicted, zero_division=0.0)
@@ -119,6 +128,7 @@ class PrecisionMicro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.precision_score(y_true, y_predicted, average='micro', zero_division=0.0)
@@ -130,6 +140,7 @@ class PrecisionMacro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.precision_score(y_true, y_predicted, average='macro', zero_division=0.0)
@@ -141,6 +152,7 @@ class PrecisionWeighted(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.precision_score(y_true, y_predicted, average='weighted', zero_division=0.0)
@@ -152,6 +164,7 @@ class Recall(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.recall_score(y_true, y_predicted, zero_division=0.0)
@@ -163,6 +176,7 @@ class RecallMicro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.recall_score(y_true, y_predicted, average='micro', zero_division=0.0)
@@ -174,6 +188,7 @@ class RecallMacro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.recall_score(y_true, y_predicted, average='macro', zero_division=0.0)
@@ -185,6 +200,7 @@ class RecallWeighted(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.recall_score(y_true, y_predicted, average='weighted', zero_division=0.0)
@@ -196,6 +212,7 @@ class AUC(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = True
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.roc_auc_score(y_true, y_predicted)
@@ -207,6 +224,7 @@ class AUCMicro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = True
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         y_true, y_predicted = _handle_predictions(y_true, y_predicted)
@@ -219,6 +237,7 @@ class AUCMacro(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = True
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         y_true, y_predicted = _handle_predictions(y_true, y_predicted)
@@ -231,6 +250,7 @@ class AUCWeighted(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = True
     perfect_score = 1.0
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         y_true, y_predicted = _handle_predictions(y_true, y_predicted)
@@ -243,6 +263,8 @@ class LogLossBinary(BinaryClassificationObjective):
     greater_is_better = False
     score_needs_proba = True
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.log_loss(y_true, y_predicted)
@@ -254,6 +276,8 @@ class LogLossMulticlass(MulticlassClassificationObjective):
     greater_is_better = False
     score_needs_proba = True
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.log_loss(y_true, y_predicted)
@@ -265,6 +289,8 @@ class MCCBinary(BinaryClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    # Range [-1, 1]
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         with warnings.catch_warnings():
@@ -279,6 +305,8 @@ class MCCMulticlass(MulticlassClassificationObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    # Range [-1, 1]
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         with warnings.catch_warnings():
@@ -293,6 +321,8 @@ class RootMeanSquaredError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_error(y_true, y_predicted, squared=False)
@@ -307,6 +337,8 @@ class RootMeanSquaredLogError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return np.sqrt(metrics.mean_squared_log_error(y_true, y_predicted))
@@ -326,6 +358,8 @@ class MeanSquaredLogError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_log_error(y_true, y_predicted)
@@ -342,6 +376,8 @@ class R2(RegressionObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1
+    # Range (-Inf, 1]
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.r2_score(y_true, y_predicted)
@@ -353,6 +389,8 @@ class MAE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = True
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_absolute_error(y_true, y_predicted)
@@ -367,6 +405,8 @@ class MAPE(TimeSeriesRegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         if (y_true == 0).any():
@@ -391,6 +431,8 @@ class MSE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.mean_squared_error(y_true, y_predicted)
@@ -402,6 +444,8 @@ class MedianAE(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.median_absolute_error(y_true, y_predicted)
@@ -413,6 +457,8 @@ class MaxError(RegressionObjective):
     greater_is_better = False
     score_needs_proba = False
     perfect_score = 0.0
+    # Range [0, Inf)
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.max_error(y_true, y_predicted)
@@ -424,6 +470,8 @@ class ExpVariance(RegressionObjective):
     greater_is_better = True
     score_needs_proba = False
     perfect_score = 1.0
+    # Range (-Inf, 1]
+    is_bounded_like_percentage = False
 
     def objective_function(self, y_true, y_predicted, X=None):
         return metrics.explained_variance_score(y_true, y_predicted)


### PR DESCRIPTION
### Pull Request Description
Fixes #1449

* For objectives bounded strictly in the range [0, 1], the percent difference is the absolute difference (not normalized by the baseline)
* For other objectives, division by 0 is now inf rather than nan


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
