### PR TITLE
Engine API

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Release Notes
         * Added full error traceback to AutoMLSearch logger file :pr:`1840`
         * Changed ``TargetEncoder`` to preserve custom indices in the data :pr:`1836`
         * Refactored ``explain_predictions`` and ``explain_predictions_best_worst`` to only compute features once for all rows that need to be explained :pr:`1843`
+        * Added ``Engines`` pipeline processing API :pr:`1838`
     * Fixes
     * Changes
         * Modified ``calculate_percent_difference`` so that division by 0 is now inf rather than nan :pr:`1809`

--- a/evalml/automl/__init__.py
+++ b/evalml/automl/__init__.py
@@ -1,2 +1,3 @@
 from .automl_search import AutoMLSearch
-from .utils import get_default_primary_search_objective, make_data_splitter
+from .utils import get_default_primary_search_objective, make_data_splitter, tune_binary_threshold
+from .engine import SequentialEngine, EngineBase

--- a/evalml/automl/automl_algorithm/automl_algorithm.py
+++ b/evalml/automl/automl_algorithm/automl_algorithm.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from evalml.exceptions import PipelineNotFoundError
 from evalml.tuners import SKOptTuner
 
 
@@ -51,6 +52,8 @@ class AutoMLAlgorithm(ABC):
             score_to_minimize (float): The score obtained by this pipeline on the primary objective, converted so that lower values indicate better pipelines.
             pipeline (PipelineBase): The trained pipeline object which was used to compute the score.
         """
+        if pipeline.name not in self._tuners:
+            raise PipelineNotFoundError(f"No such pipeline allowed in this AutoML search: {pipeline.name}")
         self._tuners[pipeline.name].add(pipeline.parameters, score_to_minimize)
 
     @property

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1,8 +1,6 @@
 import copy
-import sys
 import time
-import traceback
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import cloudpickle
 import numpy as np
@@ -13,9 +11,11 @@ from .pipeline_search_plots import PipelineSearchPlots
 
 from evalml.automl.automl_algorithm import IterativeAlgorithm
 from evalml.automl.callbacks import log_error_callback
+from evalml.automl.engine import SequentialEngine
 from evalml.automl.utils import (
     get_default_primary_search_objective,
-    make_data_splitter
+    make_data_splitter,
+    tune_binary_threshold
 )
 from evalml.data_checks import (
     AutoMLDataChecks,
@@ -24,11 +24,7 @@ from evalml.data_checks import (
     EmptyDataChecks,
     HighVarianceCVDataCheck
 )
-from evalml.exceptions import (
-    AutoMLSearchException,
-    PipelineNotFoundError,
-    PipelineScoreError
-)
+from evalml.exceptions import AutoMLSearchException, PipelineNotFoundError
 from evalml.model_family import ModelFamily
 from evalml.objectives import (
     get_core_objectives,
@@ -36,11 +32,9 @@ from evalml.objectives import (
     get_objective
 )
 from evalml.pipelines import (
-    BinaryClassificationPipeline,
     MeanBaselineRegressionPipeline,
     ModeBaselineBinaryPipeline,
     ModeBaselineMulticlassPipeline,
-    PipelineBase,
     TimeSeriesBaselineBinaryPipeline,
     TimeSeriesBaselineMulticlassPipeline,
     TimeSeriesBaselineRegressionPipeline
@@ -239,6 +233,7 @@ class AutoMLSearch:
 
         self.patience = patience
         self.tolerance = tolerance or 0.0
+
         self._results = {
             'pipeline_results': {},
             'search_order': [],
@@ -258,7 +253,7 @@ class AutoMLSearch:
         self.allowed_pipelines = allowed_pipelines
         self.allowed_model_families = allowed_model_families
         self._automl_algorithm = None
-        self._start = None
+        self._start = 0.0
         self._baseline_cv_scores = {}
         self.show_batch_output = False
 
@@ -275,6 +270,92 @@ class AutoMLSearch:
                                                    n_splits=3, shuffle=True, random_seed=self.random_seed)
         self.data_splitter = self.data_splitter or default_data_splitter
         self.pipeline_parameters = pipeline_parameters if pipeline_parameters is not None else {}
+        self.search_iteration_plot = None
+        self._interrupted = False
+
+        self._engine = SequentialEngine(self.X_train,
+                                        self.y_train,
+                                        self,
+                                        should_continue_callback=self._should_continue,
+                                        pre_evaluation_callback=self._pre_evaluation_callback,
+                                        post_evaluation_callback=self._post_evaluation_callback)
+
+        if self.allowed_pipelines is None:
+            logger.info("Generating pipelines to search over...")
+            allowed_estimators = get_estimators(self.problem_type, self.allowed_model_families)
+            logger.debug(f"allowed_estimators set to {[estimator.name for estimator in allowed_estimators]}")
+            self.allowed_pipelines = [make_pipeline(self.X_train, self.y_train, estimator, self.problem_type, custom_hyperparameters=self.pipeline_parameters) for estimator in allowed_estimators]
+
+        if self.allowed_pipelines == []:
+            raise ValueError("No allowed pipelines to search")
+
+        run_ensembling = self.ensembling
+        if run_ensembling and len(self.allowed_pipelines) == 1:
+            logger.warning("Ensembling is set to True, but the number of unique pipelines is one, so ensembling will not run.")
+            run_ensembling = False
+
+        if run_ensembling and self.max_iterations is not None:
+            # Baseline + first batch + each pipeline iteration + 1
+            first_ensembling_iteration = (1 + len(self.allowed_pipelines) + len(self.allowed_pipelines) * self._pipelines_per_batch + 1)
+            if self.max_iterations < first_ensembling_iteration:
+                run_ensembling = False
+                logger.warning(f"Ensembling is set to True, but max_iterations is too small, so ensembling will not run. Set max_iterations >= {first_ensembling_iteration} to run ensembling.")
+            else:
+                logger.info(f"Ensembling will run at the {first_ensembling_iteration} iteration and every {len(self.allowed_pipelines) * self._pipelines_per_batch} iterations after that.")
+
+        if self.max_batches and self.max_iterations is None:
+            self.show_batch_output = True
+            if run_ensembling:
+                ensemble_nth_batch = len(self.allowed_pipelines) + 1
+                num_ensemble_batches = (self.max_batches - 1) // ensemble_nth_batch
+                if num_ensemble_batches == 0:
+                    logger.warning(f"Ensembling is set to True, but max_batches is too small, so ensembling will not run. Set max_batches >= {ensemble_nth_batch + 1} to run ensembling.")
+                else:
+                    logger.info(f"Ensembling will run every {ensemble_nth_batch} batches.")
+
+                self.max_iterations = (1 + len(self.allowed_pipelines) +
+                                       self._pipelines_per_batch * (self.max_batches - 1 - num_ensemble_batches) +
+                                       num_ensemble_batches)
+            else:
+                self.max_iterations = 1 + len(self.allowed_pipelines) + (self._pipelines_per_batch * (self.max_batches - 1))
+        self.allowed_model_families = list(set([p.model_family for p in (self.allowed_pipelines)]))
+
+        logger.debug(f"allowed_pipelines set to {[pipeline.name for pipeline in self.allowed_pipelines]}")
+        logger.debug(f"allowed_model_families set to {self.allowed_model_families}")
+        if len(self.problem_configuration):
+            pipeline_params = {**{'pipeline': self.problem_configuration}, **self.pipeline_parameters}
+        else:
+            pipeline_params = self.pipeline_parameters
+
+        self._automl_algorithm = IterativeAlgorithm(
+            max_iterations=self.max_iterations,
+            allowed_pipelines=self.allowed_pipelines,
+            tuner_class=self.tuner_class,
+            random_seed=self.random_seed,
+            n_jobs=self.n_jobs,
+            number_features=self.X_train.shape[1],
+            pipelines_per_batch=self._pipelines_per_batch,
+            ensembling=run_ensembling,
+            pipeline_params=pipeline_params
+        )
+
+    def _pre_evaluation_callback(self, pipeline):
+        if self.start_iteration_callback:
+            self.start_iteration_callback(pipeline.__class__, pipeline.parameters, self)
+        desc = f"{pipeline.name}"
+        if len(desc) > AutoMLSearch._MAX_NAME_LEN:
+            desc = desc[:AutoMLSearch._MAX_NAME_LEN - 3] + "..."
+        desc = desc.ljust(AutoMLSearch._MAX_NAME_LEN)
+        batch_number = 1
+        if self._automl_algorithm is not None and self._automl_algorithm.batch_number > 0:
+            batch_number = self._automl_algorithm.batch_number
+        update_pipeline(logger,
+                        desc,
+                        len(self._results['pipeline_results']) + 1,
+                        self.max_iterations,
+                        self._start,
+                        batch_number,
+                        self.show_batch_output)
 
     def _validate_objective(self, objective):
         non_core_objectives = get_non_core_objectives()
@@ -364,16 +445,11 @@ class AutoMLSearch:
         else:
             return DataChecks(data_checks)
 
-    def _handle_keyboard_interrupt(self, pipeline, current_batch_pipelines):
+    def _handle_keyboard_interrupt(self):
         """Presents a prompt to the user asking if they want to stop the search.
 
-        Arguments:
-            pipeline (PipelineBase): Current pipeline in the search.
-            current_batch_pipelines (list): Other pipelines in the batch.
-
         Returns:
