### PR TITLE
Better error message when custom objective specified as string without required args in pipeline score

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Added utility method to create list of components from a list of ``DataCheckAction`` :pr:`1907`
         * Updated ``validate`` method to include a ``action`` key in returned dictionary for all ``DataCheck``and ``DataChecks`` :pr:`1916`
         * Aggregating the shap values for predictions that we know the provenance of, e.g. OHE, text, and date-time. :pr:`1901`
+        * Improved error message when custom objective is passed as a string in ``pipeline.score`` :pr:`1941`
     * Fixes
         * Added metaclass for time series pipelines and fix binary classification pipeline ``predict`` not using objective if it is passed as a named argument :pr:`1874`
         * Fixed stack trace in prediction explanation functions caused by mixed string/numeric pandas column names :pr:`1871`

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -11,5 +11,6 @@ from .exceptions import (
     PipelineScoreError,
     DataCheckInitError,
     EnsembleMissingPipelinesError,
-    NullsInColumnWarning
+    NullsInColumnWarning,
+    ObjectiveCreationError
 )

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -74,3 +74,7 @@ class DataCheckInitError(Exception):
 
 class NullsInColumnWarning(UserWarning):
     """Warning thrown when there are null values in the column of interest"""
+
+
+class ObjectiveCreationError(Exception):
+    """Exception when get_objective tries to instantiate an objective and required args are not provided."""

--- a/evalml/objectives/utils.py
+++ b/evalml/objectives/utils.py
@@ -2,7 +2,7 @@
 from .objective_base import ObjectiveBase
 
 from evalml import objectives
-from evalml.exceptions import ObjectiveNotFoundError
+from evalml.exceptions import ObjectiveCreationError, ObjectiveNotFoundError
 from evalml.problem_types import handle_problem_types
 from evalml.utils.gen_utils import _get_subclasses
 
@@ -85,7 +85,7 @@ def get_objective(objective, return_instance=False, **kwargs):
         try:
             return objective_class(**kwargs)
         except TypeError as e:
-            raise TypeError(f"In get_objective, cannot pass in return_instance=True for {objective} because {str(e)}")
+            raise ObjectiveCreationError(f"In get_objective, cannot pass in return_instance=True for {objective} because {str(e)}")
 
     return objective_class
 

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -2,7 +2,6 @@
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
-from evalml.objectives import get_objective
 from evalml.pipelines import PipelineBase
 from evalml.utils import _convert_woodwork_types_wrapper, infer_feature_types
 
@@ -119,7 +118,7 @@ class ClassificationPipeline(PipelineBase):
         """
         y = infer_feature_types(y)
         y = _convert_woodwork_types_wrapper(y.to_series())
-        objectives = [get_objective(o, return_instance=True) for o in objectives]
+        objectives = self.create_objectives(objectives)
         y = self._encode_targets(y)
         y_predicted, y_predicted_proba = self._compute_predictions(X, y, objectives)
         if y_predicted is not None:

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -20,7 +20,12 @@ from .components import (
 )
 from .components.utils import all_components, handle_component_class
 
-from evalml.exceptions import IllFormattedClassNameError, PipelineScoreError
+from evalml.exceptions import (
+    IllFormattedClassNameError,
+    ObjectiveCreationError,
+    PipelineScoreError
+)
+from evalml.objectives import get_objective
 from evalml.pipelines import ComponentGraph
 from evalml.pipelines.pipeline_meta import PipelineBaseMeta
 from evalml.utils import (
@@ -528,3 +533,14 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         has_dfs = any(isinstance(c, DFSTransformer) for c in self._component_graph)
         has_stacked_ensembler = any(isinstance(c, (StackedEnsembleClassifier, StackedEnsembleRegressor)) for c in self._component_graph)
         return not any([has_more_than_one_estimator, has_custom_components, has_dim_reduction, has_dfs, has_stacked_ensembler])
+
+    @staticmethod
+    def create_objectives(objectives):
+        objective_instances = []
+        for objective in objectives:
+            try:
+                objective_instances.append(get_objective(objective, return_instance=True))
+            except ObjectiveCreationError as e:
+                msg = f"Cannot pass {objective} as a string. Instantiate first and then add it to the list of objectives."
+                raise ObjectiveCreationError(msg) from e
+        return objective_instances

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -541,6 +541,6 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             try:
                 objective_instances.append(get_objective(objective, return_instance=True))
             except ObjectiveCreationError as e:
-                msg = f"Cannot pass {objective} as a string. Instantiate first and then add it to the list of objectives."
+                msg = f"Cannot pass {objective} as a string in pipeline.score. Instantiate first and then add it to the list of objectives."
                 raise ObjectiveCreationError(msg) from e
         return objective_instances

--- a/evalml/pipelines/regression_pipeline.py
+++ b/evalml/pipelines/regression_pipeline.py
@@ -1,5 +1,4 @@
 
-from evalml.objectives import get_objective
 from evalml.pipelines import PipelineBase
 from evalml.problem_types import ProblemTypes
 from evalml.utils import _convert_woodwork_types_wrapper, infer_feature_types
@@ -39,6 +38,6 @@ class RegressionPipeline(PipelineBase):
         Returns:
             dict: Ordered dictionary of objective scores
         """
