### PR TITLE
Prediction Explanations Refactor: only compute features once

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Updated ``visualize_decision_tree`` to include feature names in output :pr:`1813`
         * Added ``is_bounded_like_percentage`` property for objectives. If true, the ``calculate_percent_difference`` method will return the absolute difference rather than relative difference :pr:`1809`
         * Changed ``TargetEncoder`` to preserve custom indices in the data :pr:`1836`
+        * Refactored ``explain_predictions`` and ``explain_predictions_best_worst`` to only compute features once for all rows that need to be explained :pr:`1843`
     * Fixes
     * Changes
         * Modified ``calculate_percent_difference`` so that division by 0 is now inf rather than nan :pr:`1809`

--- a/evalml/model_understanding/prediction_explanations/_report_creator_factory.py
+++ b/evalml/model_understanding/prediction_explanations/_report_creator_factory.py
@@ -30,29 +30,29 @@ def _report_creator_factory(data, report_type, output_format, top_k_features, in
     """
     if report_type == "explain_predictions" and output_format == "text":
         heading = _Heading([""], len(data.index_list))
-        shap_table = _SHAPTable(top_k_features, include_shap_values, data.input_features)
+        shap_table = _SHAPTable(top_k_features, include_shap_values)
         report_maker = _ReportMaker(heading, None, shap_table).make_text
     elif report_type == "explain_predictions" and output_format == "dict":
-        shap_table = _SHAPTable(top_k_features, include_shap_values, data.input_features)
+        shap_table = _SHAPTable(top_k_features, include_shap_values)
         report_maker = _ReportMaker(None, None, shap_table).make_dict
     elif report_type == "explain_predictions" and output_format == "dataframe":
-        shap_table = _SHAPTable(top_k_features, include_shap_values, data.input_features)
+        shap_table = _SHAPTable(top_k_features, include_shap_values)
         report_maker = _ReportMaker(None, None, shap_table).make_dataframe
     elif report_type == "explain_predictions_best_worst" and output_format == "text":
         heading_maker = _Heading(["Best ", "Worst "], n_indices=num_to_explain)
         predicted_values = _best_worst_predicted_values_section(data, _RegressionPredictedValues,
                                                                 _ClassificationPredictedValues)
-        table_maker = _SHAPTable(top_k_features, include_shap_values, training_data=data.input_features)
+        table_maker = _SHAPTable(top_k_features, include_shap_values)
         report_maker = _ReportMaker(heading_maker, predicted_values, table_maker).make_text
     elif report_type == "explain_predictions_best_worst" and output_format == "dataframe":
         heading_maker = _Heading(["best", "worst"], n_indices=num_to_explain)
-        table_maker = _SHAPTable(top_k_features, include_shap_values, training_data=data.input_features)
+        table_maker = _SHAPTable(top_k_features, include_shap_values)
         predicted_values = _best_worst_predicted_values_section(data, _RegressionPredictedValues,
                                                                 _ClassificationPredictedValues)
         report_maker = _ReportMaker(heading_maker, predicted_values, table_maker).make_dataframe
     else:
         heading_maker = _Heading(["best", "worst"], n_indices=num_to_explain)
-        table_maker = _SHAPTable(top_k_features, include_shap_values, training_data=data.input_features)
+        table_maker = _SHAPTable(top_k_features, include_shap_values)
         predicted_values = _best_worst_predicted_values_section(data, _RegressionPredictedValues,
                                                                 _ClassificationPredictedValues)
         report_maker = _ReportMaker(heading_maker, predicted_values, table_maker).make_dict

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -223,10 +223,10 @@ def test_explain_prediction(mock_normalize_shap_values,
 
 def test_explain_prediction_errors():
     with pytest.raises(ValueError, match="Explained indices should be between"):
-        explain_prediction(None, pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, index_to_explain=5)
+        explain_prediction(MagicMock(), pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, index_to_explain=5)
 
     with pytest.raises(ValueError, match="Explained indices should be between"):
-        explain_prediction(None, pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, index_to_explain=-1)
+        explain_prediction(MagicMock(), pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, index_to_explain=-1)
 
 
 def test_error_metrics():
@@ -263,28 +263,28 @@ def test_explain_predictions_raises_pipeline_score_error():
 
 def test_explain_predictions_value_errors():
     with pytest.raises(ValueError, match="Parameter input_features must be a non-empty dataframe."):
-        explain_predictions(None, pd.DataFrame(), y=None, indices_to_explain=[0])
+        explain_predictions(MagicMock(), pd.DataFrame(), y=None, indices_to_explain=[0])
 
     with pytest.raises(ValueError, match="Explained indices should be between"):
-        explain_predictions(None, pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[5])
+        explain_predictions(MagicMock(), pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[5])
 
     with pytest.raises(ValueError, match="Explained indices should be between"):
-        explain_predictions(None, pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[1, 5])
+        explain_predictions(MagicMock(), pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[1, 5])
 
     with pytest.raises(ValueError, match="Explained indices should be between"):
-        explain_predictions(None, pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[-1])
+        explain_predictions(MagicMock(), pd.DataFrame({"a": [0, 1, 2, 3, 4]}), y=None, indices_to_explain=[-1])
 
 
 def test_output_format_checked():
     input_features, y_true = pd.DataFrame(data=[range(15)]), pd.Series(range(15))
     with pytest.raises(ValueError, match="Parameter output_format must be either text, dict, or dataframe. Received bar"):
-        explain_predictions(None, input_features, y=None, indices_to_explain=0, output_format="bar")
+        explain_predictions(pipeline=MagicMock(), input_features=input_features, y=None, indices_to_explain=0, output_format="bar")
     with pytest.raises(ValueError, match="Parameter output_format must be either text, dict, or dataframe. Received xml"):
-        explain_prediction(None, input_features=input_features, y=None, index_to_explain=0, output_format="xml")
+        explain_prediction(pipeline=MagicMock(), input_features=input_features, y=None, index_to_explain=0, output_format="xml")
 
     input_features, y_true = pd.DataFrame(data=range(15)), pd.Series(range(15))
     with pytest.raises(ValueError, match="Parameter output_format must be either text, dict, or dataframe. Received foo"):
-        explain_predictions_best_worst(None, input_features, y_true=y_true, output_format="foo")
+        explain_predictions_best_worst(pipeline=MagicMock, input_features=input_features, y_true=y_true, output_format="foo")
 
 
 regression_best_worst_answer = """Test Pipeline Name
@@ -598,6 +598,7 @@ def test_explain_predictions_best_worst_and_explain_predictions(mock_make_table,
     input_features = pd.DataFrame({"a": [3, 4]}, index=custom_index)
     pipeline.problem_type = problem_type
     pipeline.name = "Test Pipeline Name"
+    pipeline.compute_estimator_features.return_value = ww.DataTable(input_features)
 
     def _add_custom_index(answer, index_best, index_worst, output_format):
 
@@ -720,6 +721,7 @@ def test_explain_predictions_best_worst_custom_metric(mock_make_table, output_fo
     input_features = pd.DataFrame({"a": [5, 6]})
     pipeline.problem_type = ProblemTypes.REGRESSION
     pipeline.name = "Test Pipeline Name"
+    pipeline.compute_estimator_features.return_value = ww.DataTable(input_features)
 
     pipeline.predict.return_value = ww.DataColumn(pd.Series([2, 1]))
     y_true = pd.Series([3, 2])


### PR DESCRIPTION
### Pull Request Description

Fixes #1821 


### About 4x faster on fraud dataset !

![explain_predictions_best_worst_time_comparison](https://user-images.githubusercontent.com/41651716/108088656-b6b0e500-7046-11eb-9355-35472b1ee5d0.png)


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