-            list: Next pipelines to search in the batch. If the user decides to stop the search,
-                an empty list will be returned.
+            bool: If True, search should terminate early
         """
         leading_char = "\n"
         start_of_loop = time.time()
@@ -381,12 +457,12 @@ class AutoMLSearch:
             choice = input(leading_char + "Do you really want to exit search (y/n)? ").strip().lower()
             if choice == "y":
                 logger.info("Exiting AutoMLSearch.")
-                return []
+                return True
             elif choice == "n":
                 # So that the time in this loop does not count towards the time budget (if set)
                 time_in_loop = time.time() - start_of_loop
                 self._start += time_in_loop
-                return [pipeline] + current_batch_pipelines
+                return False
             else:
                 leading_char = ""
 
@@ -425,68 +501,11 @@ class AutoMLSearch:
             logger.error(result["message"])
         if self._data_check_results["errors"]:
             raise ValueError("Data checks raised some warnings and/or errors. Please see `self.data_check_results` for more information or pass data_checks='disabled' to search() to disable data checking.")
-        if self.allowed_pipelines is None:
-            logger.info("Generating pipelines to search over...")
-            allowed_estimators = get_estimators(self.problem_type, self.allowed_model_families)
-            logger.debug(f"allowed_estimators set to {[estimator.name for estimator in allowed_estimators]}")
-            self.allowed_pipelines = [make_pipeline(self.X_train, self.y_train, estimator, self.problem_type, custom_hyperparameters=self.pipeline_parameters) for estimator in allowed_estimators]
-
-        if self.allowed_pipelines == []:
-            raise ValueError("No allowed pipelines to search")
-
-        run_ensembling = self.ensembling
-        if run_ensembling and len(self.allowed_pipelines) == 1:
-            logger.warning("Ensembling is set to True, but the number of unique pipelines is one, so ensembling will not run.")
-            run_ensembling = False
-
-        if run_ensembling and self.max_iterations is not None:
-            # Baseline + first batch + each pipeline iteration + 1
-            first_ensembling_iteration = (1 + len(self.allowed_pipelines) + len(self.allowed_pipelines) * self._pipelines_per_batch + 1)
-            if self.max_iterations < first_ensembling_iteration:
-                run_ensembling = False
-                logger.warning(f"Ensembling is set to True, but max_iterations is too small, so ensembling will not run. Set max_iterations >= {first_ensembling_iteration} to run ensembling.")
-            else:
-                logger.info(f"Ensembling will run at the {first_ensembling_iteration} iteration and every {len(self.allowed_pipelines) * self._pipelines_per_batch} iterations after that.")
-
-        if self.max_batches and self.max_iterations is None:
-            self.show_batch_output = True
-            if run_ensembling:
-                ensemble_nth_batch = len(self.allowed_pipelines) + 1
-                num_ensemble_batches = (self.max_batches - 1) // ensemble_nth_batch
-                if num_ensemble_batches == 0:
-                    logger.warning(f"Ensembling is set to True, but max_batches is too small, so ensembling will not run. Set max_batches >= {ensemble_nth_batch + 1} to run ensembling.")
-                else:
-                    logger.info(f"Ensembling will run every {ensemble_nth_batch} batches.")
-
-                self.max_iterations = (1 + len(self.allowed_pipelines) +
-                                       self._pipelines_per_batch * (self.max_batches - 1 - num_ensemble_batches) +
-                                       num_ensemble_batches)
-            else:
-                self.max_iterations = 1 + len(self.allowed_pipelines) + (self._pipelines_per_batch * (self.max_batches - 1))
-        self.allowed_model_families = list(set([p.model_family for p in (self.allowed_pipelines)]))
-
-        logger.debug(f"allowed_pipelines set to {[pipeline.name for pipeline in self.allowed_pipelines]}")
-        logger.debug(f"allowed_model_families set to {self.allowed_model_families}")
-        if len(self.problem_configuration):
-            pipeline_params = {**{'pipeline': self.problem_configuration}, **self.pipeline_parameters}
-        else:
-            pipeline_params = self.pipeline_parameters
-
-        self._automl_algorithm = IterativeAlgorithm(
-            max_iterations=self.max_iterations,
-            allowed_pipelines=self.allowed_pipelines,
-            tuner_class=self.tuner_class,
-            random_seed=self.random_seed,
-            n_jobs=self.n_jobs,
-            number_features=self.X_train.shape[1],
-            pipelines_per_batch=self._pipelines_per_batch,
-            ensembling=run_ensembling,
-            pipeline_params=pipeline_params
-        )
 
         log_title(logger, "Beginning pipeline search")
         logger.info("Optimizing for %s. " % self.objective.name)
         logger.info("{} score is better.\n".format('Greater' if self.objective.greater_is_better else 'Lower'))
+        logger.info(f"Using {self._engine.__class__.__name__} to train and score pipelines.")
 
         if self.max_batches is not None:
             logger.info(f"Searching up to {self.max_batches} batches for a total of {self.max_iterations} pipelines. ")
@@ -495,50 +514,61 @@ class AutoMLSearch:
         if self.max_time is not None:
             logger.info("Will stop searching for new pipelines after %d seconds.\n" % self.max_time)
         logger.info("Allowed model families: %s\n" % ", ".join([model.value for model in self.allowed_model_families]))
-        search_iteration_plot = None
+        self.search_iteration_plot = None
         if self.plot:
-            search_iteration_plot = self.plot.search_iteration_plot(interactive_plot=show_iteration_plot)
+            self.search_iteration_plot = self.plot.search_iteration_plot(interactive_plot=show_iteration_plot)
 
         self._start = time.time()
 
-        should_terminate = self._add_baseline_pipelines()
-        if should_terminate:
-            return
+        try:
+            self._add_baseline_pipelines()
+        except KeyboardInterrupt:
+            if self._handle_keyboard_interrupt():
+                self._interrupted = True
 
         current_batch_pipelines = []
         current_batch_pipeline_scores = []
-        while self._check_stopping_condition(self._start):
+        new_pipeline_ids = []
+        loop_interrupted = False
+        while self._should_continue():
             try:
-                if current_batch_pipeline_scores and np.isnan(np.array(current_batch_pipeline_scores, dtype=float)).all():
-                    raise AutoMLSearchException(f"All pipelines in the current AutoML batch produced a score of np.nan on the primary objective {self.objective}.")
-                current_batch_pipelines = self._automl_algorithm.next_batch()
-                current_batch_pipeline_scores = []
+                if not loop_interrupted:
+                    current_batch_pipelines = self._automl_algorithm.next_batch()
             except StopIteration:
                 logger.info('AutoML Algorithm out of recommendations, ending')
                 break
+            try:
+                new_pipeline_ids = self._engine.evaluate_batch(current_batch_pipelines)
+                loop_interrupted = False
+            except KeyboardInterrupt:
+                loop_interrupted = True
+                if self._handle_keyboard_interrupt():
+                    break
+            full_rankings = self.full_rankings
+            current_batch_idx = full_rankings['id'].isin(new_pipeline_ids)
+            current_batch_pipeline_scores = full_rankings[current_batch_idx]['score']
+            if len(current_batch_pipeline_scores) and current_batch_pipeline_scores.isna().all():
+                raise AutoMLSearchException(f"All pipelines in the current AutoML batch produced a score of np.nan on the primary objective {self.objective}.")
 
-            current_batch_size = len(current_batch_pipelines)
-            current_batch_pipeline_scores = self._evaluate_pipelines(current_batch_pipelines, search_iteration_plot=search_iteration_plot)
-
-            # Different size indicates early stopping
-            if len(current_batch_pipeline_scores) != current_batch_size:
-                break
-
+        self.search_duration = time.time() - self._start
         elapsed_time = time_elapsed(self._start)
         desc = f"\nSearch finished after {elapsed_time}"
         desc = desc.ljust(self._MAX_NAME_LEN)
         logger.info(desc)
 
-        best_pipeline = self.rankings.iloc[0]
-        best_pipeline_name = best_pipeline["pipeline_name"]
         self._find_best_pipeline()
-        logger.info(f"Best pipeline: {best_pipeline_name}")
-        logger.info(f"Best pipeline {self.objective.name}: {best_pipeline['score']:3f}")
+        if self._best_pipeline is not None:
+            best_pipeline = self.rankings.iloc[0]
+            best_pipeline_name = best_pipeline["pipeline_name"]
+            logger.info(f"Best pipeline: {best_pipeline_name}")
+            logger.info(f"Best pipeline {self.objective.name}: {best_pipeline['score']:3f}")
         self._searched = True
 
     def _find_best_pipeline(self):
         """Finds the best pipeline in the rankings
         If self._best_pipeline already exists, check to make sure it is different from the current best pipeline before training and thresholding"""
+        if len(self.rankings) == 0:
+            return
         best_pipeline = self.rankings.iloc[0]
         if not (self._best_pipeline and self._best_pipeline == self.get_pipeline(best_pipeline['id'])):
             self._best_pipeline = self.get_pipeline(best_pipeline['id'])
@@ -546,45 +576,49 @@ class AutoMLSearch:
                 X_threshold_tuning = None
                 y_threshold_tuning = None
                 X_train, y_train = self.X_train, self.y_train
-                if self.optimize_thresholds and self.objective.is_defined_for_problem_type(ProblemTypes.BINARY) and self.objective.can_optimize_threshold and is_binary(self.problem_type):
+                if is_binary(self.problem_type) and self.objective.is_defined_for_problem_type(self.problem_type) \
+                   and self.optimize_thresholds and self.objective.can_optimize_threshold:
                     X_train, X_threshold_tuning, y_train, y_threshold_tuning = split_data(X_train, y_train, self.problem_type,
                                                                                           test_size=0.2,
                                                                                           random_seed=self.random_seed)
                 self._best_pipeline.fit(X_train, y_train)
-                self._best_pipeline = self._tune_binary_threshold(self._best_pipeline, X_threshold_tuning, y_threshold_tuning)
+                tune_binary_threshold(self._best_pipeline, self.objective, self.problem_type, X_threshold_tuning, y_threshold_tuning)
 
-    def _tune_binary_threshold(self, pipeline, X_threshold_tuning, y_threshold_tuning):
-        """Tunes the threshold of a binary pipeline to the X and y thresholding data
-
-        Arguments:
-            pipeline (Pipeline): Pipeline instance to threshold
-            X_threshold_tuning (ww.DataTable): X data to tune pipeline to
-            y_threshold_tuning (ww.DataColumn): Target data to tune pipeline to
+    def _num_pipelines(self):
+        """Return the number of pipeline evaluations which have been made
 
         Returns:
-            Trained pipeline instance
+            int: the number of pipeline evaluations made in the search
         """
