### PR TITLE
Update Woodwork to 0.0.10

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -11,7 +11,7 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.35.0
 texttable>=1.6.2
-woodwork==0.0.7
+woodwork==0.0.10
 featuretools>=0.20.0
 nlp-primitives>=1.1.0
 networkx>=2.5

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+        * Updated ``Woodwork`` requirement to ``v0.0.10`` :pr:`1900`
     * Fixes
         * Added metaclass for time series pipelines and fix binary classification pipeline ``predict`` not using objective if it is passed as a named argument :pr:`1874`
     * Changes

--- a/evalml/data_checks/target_leakage_data_check.py
+++ b/evalml/data_checks/target_leakage_data_check.py
@@ -69,11 +69,11 @@ class TargetLeakageDataCheck(DataCheck):
         Example:
             >>> import pandas as pd
             >>> X = pd.DataFrame({
-            ...    'leak': [10, 42, 31, 51, 61],
+            ...    'leak': [10, 44, 31, 51, 44],
             ...    'x': [42, 54, 12, 64, 12],
             ...    'y': [13, 5, 13, 74, 24],
             ... })
-            >>> y = pd.Series([10, 42, 31, 51, 40])
+            >>> y = pd.Series([10, 42, 31, 51, 42])
             >>> target_leakage_check = TargetLeakageDataCheck(pct_corr_threshold=0.95)
             >>> assert target_leakage_check.validate(X, y) == {"warnings": [{"message": "Column 'leak' is 95.0% or more correlated with the target",\
                                                                              "data_check_name": "TargetLeakageDataCheck",\

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -158,16 +158,12 @@ def test_default_data_checks_regression(input_type):
         X = ww.DataTable(X)
         y = ww.DataColumn(y)
         y_no_variance = ww.DataColumn(y_no_variance)
-    id_leakage = [DataCheckWarning(message="Column 'id' is 95.0% or more correlated with the target",
-                                   data_check_name="TargetLeakageDataCheck",
-                                   message_code=DataCheckMessageCode.TARGET_LEAKAGE,
-                                   details={"column": "id"}).to_dict()]
     null_leakage = [DataCheckWarning(message="Column 'lots_of_null' is 95.0% or more correlated with the target",
                                      data_check_name="TargetLeakageDataCheck",
                                      message_code=DataCheckMessageCode.TARGET_LEAKAGE,
                                      details={"column": "lots_of_null"}).to_dict()]
     data_checks = DefaultDataChecks("regression", get_default_primary_search_objective("regression"))
-    assert data_checks.validate(X, y) == {"warnings": messages[:3] + id_leakage, "errors": messages[3:]}
+    assert data_checks.validate(X, y) == {"warnings": messages[:3], "errors": messages[3:]}
 
     # Skip Invalid Target
     assert data_checks.validate(X, y_no_variance) == {"warnings": messages[:3] + null_leakage, "errors": messages[4:] + [DataCheckError(message="Y has 1 unique value.",
@@ -178,7 +174,7 @@ def test_default_data_checks_regression(input_type):
     data_checks = DataChecks(DefaultDataChecks._DEFAULT_DATA_CHECK_CLASSES,
                              {"InvalidTargetDataCheck": {"problem_type": "regression",
                                                          "objective": get_default_primary_search_objective("regression")}})
-    assert data_checks.validate(X, y) == {"warnings": messages[:3] + id_leakage, "errors": messages[3:]}
+    assert data_checks.validate(X, y) == {"warnings": messages[:3], "errors": messages[3:]}
 
 
 def test_default_data_checks_time_series_regression():

--- a/evalml/tests/data_checks_tests/test_multicollinearity_data_check.py
+++ b/evalml/tests/data_checks_tests/test_multicollinearity_data_check.py
@@ -30,7 +30,7 @@ def test_multicollinearity_data_check_init():
 
 
 def test_multicollinearity_returns_warning():
-    col = pd.Series([1, 0, 2, 3, 4])
+    col = pd.Series([1, 0, 0, 3, 4])
     X = pd.DataFrame({'col_1': col,
                       'col_2': col * 3,
                       'col_3': ~col,
@@ -53,7 +53,7 @@ def test_multicollinearity_returns_warning():
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_multicollinearity_nonnumeric_cols(data_type, make_data_type):
     X = pd.DataFrame({'col_1': ["a", "b", "c", "d", "a"],
-                      'col_2': ["w", "x", "y", "z", "b"],
+                      'col_2': ["w", "x", "y", "z", "w"],
                       'col_3': ["a", "a", "c", "d", "a"],
                       'col_4': ["a", "b", "c", "d", "a"],
                       'col_5': ["0", "0", "1", "2", "0"],
@@ -62,10 +62,12 @@ def test_multicollinearity_nonnumeric_cols(data_type, make_data_type):
     X = make_data_type(data_type, X)
     multi_check = MulticollinearityDataCheck(threshold=0.9)
     assert multi_check.validate(X) == {
-        "warnings": [DataCheckWarning(message="Columns are likely to be correlated: [('col_1', 'col_4'), ('col_3', 'col_5'), ('col_3', 'col_6'), ('col_5', 'col_6'), ('col_1', 'col_2'), ('col_2', 'col_4')]",
+        "warnings": [DataCheckWarning(message="Columns are likely to be correlated: [('col_1', 'col_2'), ('col_1', 'col_4'), ('col_2', 'col_4'), ('col_3', 'col_5'), ('col_3', 'col_6'), ('col_5', 'col_6')]",
                                       data_check_name=multi_data_check_name,
                                       message_code=DataCheckMessageCode.IS_MULTICOLLINEAR,
-                                      details={'columns': [('col_1', 'col_4'), ('col_3', 'col_5'), ('col_3', 'col_6'), ('col_5', 'col_6'), ('col_1', 'col_2'), ('col_2', 'col_4')]}).to_dict()],
+                                      details={'columns': [('col_1', 'col_2'), ('col_1', 'col_4'),
+                                                           ('col_2', 'col_4'), ('col_3', 'col_5'),
+                                                           ('col_3', 'col_6'), ('col_5', 'col_6')]}).to_dict()],
         "errors": []
     }
 

--- a/evalml/tests/data_checks_tests/test_target_leakage_data_check.py
+++ b/evalml/tests/data_checks_tests/test_target_leakage_data_check.py
@@ -229,13 +229,13 @@ def test_target_leakage_regression():
     # test empty pd.DataFrame, empty pd.Series
     assert leakage_check.validate(pd.DataFrame(), pd.Series()) == {"warnings": [], "errors": []}
 
-    y = pd.Series([0.4, 0.1, 2.3, 4.3, 2.2, 1.8, 3.7, 3.6, 2.4, 0.9, 3.1, 2.8, 4.1, 1.6, 1.2])
+    y = pd.Series([0.4, 0.4, 2.3, 4.3, 2.2, 1.8, 3.7, 3.6, 2.4, 0.9, 3.1, 2.8, 4.1, 1.6, 1.2])
     X = pd.DataFrame()
     X["a"] = y * 3
     X["b"] = y - 1
     X["c"] = y / 10
     X["d"] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    X["e"] = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"]
+    X["e"] = ["a", "a", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"]
 
     expected_messages = {
         "warnings": [DataCheckWarning(message="Column 'a' is 80.0% or more correlated with the target",

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -22,5 +22,5 @@ scipy==1.6.1
 seaborn==0.11.1
 shap==0.38.1
 texttable==1.6.3
-woodwork==0.0.7
+woodwork==0.0.10
 xgboost==1.2.1


### PR DESCRIPTION
Closes #1899 

Changes made in `0.0.10` to `mutual_information` (https://github.com/alteryx/woodwork/pull/563) s.t. columns which have completely unique values are no longer considered. Hence, had to tweak some of our tests so that the return values were as expected.