-        objectives = [get_objective(o, return_instance=True) for o in objectives]
+        objectives = self.create_objectives(objectives)
         y_predicted = _convert_woodwork_types_wrapper(self.predict(X).to_series())
         return self._score_all_objectives(X, y, y_predicted, y_pred_proba=None, objectives=objectives)

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -154,7 +154,7 @@ class TimeSeriesClassificationPipeline(ClassificationPipeline, metaclass=TimeSer
         X, y = self._convert_to_woodwork(X, y)
         X = _convert_woodwork_types_wrapper(X.to_dataframe())
         y = _convert_woodwork_types_wrapper(y.to_series())
-        objectives = [get_objective(o, return_instance=True) for o in objectives]
+        objectives = self.create_objectives(objectives)
 
         y_encoded = self._encode_targets(y)
         y_shifted = y_encoded.shift(-self.gap)

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-from evalml.objectives import get_objective
 from evalml.pipelines.pipeline_meta import TimeSeriesPipelineBaseMeta
 from evalml.pipelines.regression_pipeline import RegressionPipeline
 from evalml.problem_types import ProblemTypes
@@ -117,7 +116,7 @@ class TimeSeriesRegressionPipeline(RegressionPipeline, metaclass=TimeSeriesPipel
         y_predicted = _convert_woodwork_types_wrapper(y_predicted.to_series())
 
         y_shifted = y.shift(-self.gap)
-        objectives = [get_objective(o, return_instance=True) for o in objectives]
+        objectives = self.create_objectives(objectives)
         y_shifted, y_predicted = drop_rows_with_nans(y_shifted, y_predicted)
         return self._score_all_objectives(X, y_shifted,
                                           y_predicted,

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from evalml.exceptions import ObjectiveNotFoundError
+from evalml.exceptions import ObjectiveCreationError, ObjectiveNotFoundError
 from evalml.objectives import (
     BinaryClassificationObjective,
     CostBenefitMatrix,
@@ -62,7 +62,7 @@ def test_get_objective_does_raises_error_for_incorrect_name_or_random_class():
 
 def test_get_objective_return_instance_does_not_work_for_some_objectives():
 
-    with pytest.raises(TypeError, match="In get_objective, cannot pass in return_instance=True for Cost Benefit Matrix"):
+    with pytest.raises(ObjectiveCreationError, match="In get_objective, cannot pass in return_instance=True for Cost Benefit Matrix"):
         get_objective("Cost Benefit Matrix", return_instance=True)
 
     cbm = CostBenefitMatrix(0, 0, 0, 0)

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2006,7 +2006,7 @@ def test_score_error_when_custom_objective_not_instantiated(problem_type, logist
 
     X, y = X_y_binary
     pipeline.fit(X, y)
-    msg = "Cannot pass cost benefit matrix as a string. Instantiate first and then add it to the list of objectives."
+    msg = "Cannot pass cost benefit matrix as a string in pipeline.score. Instantiate first and then add it to the list of objectives."
     with pytest.raises(ObjectiveCreationError, match=msg):
         pipeline.score(X, y, objectives=["cost benefit matrix", "F1"])
 

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -14,11 +14,13 @@ from evalml.demos import load_breast_cancer, load_wine
 from evalml.exceptions import (
     IllFormattedClassNameError,
     MissingComponentError,
+    ObjectiveCreationError,
+    ObjectiveNotFoundError,
     PipelineNotYetFittedError,
     PipelineScoreError
 )
 from evalml.model_family import ModelFamily
-from evalml.objectives import FraudCost, Precision
+from evalml.objectives import CostBenefitMatrix, FraudCost, Precision
 from evalml.pipelines import (
     BinaryClassificationPipeline,
     GeneratedPipelineBinary,
@@ -52,7 +54,12 @@ from evalml.pipelines.utils import (
     get_generated_pipeline_class
 )
 from evalml.preprocessing.utils import is_classification
-from evalml.problem_types import ProblemTypes, is_time_series
+from evalml.problem_types import (
+    ProblemTypes,
+    is_binary,
+    is_multiclass,
+    is_time_series
+)
 
 
 def test_allowed_model_families(has_minimal_dependencies):
@@ -1985,3 +1992,28 @@ def test_pipelines_raise_deprecated_random_state_warning(dummy_binary_pipeline_c
     test_pipeline_class(dummy_time_series_regression_pipeline_class)
     test_pipeline_class(dummy_ts_binary_pipeline_class)
     test_pipeline_class(time_series_multiclass_classification_pipeline_class)
+
+
+@pytest.mark.parametrize("problem_type", ProblemTypes.all_problem_types)
+def test_score_error_when_custom_objective_not_instantiated(problem_type, logistic_regression_binary_pipeline_class,
+                                                            dummy_multiclass_pipeline_class,
+                                                            dummy_regression_pipeline_class, X_y_binary):
+    pipeline = dummy_regression_pipeline_class({})
+    if is_binary(problem_type):
+        pipeline = logistic_regression_binary_pipeline_class({})
+    elif is_multiclass(problem_type):
+        pipeline = dummy_multiclass_pipeline_class({})
+
+    X, y = X_y_binary
+    pipeline.fit(X, y)
+    msg = "Cannot pass cost benefit matrix as a string. Instantiate first and then add it to the list of objectives."
+    with pytest.raises(ObjectiveCreationError, match=msg):
+        pipeline.score(X, y, objectives=["cost benefit matrix", "F1"])
+
+    # Verify ObjectiveCreationError only raised when string matches an existing objective
+    with pytest.raises(ObjectiveNotFoundError, match="cost benefit is not a valid Objective!"):
+        pipeline.score(X, y, objectives=["cost benefit", "F1"])
+
+    # Verify no exception when objective properly specified
+    if is_binary(problem_type):
+        pipeline.score(X, y, objectives=[CostBenefitMatrix(1, 1, -1, -1), "F1"])


### PR DESCRIPTION
### Pull Request Description
Fixes #1603 

```python
pipeline.score(X, y, objectives=['cost benefit matrix'])
```

![image](https://user-images.githubusercontent.com/41651716/110344449-7caa8180-7ffb-11eb-98d8-99472afa3678.png)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