-        if self.objective.is_defined_for_problem_type(ProblemTypes.BINARY) and is_binary(self.problem_type):
-            pipeline.threshold = 0.5
-            if X_threshold_tuning:
-                y_predict_proba = pipeline.predict_proba(X_threshold_tuning)
-                y_predict_proba = y_predict_proba.iloc[:, 1]
-                pipeline.threshold = self.objective.optimize_threshold(y_predict_proba, y_threshold_tuning, X=X_threshold_tuning)
-        return pipeline
+        return len(self._results['pipeline_results'])
 
-    def _check_stopping_condition(self, start):
-        should_continue = True
-        num_pipelines = len(self._results['pipeline_results'])
+    def _should_continue(self):
+        """Given the original stopping criterion and current state, should the search continue?
+
+        Returns:
+            bool: True if yes, False if no.
+        """
+        if self._interrupted:
+            return False
+
+        # for add_to_rankings
+        if self._searched:
+            return True
+
+        # Run at least one pipeline for every search
+        num_pipelines = self._num_pipelines()
+        if num_pipelines == 0:
+            return True
 
         # check max_time and max_iterations
-        elapsed = time.time() - start
+        elapsed = time.time() - self._start
         if self.max_time and elapsed >= self.max_time:
             return False
         elif self.max_iterations and num_pipelines >= self.max_iterations:
             return False
 
         # check for early stopping
-        if self.patience is None:
+        if self.patience is None or self.tolerance is None:
             return True
 
         first_id = self._results['search_order'][0]
@@ -602,7 +636,7 @@ class AutoMLSearch:
             if num_without_improvement >= self.patience:
                 logger.info("\n\n{} iterations without improvement. Stopping search early...".format(self.patience))
                 return False
-        return should_continue
+        return True
 
     def _validate_problem_type(self):
         for obj in self.additional_objectives:
@@ -617,12 +651,7 @@ class AutoMLSearch:
         """Fits a baseline pipeline to the data.
 
         This is the first pipeline fit during search.
-
-        Returns:
-            bool - If the user ends the search early, will return True and searching will immediately finish. Else,
-                will return False and more pipelines will be searched.
         """
-
         if self.problem_type == ProblemTypes.BINARY:
             baseline = ModeBaselineBinaryPipeline(parameters={})
         elif self.problem_type == ProblemTypes.MULTICLASS:
@@ -637,12 +666,7 @@ class AutoMLSearch:
             max_delay = self.problem_configuration['max_delay']
             baseline = pipeline_class(parameters={"pipeline": {"gap": gap, "max_delay": max_delay},
                                                   "Time Series Baseline Estimator": {"gap": gap, "max_delay": max_delay}})
-
-        pipelines = [baseline]
-        scores = self._evaluate_pipelines(pipelines, baseline=True)
-        if scores == []:
-            return True
-        return False
+        self._engine.evaluate_batch([baseline])
 
     @staticmethod
     def _get_mean_cv_scores_for_all_objectives(cv_data, objective_name_to_class):
@@ -657,83 +681,17 @@ class AutoMLSearch:
                     scores[field] += value
         return {objective: float(score) / n_folds for objective, score in scores.items()}
 
-    def _compute_cv_scores(self, pipeline):
-        start = time.time()
-        cv_data = []
-        logger.info("\tStarting cross validation")
-
-        X_pd = _convert_woodwork_types_wrapper(self.X_train.to_dataframe())
-        y_pd = _convert_woodwork_types_wrapper(self.y_train.to_series())
-        for i, (train, valid) in enumerate(self.data_splitter.split(X_pd, y_pd)):
-
-            if pipeline.model_family == ModelFamily.ENSEMBLE and i > 0:
-                # Stacked ensembles do CV internally, so we do not run CV here for performance reasons.
-                logger.debug(f"Skipping fold {i} because CV for stacked ensembles is not supported.")
-                break
-            logger.debug(f"\t\tTraining and scoring on fold {i}")
-            X_train, X_valid = self.X_train.iloc[train], self.X_train.iloc[valid]
-            y_train, y_valid = self.y_train.iloc[train], self.y_train.iloc[valid]
-            if self.problem_type in [ProblemTypes.BINARY, ProblemTypes.MULTICLASS]:
-                diff_train = set(np.setdiff1d(self.y_train.to_series(), y_train.to_series()))
-                diff_valid = set(np.setdiff1d(self.y_train.to_series(), y_valid.to_series()))
-                diff_string = f"Missing target values in the training set after data split: {diff_train}. " if diff_train else ""
-                diff_string += f"Missing target values in the validation set after data split: {diff_valid}." if diff_valid else ""
-                if diff_string:
-                    raise Exception(diff_string)
-            objectives_to_score = [self.objective] + self.additional_objectives
-            cv_pipeline = None
-            try:
-                X_threshold_tuning = None
-                y_threshold_tuning = None
-                if self.optimize_thresholds and self.objective.is_defined_for_problem_type(ProblemTypes.BINARY) and self.objective.can_optimize_threshold and is_binary(self.problem_type):
-                    X_train, X_threshold_tuning, y_train, y_threshold_tuning = split_data(X_train, y_train, self.problem_type,
-                                                                                          test_size=0.2,
-                                                                                          random_seed=self.random_seed)
-                cv_pipeline = pipeline.clone()
-                logger.debug(f"\t\t\tFold {i}: starting training")
-                cv_pipeline.fit(X_train, y_train)
-                logger.debug(f"\t\t\tFold {i}: finished training")
-                cv_pipeline = self._tune_binary_threshold(cv_pipeline, X_threshold_tuning, y_threshold_tuning)
-                if X_threshold_tuning:
-                    logger.debug(f"\t\t\tFold {i}: Optimal threshold found ({cv_pipeline.threshold:.3f})")
-                logger.debug(f"\t\t\tFold {i}: Scoring trained pipeline")
-                scores = cv_pipeline.score(X_valid, y_valid, objectives=objectives_to_score)
-                logger.debug(f"\t\t\tFold {i}: {self.objective.name} score: {scores[self.objective.name]:.3f}")
-                score = scores[self.objective.name]
-            except Exception as e:
-                if self.error_callback is not None:
-                    self.error_callback(exception=e, traceback=traceback.format_tb(sys.exc_info()[2]), automl=self,
-                                        fold_num=i, pipeline=pipeline)
-                if isinstance(e, PipelineScoreError):
-                    nan_scores = {objective: np.nan for objective in e.exceptions}
-                    scores = {**nan_scores, **e.scored_successfully}
-                    scores = OrderedDict({o.name: scores[o.name] for o in [self.objective] + self.additional_objectives})
-                    score = scores[self.objective.name]
-                else:
-                    score = np.nan
-                    scores = OrderedDict(zip([n.name for n in self.additional_objectives], [np.nan] * len(self.additional_objectives)))
-
-            ordered_scores = OrderedDict()
-            ordered_scores.update({self.objective.name: score})
-            ordered_scores.update(scores)
-            ordered_scores.update({"# Training": y_train.shape[0]})
-            ordered_scores.update({"# Validation": y_valid.shape[0]})
-
-            evaluation_entry = {"all_objective_scores": ordered_scores, "score": score, 'binary_classification_threshold': None}
-            if isinstance(cv_pipeline, BinaryClassificationPipeline) and cv_pipeline.threshold is not None:
-                evaluation_entry['binary_classification_threshold'] = cv_pipeline.threshold
-            cv_data.append(evaluation_entry)
-        training_time = time.time() - start
-        cv_scores = pd.Series([fold['score'] for fold in cv_data])
-        cv_score_mean = cv_scores.mean()
-        logger.info(f"\tFinished cross validation - mean {self.objective.name}: {cv_score_mean:.3f}")
-        return {'cv_data': cv_data, 'training_time': training_time, 'cv_scores': cv_scores, 'cv_score_mean': cv_score_mean}
-
-    def _add_result(self, trained_pipeline, parameters, training_time, cv_data, cv_scores):
+    def _post_evaluation_callback(self, pipeline, evaluation_results):
+        training_time = evaluation_results['training_time']
+        cv_data = evaluation_results['cv_data']
+        cv_scores = evaluation_results['cv_scores']
+        is_baseline = pipeline.model_family == ModelFamily.BASELINE
         cv_score = cv_scores.mean()
 
         percent_better_than_baseline = {}
         mean_cv_all_objectives = self._get_mean_cv_scores_for_all_objectives(cv_data, self.objective_name_to_class)
+        if is_baseline:
+            self._baseline_cv_scores = mean_cv_all_objectives
         for obj_name in mean_cv_all_objectives:
             objective_class = self.objective_name_to_class[obj_name]
 
@@ -743,23 +701,21 @@ class AutoMLSearch:
                                                                           self._baseline_cv_scores.get(obj_name, np.nan))
             percent_better_than_baseline[obj_name] = percent_better
 
-        pipeline_name = trained_pipeline.name
-        pipeline_summary = trained_pipeline.summary
-        pipeline_id = len(self._results['pipeline_results'])
-
+        pipeline_name = pipeline.name
         high_variance_cv_check = HighVarianceCVDataCheck(threshold=0.2)
         high_variance_cv_check_results = high_variance_cv_check.validate(pipeline_name=pipeline_name, cv_scores=cv_scores)
         high_variance_cv = False
