### PR TITLE
Fixing coverage in TextFeaturizer

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Release Notes
         * Added ``random_seed`` as an argument to our automl/pipeline/component API. Using ``random_state`` will raise a warning :pr:`1798`
     * Documentation Changes
     * Testing Changes
+        * Added back coverage for ``_get_feature_provenance`` in ``TextFeaturizer`` after ``text_columns`` was removed :pr:`1842`
 
 
 **v0.18.2 Feb. 10, 2021**

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -71,6 +71,9 @@ class LinearPipelineWithTextFeatures(BinaryClassificationPipeline):
     component_graph = ['Imputer', 'Drop Columns Transformer', TextFeaturizer, OneHotEncoder, 'Random Forest Classifier']
 
 
+class LinearPipelineWithTextFeaturizerNoTextFeatures(LinearPipelineWithTextFeatures):
+    """Testing a pipeline with TextFeaturizer but no text features."""
+
 class LinearPipelineWithDoubling(BinaryClassificationPipeline):
     component_graph = ['Select Columns Transformer', DoubleColumns, DoubleColumns, DoubleColumns, 'Random Forest Classifier']
 
@@ -115,9 +118,8 @@ test_cases = [(LinearPipelineWithDropCols, {"Drop Columns Transformer": {'column
               (LinearPipelineSameFeatureUsedByTwoComponents, {'DateTime Featurization Component': {'encode_as_categories': True}}),
               (LinearPipelineTwoEncoders, {'One Hot Encoder': {'features_to_encode': ['currency', 'expiration_date', 'provider']},
                                            'One Hot Encoder_2': {'features_to_encode': ['region', 'country']}}),
-              (LinearPipelineWithTextFeatures, {'Drop Columns Transformer': {'columns': ['datetime']},
-                                                'Text Featurization Component': {'text_columns': ['provider']}}),
               (LinearPipelineWithTextFeatures, {'Drop Columns Transformer': {'columns': ['datetime']}}),
+              (LinearPipelineWithTextFeaturizerNoTextFeatures, {'Drop Columns Transformer': {'columns': ['datetime']}}),
               (LinearPipelineWithDoubling, {'Select Columns Transformer': {'columns': ['amount']}}),
               (LinearPipelineWithDoubling, {'Select Columns Transformer': {'columns': ['amount']},
                                             'DoubleColumns': {'drop_old_columns': False}}),
@@ -148,6 +150,9 @@ def test_fast_permutation_importance_matches_sklearn_output(mock_supports_fast_i
         pytest.skip("Skipping test_fast_permutation_importance_matches_sklearn_output for target encoder cause "
                     "dependency not installed.")
     X, y = load_fraud(100)
+
+    if pipeline_class == LinearPipelineWithTextFeatures:
+        X = X.set_types(logical_types={'provider': 'NaturalLanguage'})
 
     # Do this to make sure we use the same int as sklearn under the hood
     random_state = np.random.RandomState(0)

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -74,6 +74,7 @@ class LinearPipelineWithTextFeatures(BinaryClassificationPipeline):
 class LinearPipelineWithTextFeaturizerNoTextFeatures(LinearPipelineWithTextFeatures):
     """Testing a pipeline with TextFeaturizer but no text features."""
 
+
 class LinearPipelineWithDoubling(BinaryClassificationPipeline):
     component_graph = ['Select Columns Transformer', DoubleColumns, DoubleColumns, DoubleColumns, 'Random Forest Classifier']
 


### PR DESCRIPTION
### Pull Request Description

With the removal of `text_columns` in #1652, the `_get_feature_provenance` method of `TextFeaturizer` and `LSA` was [no longer being covered](https://codecov.io/gh/alteryx/evalml/src/main/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py) because the test dataset doesn't have any text features and the text features were specified with `text_columns`. 




-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