-
         if high_variance_cv_check_results["warnings"]:
             logger.warning(high_variance_cv_check_results["warnings"][0]["message"])
             high_variance_cv = True
+
+        pipeline_id = len(self._results['pipeline_results'])
         self._results['pipeline_results'][pipeline_id] = {
             "id": pipeline_id,
             "pipeline_name": pipeline_name,
-            "pipeline_class": type(trained_pipeline),
-            "pipeline_summary": pipeline_summary,
-            "parameters": parameters,
+            "pipeline_class": type(pipeline),
+            "pipeline_summary": pipeline.summary,
+            "parameters": pipeline.parameters,
             "score": cv_score,
             "high_variance_cv": high_variance_cv,
             "training_time": training_time,
@@ -770,67 +726,19 @@ class AutoMLSearch:
         }
         self._results['search_order'].append(pipeline_id)
 
-        if self.add_result_callback:
-            self.add_result_callback(self._results['pipeline_results'][pipeline_id], trained_pipeline, self)
-
-    def _evaluate_pipelines(self, current_pipeline_batch, baseline=False, search_iteration_plot=None):
-        current_batch_pipeline_scores = []
-        add_single_pipeline = False
-        if isinstance(current_pipeline_batch, PipelineBase):
-            current_pipeline_batch = [current_pipeline_batch]
-            add_single_pipeline = True
-
-        while len(current_pipeline_batch) > 0 and (add_single_pipeline or baseline or self._check_stopping_condition(self._start)):
-            pipeline = current_pipeline_batch.pop()
+        if not is_baseline:
+            score_to_minimize = -cv_score if self.objective.greater_is_better else cv_score
             try:
-                parameters = pipeline.parameters
-                logger.debug('Evaluating pipeline {}'.format(pipeline.name))
-                logger.debug('Pipeline parameters: {}'.format(parameters))
+                self._automl_algorithm.add_result(score_to_minimize, pipeline)
+            except PipelineNotFoundError:
+                pass
 
-                if self.start_iteration_callback:
-                    self.start_iteration_callback(pipeline.__class__, parameters, self)
-                desc = f"{pipeline.name}"
-                if len(desc) > self._MAX_NAME_LEN:
-                    desc = desc[:self._MAX_NAME_LEN - 3] + "..."
-                desc = desc.ljust(self._MAX_NAME_LEN)
+        if self.search_iteration_plot:
+            self.search_iteration_plot.update()
 
-                if not add_single_pipeline:
-                    update_pipeline(logger, desc, len(self._results['pipeline_results']) + 1, self.max_iterations,
-                                    self._start, 1 if baseline else self._automl_algorithm.batch_number, self.show_batch_output)
-
-                evaluation_results = self._compute_cv_scores(pipeline)
-                parameters = pipeline.parameters
-
-                if baseline:
-                    self._baseline_cv_scores = self._get_mean_cv_scores_for_all_objectives(evaluation_results["cv_data"], self.objective_name_to_class)
-
-                logger.debug('Adding results for pipeline {}\nparameters {}\nevaluation_results {}'.format(pipeline.name, parameters, evaluation_results))
-                self._add_result(trained_pipeline=pipeline,
-                                 parameters=parameters,
-                                 training_time=evaluation_results['training_time'],
-                                 cv_data=evaluation_results['cv_data'],
-                                 cv_scores=evaluation_results['cv_scores'])
-                logger.debug('Adding results complete')
-
-                score = evaluation_results['cv_score_mean']
-                score_to_minimize = -score if self.objective.greater_is_better else score
-                current_batch_pipeline_scores.append(score_to_minimize)
-
-                if not baseline and not add_single_pipeline:
-                    self._automl_algorithm.add_result(score_to_minimize, pipeline)
-
-                if search_iteration_plot:
-                    search_iteration_plot.update()
-
-                if add_single_pipeline:
-                    add_single_pipeline = False
-
-            except KeyboardInterrupt:
-                current_pipeline_batch = self._handle_keyboard_interrupt(pipeline, current_pipeline_batch)
-                if current_pipeline_batch == []:
-                    return current_batch_pipeline_scores
-
-        return current_batch_pipeline_scores
+        if self.add_result_callback:
+            self.add_result_callback(self._results['pipeline_results'][pipeline_id], pipeline, self)
+        return pipeline_id
 
     def get_pipeline(self, pipeline_id):
         """Given the ID of a pipeline training result, returns an untrained instance of the specified pipeline
@@ -915,7 +823,8 @@ class AutoMLSearch:
         for parameter in pipeline_rows['parameters']:
             if pipeline.parameters == parameter:
                 return
-        self._evaluate_pipelines(pipeline)
+
+        self._engine.evaluate_batch([pipeline])
         self._find_best_pipeline()
 
     @property

--- a/evalml/automl/callbacks.py
+++ b/evalml/automl/callbacks.py
@@ -10,7 +10,7 @@ def silent_error_callback(exception, traceback, automl, **kwargs):
 
 def raise_error_callback(exception, traceback, automl, **kwargs):
     """Raises the exception thrown by the AutoMLSearch object. Also logs the exception as an error."""
-    logger.error(f'AutoMLSearch raised a fatal exception: {str(exception)}')
+    logger.error(f'AutoML search raised a fatal exception: {str(exception)}')
     logger.error("\n".join(traceback))
     raise exception
 
@@ -26,7 +26,7 @@ def log_and_save_error_callback(exception, traceback, automl, **kwargs):
 def raise_and_save_error_callback(exception, traceback, automl, **kwargs):
     """Raises the exception thrown by the AutoMLSearch object, logs it as an error,
         and adds the exception to the 'errors' list in AutoMLSearch object results."""
-    logger.error(f'AutoMLSearch raised a fatal exception: {str(exception)}')
+    logger.error(f'AutoML search raised a fatal exception: {str(exception)}')
     logger.error("\n".join(traceback))
     automl._results['errors'].append(exception)
     raise exception

--- a/evalml/automl/engine/__init__.py
+++ b/evalml/automl/engine/__init__.py
@@ -1,0 +1,2 @@
+from .engine_base import EngineBase
+from .sequential_engine import SequentialEngine

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -1,0 +1,135 @@
+import sys
+import time
+import traceback
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+
+import numpy as np
+import pandas as pd
+
+from evalml.automl.utils import tune_binary_threshold
+from evalml.exceptions import PipelineScoreError
+from evalml.model_family import ModelFamily
+from evalml.preprocessing import split_data
+from evalml.problem_types import is_binary, is_multiclass
+from evalml.utils.logger import get_logger
+from evalml.utils.woodwork_utils import _convert_woodwork_types_wrapper
+
+logger = get_logger(__file__)
+
+
+class EngineBase(ABC):
+    """Base class for the engine API which handles the fitting and evaluation of pipelines during AutoML."""
+
+    def __init__(self, X_train=None, y_train=None, automl=None, should_continue_callback=None, pre_evaluation_callback=None, post_evaluation_callback=None):
+        """Base class for the engine API which handles the fitting and evaluation of pipelines during AutoML.
+
+        Arguments:
+            X_train (ww.DataTable): training features
+            y_train (ww.DataColumn): training target
+            automl (AutoMLSearch): a reference to the AutoML search. Used to access configuration and by the error callback.
+            should_continue_callback (function): returns True if another pipeline from the list should be evaluated, False otherwise.
+            pre_evaluation_callback (function): optional callback invoked before pipeline evaluation.
+            post_evaluation_callback (function): optional callback invoked after pipeline evaluation, with args pipeline and evaluation results. Expected to return a list of pipeline IDs corresponding to each pipeline evaluation.
+        """
+        self.X_train = X_train
+        self.y_train = y_train
+        self.automl = automl
+        self._should_continue_callback = should_continue_callback
+        self._pre_evaluation_callback = pre_evaluation_callback
+        self._post_evaluation_callback = post_evaluation_callback
+
+    @abstractmethod
+    def evaluate_batch(self, pipelines):
+        """Evaluate a batch of pipelines using the current dataset and AutoML state.
+
+        Arguments:
+            pipeline_batch (list(PipelineBase)): A batch of pipelines to be fitted and evaluated
+
+        Returns:
+            list (int): a list of the new pipeline IDs which were created by the AutoML search.
+        """
+
+    @staticmethod
+    def train_and_score_pipeline(pipeline, automl, full_X_train, full_y_train):
+        """Given a pipeline, config and data, train and score the pipeline and return the CV or TV scores
+
+        Arguments:
+            pipeline (PipelineBase): the pipeline to score
+            automl (AutoMLSearch): the AutoML search, used to access config and for the error callback
+            full_X_train (ww.DataTable): training features
+            full_y_train (ww.DataColumn): training target
+
+        Returns:
+            dict: a dict containing cv_score_mean, cv_scores, training_time and a cv_data structure with details.
+        """
+        start = time.time()
+        cv_data = []
+        logger.info("\tStarting cross validation")
+        X_pd = _convert_woodwork_types_wrapper(full_X_train.to_dataframe())
+        y_pd = _convert_woodwork_types_wrapper(full_y_train.to_series())
+        for i, (train, valid) in enumerate(automl.data_splitter.split(X_pd, y_pd)):
+            if pipeline.model_family == ModelFamily.ENSEMBLE and i > 0:
+                # Stacked ensembles do CV internally, so we do not run CV here for performance reasons.
+                logger.debug(f"Skipping fold {i} because CV for stacked ensembles is not supported.")
+                break
+            logger.debug(f"\t\tTraining and scoring on fold {i}")
+            X_train, X_valid = full_X_train.iloc[train], full_X_train.iloc[valid]
+            y_train, y_valid = full_y_train.iloc[train], full_y_train.iloc[valid]
+            if is_binary(automl.problem_type) or is_multiclass(automl.problem_type):
+                diff_train = set(np.setdiff1d(full_y_train.to_series(), y_train.to_series()))
+                diff_valid = set(np.setdiff1d(full_y_train.to_series(), y_valid.to_series()))
+                diff_string = f"Missing target values in the training set after data split: {diff_train}. " if diff_train else ""
+                diff_string += f"Missing target values in the validation set after data split: {diff_valid}." if diff_valid else ""
+                if diff_string:
+                    raise Exception(diff_string)
+            objectives_to_score = [automl.objective] + automl.additional_objectives
+            cv_pipeline = None
+            try:
+                X_threshold_tuning = None
+                y_threshold_tuning = None
+                if automl.optimize_thresholds and automl.objective.is_defined_for_problem_type(automl.problem_type) and \
+                   automl.objective.can_optimize_threshold and is_binary(automl.problem_type):
+                    X_train, X_threshold_tuning, y_train, y_threshold_tuning = split_data(X_train, y_train, automl.problem_type,
+                                                                                          test_size=0.2,
+                                                                                          random_state=automl.random_seed)
+                cv_pipeline = pipeline.clone()
+                logger.debug(f"\t\t\tFold {i}: starting training")
+                cv_pipeline.fit(X_train, y_train)
+                logger.debug(f"\t\t\tFold {i}: finished training")
+                tune_binary_threshold(cv_pipeline, automl.objective, automl.problem_type,
+                                      X_threshold_tuning, y_threshold_tuning)
+                if X_threshold_tuning:
+                    logger.debug(f"\t\t\tFold {i}: Optimal threshold found ({cv_pipeline.threshold:.3f})")
+                logger.debug(f"\t\t\tFold {i}: Scoring trained pipeline")
+                scores = cv_pipeline.score(X_valid, y_valid, objectives=objectives_to_score)
+                logger.debug(f"\t\t\tFold {i}: {automl.objective.name} score: {scores[automl.objective.name]:.3f}")
+                score = scores[automl.objective.name]
+            except Exception as e:
+                if automl.error_callback is not None:
+                    automl.error_callback(exception=e, traceback=traceback.format_tb(sys.exc_info()[2]), automl=automl,
+                                          fold_num=i, pipeline=pipeline)
+                if isinstance(e, PipelineScoreError):
+                    nan_scores = {objective: np.nan for objective in e.exceptions}
+                    scores = {**nan_scores, **e.scored_successfully}
+                    scores = OrderedDict({o.name: scores[o.name] for o in [automl.objective] + automl.additional_objectives})
+                    score = scores[automl.objective.name]
+                else:
+                    score = np.nan
+                    scores = OrderedDict(zip([n.name for n in automl.additional_objectives], [np.nan] * len(automl.additional_objectives)))
+
+            ordered_scores = OrderedDict()
+            ordered_scores.update({automl.objective.name: score})
+            ordered_scores.update(scores)
+            ordered_scores.update({"# Training": y_train.shape[0]})
+            ordered_scores.update({"# Validation": y_valid.shape[0]})
+
+            evaluation_entry = {"all_objective_scores": ordered_scores, "score": score, 'binary_classification_threshold': None}
+            if is_binary(automl.problem_type) and cv_pipeline is not None and cv_pipeline.threshold is not None:
+                evaluation_entry['binary_classification_threshold'] = cv_pipeline.threshold
+            cv_data.append(evaluation_entry)
+        training_time = time.time() - start
+        cv_scores = pd.Series([fold['score'] for fold in cv_data])
+        cv_score_mean = cv_scores.mean()
+        logger.info(f"\tFinished cross validation - mean {automl.objective.name}: {cv_score_mean:.3f}")
+        return {'cv_data': cv_data, 'training_time': training_time, 'cv_scores': cv_scores, 'cv_score_mean': cv_score_mean}

--- a/evalml/automl/engine/sequential_engine.py
+++ b/evalml/automl/engine/sequential_engine.py
@@ -1,0 +1,26 @@
+from evalml.automl.engine import EngineBase
+
+
+class SequentialEngine(EngineBase):
+    """The default engine for the AutoML search. Trains and scores pipelines locally, one after another."""
+
+    def evaluate_batch(self, pipelines):
+        """Evaluate a batch of pipelines using the current dataset and AutoML state.
+
+        Arguments:
+            pipelines (list(PipelineBase)): A batch of pipelines to be fitted and evaluated.
+
+        Returns:
+            list (int): a list of the new pipeline IDs which were created by the AutoML search.
+        """
+        if self.X_train is None or self.y_train is None:
+            raise ValueError("Dataset has not been loaded into the engine.")
+        new_pipeline_ids = []
+        index = 0
+        while self._should_continue_callback() and index < len(pipelines):
+            pipeline = pipelines[index]
+            self._pre_evaluation_callback(pipeline)
+            evaluation_result = EngineBase.train_and_score_pipeline(pipeline, self.automl, self.X_train, self.y_train)
+            new_pipeline_ids.append(self._post_evaluation_callback(pipeline, evaluation_result))
+            index += 1
+        return new_pipeline_ids

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -8,6 +8,7 @@ from evalml.preprocessing.data_splitters import (
 from evalml.problem_types import (
     ProblemTypes,
     handle_problem_types,
+    is_binary,
     is_time_series
 )
 from evalml.utils import deprecate_arg
@@ -68,3 +69,19 @@ def make_data_splitter(X, y, problem_type, problem_configuration=None, n_splits=
             raise ValueError("problem_configuration is required for time series problem types")
         return TimeSeriesSplit(n_splits=n_splits, gap=problem_configuration.get('gap'),
                                max_delay=problem_configuration.get('max_delay'))
+
+
+def tune_binary_threshold(pipeline, objective, problem_type, X_threshold_tuning, y_threshold_tuning):
+    """Tunes the threshold of a binary pipeline to the X and y thresholding data
+
+    Arguments:
+        pipeline (Pipeline): Pipeline instance to threshold
+        X_threshold_tuning (ww.DataTable): Features to tune pipeline to
+        y_threshold_tuning (ww.DataColumn): Target data to tune pipeline to
+    """
+    if is_binary(problem_type) and objective.is_defined_for_problem_type(problem_type) and objective.can_optimize_threshold:
+        pipeline.threshold = 0.5
+        if X_threshold_tuning:
+            y_predict_proba = pipeline.predict_proba(X_threshold_tuning)
+            y_predict_proba = y_predict_proba.iloc[:, 1]
+            pipeline.threshold = objective.optimize_threshold(y_predict_proba, y_threshold_tuning, X=X_threshold_tuning)

--- a/evalml/objectives/objective_base.py
+++ b/evalml/objectives/objective_base.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import woodwork as ww
 
+from evalml.problem_types import handle_problem_types
 from evalml.utils import _convert_woodwork_types_wrapper, classproperty
 
 
@@ -162,4 +163,4 @@ class ObjectiveBase(ABC):
 
     @classmethod
     def is_defined_for_problem_type(cls, problem_type):
-        return problem_type in cls.problem_types
+        return handle_problem_types(problem_type) in cls.problem_types

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -280,7 +280,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
 
     @classproperty
     def model_family(cls):
-        "Returns model family of this pipeline template"""
+        """Returns model family of this pipeline template"""
         component_graph = copy.copy(cls.component_graph)
         if isinstance(component_graph, list):
             return handle_component_class(component_graph[-1]).model_family
@@ -291,7 +291,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
 
     @classproperty
     def hyperparameters(cls):
-        "Returns hyperparameter ranges from all components as a dictionary"
+        """Returns hyperparameter ranges from all components as a dictionary"""
         hyperparameter_ranges = dict()
         component_graph = copy.copy(cls.component_graph)
         if isinstance(component_graph, list):

--- a/evalml/tests/automl_tests/test_automl_algorithm.py
+++ b/evalml/tests/automl_tests/test_automl_algorithm.py
@@ -1,6 +1,7 @@
 import pytest
 
 from evalml.automl.automl_algorithm import AutoMLAlgorithm
+from evalml.exceptions import PipelineNotFoundError
 
 
 class DummyAlgorithm(AutoMLAlgorithm):
@@ -35,3 +36,10 @@ def test_automl_algorithm_dummy():
     assert algo.batch_number == 3
     with pytest.raises(StopIteration, match='No more pipelines!'):
         algo.next_batch()
+
+
+def test_automl_algorithm_invalid_pipeline_add(dummy_regression_pipeline_class):
+    algo = DummyAlgorithm()
+    pipeline = dummy_regression_pipeline_class(parameters={})
+    with pytest.raises(PipelineNotFoundError, match="No such pipeline allowed in this AutoML search: Mock Regression Pipeline"):
+        algo.add_result(0.1234, pipeline)

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -1,5 +1,4 @@
 import pickle
-import time
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -277,30 +276,10 @@ def test_non_optimizable_threshold(mock_fit, mock_score, X_y_binary):
     automl.search()
     mock_fit.assert_called()
     mock_score.assert_called()
-    assert automl.best_pipeline.threshold is not None
-    assert automl.results['pipeline_results'][0]['cv_data'][0].get('binary_classification_threshold') == 0.5
-    assert automl.results['pipeline_results'][0]['cv_data'][1].get('binary_classification_threshold') == 0.5
-    assert automl.results['pipeline_results'][0]['cv_data'][2].get('binary_classification_threshold') == 0.5
-
-
-@patch('evalml.pipelines.MulticlassClassificationPipeline.score')
-@patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
-def test_non_optimizable_threshold_multi(mock_fit, mock_score, X_y_multi):
-    mock_score.return_value = {"Log Loss Multiclass": 0.5}
-    X, y = X_y_multi
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='multiclass', objective='Log Loss Multiclass', max_iterations=1)
-    automl.search()
-    mock_fit.assert_called()
-    mock_score.assert_called()
-    with pytest.raises(AttributeError):
-        automl.best_pipeline.threshold
-
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='multiclass', objective='Log Loss Multiclass', max_iterations=1, optimize_thresholds=True)
-    automl.search()
-    mock_fit.assert_called()
-    mock_score.assert_called()
-    with pytest.raises(AttributeError):
-        automl.best_pipeline.threshold
+    assert automl.best_pipeline.threshold is None
+    assert automl.results['pipeline_results'][0]['cv_data'][0].get('binary_classification_threshold') is None
+    assert automl.results['pipeline_results'][0]['cv_data'][1].get('binary_classification_threshold') is None
+    assert automl.results['pipeline_results'][0]['cv_data'][2].get('binary_classification_threshold') is None
 
 
 def test_describe_pipeline_objective_ordered(X_y_binary, caplog):
@@ -338,34 +317,6 @@ def test_max_time_units(X_y_binary):
 
     with pytest.raises(TypeError, match="Parameter max_time must be a float, int, string or None. Received <class 'tuple'> with value \\(30, 'minutes'\\)."):
         AutoMLSearch(X_train=X, y_train=y, problem_type='binary', objective='F1', max_time=(30, 'minutes'))
-
-
-def test_early_stopping(caplog, logistic_regression_binary_pipeline_class, X_y_binary):
-    X, y = X_y_binary
-    with pytest.raises(ValueError, match='patience value must be a positive integer.'):
-        automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', objective='AUC', max_iterations=5, allowed_model_families=['linear_model'], patience=-1, random_seed=0)
-
-    with pytest.raises(ValueError, match='tolerance value must be'):
-        automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', objective='AUC', max_iterations=5, allowed_model_families=['linear_model'], patience=1, tolerance=1.5, random_seed=0)
-
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', objective='AUC', max_iterations=5,
-                          allowed_model_families=['linear_model'], patience=2, tolerance=0.05,
-                          random_seed=0, n_jobs=1)
-    mock_results = {
-        'search_order': [0, 1, 2],
-        'pipeline_results': {}
-    }
-
-    scores = [0.95, 0.84, 0.96]  # 0.96 is only 1% greater so it doesn't trigger patience due to tolerance
-    for id in mock_results['search_order']:
-        mock_results['pipeline_results'][id] = {}
-        mock_results['pipeline_results'][id]['score'] = scores[id]
-        mock_results['pipeline_results'][id]['pipeline_class'] = logistic_regression_binary_pipeline_class
-
-    automl._results = mock_results
-    automl._check_stopping_condition(time.time())
-    out = caplog.text
-    assert "2 iterations without improvement. Stopping search early." in out
 
 
 def test_plot_disabled_missing_dependency(X_y_binary, has_minimal_dependencies):
@@ -466,10 +417,8 @@ def test_automl_allowed_pipelines_no_allowed_pipelines(automl_type, X_y_binary, 
     is_multiclass = automl_type == ProblemTypes.MULTICLASS
     X, y = X_y_multi if is_multiclass else X_y_binary
     problem_type = 'multiclass' if is_multiclass else 'binary'
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type=problem_type, allowed_pipelines=None, allowed_model_families=[])
-    assert automl.allowed_pipelines is None
     with pytest.raises(ValueError, match="No allowed pipelines to search"):
-        automl.search()
+        AutoMLSearch(X_train=X, y_train=y, problem_type=problem_type, allowed_pipelines=None, allowed_model_families=[])
 
 
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
@@ -480,7 +429,7 @@ def test_automl_allowed_pipelines_specified_allowed_pipelines_binary(mock_fit, m
     expected_pipelines = [dummy_binary_pipeline_class]
     mock_score.return_value = {automl.objective.name: 1.0}
     assert automl.allowed_pipelines == expected_pipelines
-    assert automl.allowed_model_families is None
+    assert automl.allowed_model_families == [ModelFamily.NONE]
 
     automl.search()
     mock_fit.assert_called()
@@ -497,7 +446,7 @@ def test_automl_allowed_pipelines_specified_allowed_pipelines_multi(mock_fit, mo
     expected_pipelines = [dummy_multiclass_pipeline_class]
     mock_score.return_value = {automl.objective.name: 1.0}
     assert automl.allowed_pipelines == expected_pipelines
-    assert automl.allowed_model_families is None
+    assert automl.allowed_model_families == [ModelFamily.NONE]
 
     automl.search()
     mock_fit.assert_called()
@@ -513,7 +462,7 @@ def test_automl_allowed_pipelines_specified_allowed_model_families_binary(mock_f
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', allowed_pipelines=None, allowed_model_families=[ModelFamily.RANDOM_FOREST])
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.BINARY) for estimator in get_estimators(ProblemTypes.BINARY, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -525,7 +474,7 @@ def test_automl_allowed_pipelines_specified_allowed_model_families_binary(mock_f
     mock_score.reset_mock()
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', allowed_pipelines=None, allowed_model_families=['random_forest'])
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.BINARY) for estimator in get_estimators(ProblemTypes.BINARY, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
@@ -540,7 +489,7 @@ def test_automl_allowed_pipelines_specified_allowed_model_families_multi(mock_fi
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='multiclass', allowed_pipelines=None, allowed_model_families=[ModelFamily.RANDOM_FOREST])
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.MULTICLASS) for estimator in get_estimators(ProblemTypes.MULTICLASS, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -552,7 +501,7 @@ def test_automl_allowed_pipelines_specified_allowed_model_families_multi(mock_fi
     mock_score.reset_mock()
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='multiclass', allowed_pipelines=None, allowed_model_families=['random_forest'])
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.MULTICLASS) for estimator in get_estimators(ProblemTypes.MULTICLASS, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
@@ -567,7 +516,7 @@ def test_automl_allowed_pipelines_init_allowed_both_not_specified_binary(mock_fi
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', allowed_pipelines=None, allowed_model_families=None)
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.BINARY) for estimator in get_estimators(ProblemTypes.BINARY, model_families=None)]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -583,7 +532,7 @@ def test_automl_allowed_pipelines_init_allowed_both_not_specified_multi(mock_fit
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='multiclass', allowed_pipelines=None, allowed_model_families=None)
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.MULTICLASS) for estimator in get_estimators(ProblemTypes.MULTICLASS, model_families=None)]
-    assert automl.allowed_pipelines is None
+    assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -600,7 +549,8 @@ def test_automl_allowed_pipelines_init_allowed_both_specified_binary(mock_fit, m
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [dummy_binary_pipeline_class]
     assert automl.allowed_pipelines == expected_pipelines
-    assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
+    # the dummy binary pipeline estimator has model family NONE
+    assert set(automl.allowed_model_families) == set([ModelFamily.NONE])
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -617,7 +567,8 @@ def test_automl_allowed_pipelines_init_allowed_both_specified_multi(mock_fit, mo
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [dummy_multiclass_pipeline_class]
     assert automl.allowed_pipelines == expected_pipelines
-    assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
+    # the dummy multiclass pipeline estimator has model family NONE
+    assert set(automl.allowed_model_families) == set([ModelFamily.NONE])
 
     automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
@@ -728,6 +679,8 @@ def test_automl_supports_time_series_classification(mock_binary_fit, mock_multi_
 @patch('evalml.pipelines.BinaryClassificationPipeline.score')
 def test_automl_pickle_generated_pipeline(mock_binary_score, mock_binary_fit, mock_multi_score, mock_multi_fit,
                                           problem_type, X_y_binary, X_y_multi):
+    mock_binary_score.return_value = {"Log Loss Binary": 1.0}
+    mock_multi_score.return_value = {"Log Loss Multiclass": 1.0}
     if problem_type == ProblemTypes.BINARY:
         X, y = X_y_binary
         pipeline = GeneratedPipelineBinary
@@ -749,8 +702,11 @@ def test_automl_pickle_generated_pipeline(mock_binary_score, mock_binary_fit, mo
 @patch('evalml.pipelines.TimeSeriesBinaryClassificationPipeline.score')
 @patch('evalml.pipelines.TimeSeriesMulticlassClassificationPipeline.fit')
 @patch('evalml.pipelines.TimeSeriesBinaryClassificationPipeline.fit')
-def test_automl_time_series_classification_pickle_generated_pipeline(mock_binary_fit, mock_multi_fit, mock_binary_score, mock_multiclass_score,
+def test_automl_time_series_classification_pickle_generated_pipeline(mock_binary_fit, mock_multi_fit,
+                                                                     mock_binary_score, mock_multiclass_score,
                                                                      problem_type, X_y_binary, X_y_multi):
+    mock_binary_score.return_value = {"Log Loss Binary": 1.0}
+    mock_multiclass_score.return_value = {"Log Loss Multiclass": 1.0}
     if problem_type == ProblemTypes.TIME_SERIES_BINARY:
         X, y = X_y_binary
         pipeline = GeneratedPipelineTimeSeriesBinary
@@ -789,12 +745,16 @@ def test_automl_time_series_classification_threshold(mock_binary_fit, mock_binar
                           max_batches=2)
     automl.search()
     assert isinstance(automl.data_splitter, TimeSeriesSplit)
-    if optimize and objective == 'F1':
+    if objective == 'Log Loss Binary':
+        mock_optimize_threshold.assert_not_called()
+        assert automl.best_pipeline.threshold is None
+        mock_split_data.assert_not_called()
+    elif optimize and objective == 'F1':
         mock_optimize_threshold.assert_called()
         assert automl.best_pipeline.threshold == 0.62
         mock_split_data.assert_called()
         assert str(mock_split_data.call_args[0][2]) == problem_type
-    else:
+    elif not optimize and objective == 'F1':
         mock_optimize_threshold.assert_not_called()
         assert automl.best_pipeline.threshold == 0.5
         mock_split_data.assert_not_called()

--- a/evalml/tests/automl_tests/test_automl_search_regression.py
+++ b/evalml/tests/automl_tests/test_automl_search_regression.py
@@ -1,5 +1,4 @@
 import pickle
-import time
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -91,31 +90,6 @@ def test_callback(X_y_regression):
     assert counts["add_result_callback"] == max_iterations
 
 
-def test_early_stopping(caplog, linear_regression_pipeline_class, X_y_regression):
-    X, y = X_y_regression
-    tolerance = 0.005
-    patience = 2
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', objective='mse', max_time='60 seconds',
-                          patience=patience, tolerance=tolerance,
-                          allowed_model_families=['linear_model'], random_seed=0, n_jobs=1)
-
-    mock_results = {
-        'search_order': [0, 1, 2],
-        'pipeline_results': {}
-    }
-
-    scores = [150, 200, 195]
-    for id in mock_results['search_order']:
-        mock_results['pipeline_results'][id] = {}
-        mock_results['pipeline_results'][id]['score'] = scores[id]
-        mock_results['pipeline_results'][id]['pipeline_class'] = linear_regression_pipeline_class
-
-    automl._results = mock_results
-    automl._check_stopping_condition(time.time())
-    out = caplog.text
-    assert "2 iterations without improvement. Stopping search early." in out
-
-
 def test_plot_disabled_missing_dependency(X_y_regression, has_minimal_dependencies):
     X, y = X_y_regression
 
@@ -175,10 +149,8 @@ def test_log_metrics_only_passed_directly(X_y_regression):
 
 def test_automl_allowed_pipelines_no_allowed_pipelines(X_y_regression):
     X, y = X_y_regression
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=None, allowed_model_families=[])
-    assert automl.allowed_pipelines is None
     with pytest.raises(ValueError, match="No allowed pipelines to search"):
-        automl.search()
+        AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=None, allowed_model_families=[])
 
 
 @patch('evalml.pipelines.RegressionPipeline.score')
@@ -190,7 +162,7 @@ def test_automl_allowed_pipelines_specified_allowed_pipelines(mock_fit, mock_sco
     expected_pipelines = [dummy_regression_pipeline_class]
     mock_score.return_value = {automl.objective.name: 1.0}
     assert automl.allowed_pipelines == expected_pipelines
-    assert automl.allowed_model_families is None
+    assert automl.allowed_model_families == [ModelFamily.NONE]
 
     automl.search()
     mock_fit.assert_called()
@@ -206,11 +178,9 @@ def test_automl_allowed_pipelines_specified_allowed_model_families(mock_fit, moc
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=None, allowed_model_families=[ModelFamily.RANDOM_FOREST])
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.REGRESSION) for estimator in get_estimators(ProblemTypes.REGRESSION, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
-
-    automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
+    automl.search()
     mock_fit.assert_called()
     mock_score.assert_called()
 
@@ -218,11 +188,9 @@ def test_automl_allowed_pipelines_specified_allowed_model_families(mock_fit, moc
     mock_score.reset_mock()
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=None, allowed_model_families=['random_forest'])
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.REGRESSION) for estimator in get_estimators(ProblemTypes.REGRESSION, model_families=[ModelFamily.RANDOM_FOREST])]
-    assert automl.allowed_pipelines is None
-
-    automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
+    automl.search()
     mock_fit.assert_called()
     mock_score.assert_called()
 
@@ -234,11 +202,9 @@ def test_automl_allowed_pipelines_init_allowed_both_not_specified(mock_fit, mock
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=None, allowed_model_families=None)
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [make_pipeline(X, y, estimator, ProblemTypes.REGRESSION) for estimator in get_estimators(ProblemTypes.REGRESSION, model_families=None)]
-    assert automl.allowed_pipelines is None
-
-    automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([p.model_family for p in expected_pipelines])
+    automl.search()
     mock_fit.assert_called()
     mock_score.assert_called()
 
@@ -250,12 +216,9 @@ def test_automl_allowed_pipelines_init_allowed_both_specified(mock_fit, mock_sco
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=[dummy_regression_pipeline_class], allowed_model_families=[ModelFamily.RANDOM_FOREST])
     mock_score.return_value = {automl.objective.name: 1.0}
     expected_pipelines = [dummy_regression_pipeline_class]
-    assert automl.allowed_pipelines == expected_pipelines
-    assert set(automl.allowed_model_families) == set([ModelFamily.RANDOM_FOREST])
-
-    automl.search()
     assert_allowed_pipelines_equal_helper(automl.allowed_pipelines, expected_pipelines)
     assert set(automl.allowed_model_families) == set([p.model_family for p in expected_pipelines])
+    automl.search()
     mock_fit.assert_called()
     mock_score.assert_called()
 
@@ -311,10 +274,12 @@ def test_automl_supports_time_series_regression(mock_fit, mock_score, X_y_regres
         assert result['parameters']['pipeline'] == configuration
 
 
-@patch('evalml.pipelines.RegressionPipeline.fit')
 @patch('evalml.pipelines.RegressionPipeline.score')
-def test_automl_pickle_generated_pipeline(mock_regression_score, mock_regression_fit, X_y_regression):
-    class RegressionPipelineCustoms(RegressionPipeline):
+@patch('evalml.pipelines.RegressionPipeline.fit')
+def test_automl_pickle_generated_pipeline(mock_regression_fit, mock_regression_score, X_y_regression):
+    mock_regression_score.return_value = {"R2": 1.0}
+
+    class RegressionPipelineCustom(RegressionPipeline):
         custom_name = "Custom Regression Name"
         component_graph = ["Imputer", "Linear Regressor"]
         custom_hyperparameters = {"Imputer": {"numeric_impute_strategy": "most_frequent"}}
@@ -322,24 +287,28 @@ def test_automl_pickle_generated_pipeline(mock_regression_score, mock_regression
     X, y = X_y_regression
     pipeline = GeneratedPipelineRegression
 
-    a = AutoMLSearch(X_train=X, y_train=y, problem_type='regression')
+    allowed_estimators = get_estimators('regression')
+    allowed_pipelines = [make_pipeline(X, y, estimator, problem_type='regression') for estimator in allowed_estimators]
+    allowed_pipelines.append(RegressionPipelineCustom)
+    a = AutoMLSearch(X_train=X, y_train=y, problem_type='regression', allowed_pipelines=allowed_pipelines)
     a.search()
-    a.add_to_rankings(RegressionPipelineCustoms({}))
+    a.add_to_rankings(RegressionPipelineCustom({}))
     seen_name = False
     for i, row in a.rankings.iterrows():
         automl_pipeline = a.get_pipeline(row['id'])
         assert automl_pipeline.__class__ == pipeline
         assert pickle.loads(pickle.dumps(automl_pipeline))
-        if automl_pipeline.custom_name == RegressionPipelineCustoms.custom_name:
+        if automl_pipeline.custom_name == RegressionPipelineCustom.custom_name:
             seen_name = True
-            assert automl_pipeline.custom_hyperparameters == RegressionPipelineCustoms.custom_hyperparameters
-            assert automl_pipeline.component_graph == RegressionPipelineCustoms.component_graph
+            assert automl_pipeline.custom_hyperparameters == RegressionPipelineCustom.custom_hyperparameters
+            assert automl_pipeline.component_graph == RegressionPipelineCustom.component_graph
     assert seen_name
 
 
 @patch('evalml.pipelines.TimeSeriesRegressionPipeline.score')
 @patch('evalml.pipelines.TimeSeriesRegressionPipeline.fit')
 def test_automl_time_series_regression_pickle_generated_pipeline(mock_fit, mock_score, X_y_regression):
+    mock_score.return_value = {"R2": 1.0}
     X, y = X_y_regression
     configuration = {"gap": 0, "max_delay": 0, 'delay_target': False, 'delay_features': True}
     a = AutoMLSearch(X_train=X, y_train=y, problem_type="time series regression", problem_configuration=configuration)

--- a/evalml/tests/automl_tests/test_engine_base.py
+++ b/evalml/tests/automl_tests/test_engine_base.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from evalml.automl.automl_search import AutoMLSearch
+from evalml.automl.engine import EngineBase
+
+
+@patch('evalml.pipelines.BinaryClassificationPipeline.score')
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+def test_train_and_score_pipelines(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary):
+    X, y = X_y_binary
+    mock_score.return_value = {'Log Loss Binary': 0.42}
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', max_time=1, max_batches=1,
+                          allowed_pipelines=[dummy_binary_pipeline_class])
+    pipeline = dummy_binary_pipeline_class({})
+    evaluation_result = EngineBase.train_and_score_pipeline(pipeline, automl, automl.X_train, automl.y_train)
+    assert mock_fit.call_count == automl.data_splitter.get_n_splits()
+    assert mock_score.call_count == automl.data_splitter.get_n_splits()
+    assert evaluation_result.get('training_time') is not None
+    assert evaluation_result.get('cv_score_mean') == 0.42
+    pd.testing.assert_series_equal(evaluation_result.get('cv_scores'), pd.Series([0.42] * 3))
+    for i in range(automl.data_splitter.get_n_splits()):
+        assert evaluation_result['cv_data'][i]['all_objective_scores']['Log Loss Binary'] == 0.42
+
+
+@patch('evalml.pipelines.BinaryClassificationPipeline.score')
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+def test_train_and_score_pipelines_error(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary, caplog):
+    X, y = X_y_binary
+    mock_score.side_effect = Exception('yeet')
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', max_time=1, max_batches=1,
+                          allowed_pipelines=[dummy_binary_pipeline_class])
+    pipeline = dummy_binary_pipeline_class({})
+    evaluation_result = EngineBase.train_and_score_pipeline(pipeline, automl, automl.X_train, automl.y_train)
+    assert mock_fit.call_count == automl.data_splitter.get_n_splits()
+    assert mock_score.call_count == automl.data_splitter.get_n_splits()
+    assert evaluation_result.get('training_time') is not None
+    assert np.isnan(evaluation_result.get('cv_score_mean'))
+    pd.testing.assert_series_equal(evaluation_result.get('cv_scores'), pd.Series([np.nan] * 3))
+    for i in range(automl.data_splitter.get_n_splits()):
+        assert np.isnan(evaluation_result['cv_data'][i]['all_objective_scores']['Log Loss Binary'])
+    assert 'yeet' in caplog.text

--- a/evalml/tests/automl_tests/test_sequential_engine.py
+++ b/evalml/tests/automl_tests/test_sequential_engine.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evalml.automl import AutoMLSearch
+from evalml.automl.engine import SequentialEngine
+
+
+def test_evaluate_no_data():
+    engine = SequentialEngine()
+    expected_error = "Dataset has not been loaded into the engine."
+    with pytest.raises(ValueError, match=expected_error):
+        engine.evaluate_batch([])
+
+
+@patch('evalml.pipelines.BinaryClassificationPipeline.score')
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+def test_evaluate_batch(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary):
+    X, y = X_y_binary
+    mock_score.side_effect = [{'Log Loss Binary': 0.42}] * 3 + [{'Log Loss Binary': 0.5}] * 3
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', max_time=1, max_batches=1,
+                          allowed_pipelines=[dummy_binary_pipeline_class])
+    pipelines = [dummy_binary_pipeline_class({'Mock Classifier': {'a': 1}}),
+                 dummy_binary_pipeline_class({'Mock Classifier': {'a': 4.2}})]
+
+    mock_should_continue_callback = MagicMock(return_value=True)
+    mock_pre_evaluation_callback = MagicMock()
+    mock_post_evaluation_callback = MagicMock(side_effect=[123, 456])
+
+    engine = SequentialEngine(X_train=automl.X_train,
+                              y_train=automl.y_train,
+                              automl=automl,
+                              should_continue_callback=mock_should_continue_callback,
+                              pre_evaluation_callback=mock_pre_evaluation_callback,
+                              post_evaluation_callback=mock_post_evaluation_callback)
+    new_pipeline_ids = engine.evaluate_batch(pipelines)
+
+    assert len(pipelines) == 2  # input arg should not have been modified
+    assert mock_should_continue_callback.call_count == 3
+    assert mock_pre_evaluation_callback.call_count == 2
+    assert mock_post_evaluation_callback.call_count == 2
+    assert new_pipeline_ids == [123, 456]
+    assert mock_pre_evaluation_callback.call_args_list[0][0][0] == pipelines[0]
+    assert mock_pre_evaluation_callback.call_args_list[1][0][0] == pipelines[1]
+    assert mock_post_evaluation_callback.call_args_list[0][0][0] == pipelines[0]
+    assert mock_post_evaluation_callback.call_args_list[0][0][1]['cv_score_mean'] == 0.42
+    assert mock_post_evaluation_callback.call_args_list[1][0][0] == pipelines[1]
+    assert mock_post_evaluation_callback.call_args_list[1][0][1]['cv_score_mean'] == 0.5
+
+
+@patch('evalml.pipelines.BinaryClassificationPipeline.score')
+@patch('evalml.pipelines.BinaryClassificationPipeline.fit')
+def test_evaluate_batch_should_continue(mock_fit, mock_score, dummy_binary_pipeline_class, X_y_binary):
+    X, y = X_y_binary
+    mock_score.side_effect = [{'Log Loss Binary': 0.42}] * 3 + [{'Log Loss Binary': 0.5}] * 3
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', max_time=1, max_batches=1,
+                          allowed_pipelines=[dummy_binary_pipeline_class])
+    pipelines = [dummy_binary_pipeline_class({'Mock Classifier': {'a': 1}}),
+                 dummy_binary_pipeline_class({'Mock Classifier': {'a': 4.2}})]
+
+    # signal stop after 1st pipeline
+    mock_should_continue_callback = MagicMock(side_effect=[True, False])
+    mock_pre_evaluation_callback = MagicMock()
+    mock_post_evaluation_callback = MagicMock(side_effect=[123, 456])
+
+    engine = SequentialEngine(X_train=automl.X_train,
+                              y_train=automl.y_train,
+                              automl=automl,
+                              should_continue_callback=mock_should_continue_callback,
+                              pre_evaluation_callback=mock_pre_evaluation_callback,
+                              post_evaluation_callback=mock_post_evaluation_callback)
+    new_pipeline_ids = engine.evaluate_batch(pipelines)
+
+    assert len(pipelines) == 2  # input arg should not have been modified
+    assert mock_should_continue_callback.call_count == 2
+    assert mock_pre_evaluation_callback.call_count == 1
+    assert mock_post_evaluation_callback.call_count == 1
+    assert new_pipeline_ids == [123]
+    assert mock_pre_evaluation_callback.call_args_list[0][0][0] == pipelines[0]
+    assert mock_post_evaluation_callback.call_args_list[0][0][0] == pipelines[0]
+    assert mock_post_evaluation_callback.call_args_list[0][0][1]['cv_score_mean'] == 0.42
+
+    # no pipelines
+    mock_should_continue_callback = MagicMock(return_value=False)
+    mock_pre_evaluation_callback = MagicMock()
+    mock_post_evaluation_callback = MagicMock(side_effect=[123, 456])
+
+    engine = SequentialEngine(X_train=automl.X_train,
+                              y_train=automl.y_train,
+                              automl=automl,
+                              should_continue_callback=mock_should_continue_callback,
+                              pre_evaluation_callback=mock_pre_evaluation_callback,
+                              post_evaluation_callback=mock_post_evaluation_callback)
+    new_pipeline_ids = engine.evaluate_batch(pipelines)
+
+    assert len(pipelines) == 2  # input arg should not have been modified
+    assert mock_should_continue_callback.call_count == 1
+    assert mock_pre_evaluation_callback.call_count == 0
+    assert mock_post_evaluation_callback.call_count == 0
+    assert new_pipeline_ids == []

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -6,6 +6,7 @@ from evalml.exceptions import ObjectiveNotFoundError
 from evalml.objectives import (
     BinaryClassificationObjective,
     CostBenefitMatrix,
+    LogLossBinary,
     MulticlassClassificationObjective,
     RegressionObjective,
     get_all_objective_names,
@@ -126,3 +127,9 @@ def test_objective_outputs(X_y_binary, X_y_multi, binary_core_objectives,
                 y_predicted_pd = pd.DataFrame(y_predicted)
             np.testing.assert_almost_equal(objective.score(y_true_multi_np, y_predicted), expected_value)
             np.testing.assert_almost_equal(objective.score(pd.Series(y_true_multi_np), y_predicted_pd), expected_value)
+
+
+def test_is_defined_for_problem_type():
+    assert LogLossBinary.is_defined_for_problem_type(ProblemTypes.BINARY)
+    assert LogLossBinary.is_defined_for_problem_type('binary')
+    assert not LogLossBinary.is_defined_for_problem_type(ProblemTypes.MULTICLASS)


### PR DESCRIPTION
Fix #1296 

Changes
* Add `EngineBase` base class to define engine interface, and `SequentialEngine` which preserves existing behavior, evaluates pipelines in series
* Define `_pre_evaluation_callback` for logging and `_post_evaluation_callback` to add evaluation results to `AutoMLSearch`
* Move `AutoMLSearch. _compute_cv_scores` to `EngineBase.train_and_score_pipeline` as a `staticmethod`
* Refactored the `AutoMLSearch` binary threshold tuning logic into `tune_binary_threshold` so it could be reused. Fixed bug where all bin class pipelines were getting a threshold of 0.5 -- [now will get `None`](https://github.com/alteryx/evalml/pull/1838/files#diff-068c8096e3b254dc70a1399ca4a70f74aea2f8e17e03ae111460078891bf4c7eR2107) as was the original intent.
* Tweak criterion for doing bin threshold tuning to apply to timeseries binary classification as well.
* Now that `AutoMLSearch` constructor expects data, move much of the `search` setup logic into the constructor to simplify the behavior.
* Have `AutoMLAlgorithm.add_result` raise error if pipeline is unrecognized
* Update and simplify keyboard interrupt code; no intended change in user behavior
* Rename `_check_stopping_condition` to `_should_continue`
* Add traceback to the end of `log_error_callback`, which I believe partially handles #1778 (@bchen1116 heads up). This was helpful to me when debugging so I just went ahead and did it.
* Fixed some test bugs
    * In `test_automl.py`, `CustomClassificationObjective` wasn't subclassed from `BinaryClassificationObjective`, same for regression
    * Many tests were mocking pipeline `score` but not providing a return value, causing scores to be `nan`



Future:
* Pass a config object to engine classes' constructor instead of `AutoMLSearch` instance. I couldn't easily do this today because of the logging callback -- it expects a reference to `AutoMLSearch` to add the error to the `results` structure
* When we implement parallel evaluation, we'll have to decide what to do with the early stopping parameters, as those won't map over easily to the parallel batched evaluation format.
* **The changes in this PR are not threadsafe**. The calls to the should_continue/pre/post callbacks access and modify `AutoMLSearch` state without any sort of locking or atomicity. This is fine for this PR, but when we implement parallel evaluation, we'll need to address this.
* Add ability to accept an `EngineBase` subclass as input to `AutoMLSearch`, rather than creating internally. This would require thought about how to pass parameters and create the instance. We'd probably wanna switch to using a config object first for `AutoMLSearch`

Big credit to @christopherbunn for providing the initial implementation this PR is based on! 🙏 