### PR TITLE
Add params to the data splitter for visibility

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Added multiple oversampling and undersampling sampling methods as data splitters for imbalanced classification :pr:`1775`
-        * Added params to balanced classification data splitters for visibility :pr:``
+        * Added params to balanced classification data splitters for visibility :pr:`1966`
     * Fixes
     * Changes
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Added multiple oversampling and undersampling sampling methods as data splitters for imbalanced classification :pr:`1775`
+        * Added params to balanced classification data splitters for visibility :pr:``
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/preprocessing/data_splitters/balanced_classification_splitter.py
+++ b/evalml/preprocessing/data_splitters/balanced_classification_splitter.py
@@ -39,6 +39,9 @@ class BalancedClassificationDataTVSplit(BaseUnderSamplingSplitter):
         super().__init__(sampler=self.sampler, n_splits=1, random_seed=random_seed)
         self.shuffle = shuffle
         self.test_size = test_size
+        self.balanced_ratio = balanced_ratio
+        self.min_samples = min_samples
+        self.min_percentage = min_percentage
         self.splitter = TrainingValidationSplit(test_size=test_size, shuffle=shuffle, random_state=random_seed)
 
 
@@ -69,4 +72,7 @@ class BalancedClassificationDataCVSplit(BaseUnderSamplingSplitter):
         self.sampler = BalancedClassificationSampler(balanced_ratio=balanced_ratio, min_samples=min_samples, min_percentage=min_percentage, random_seed=random_seed)
         super().__init__(sampler=self.sampler, n_splits=n_splits, random_seed=random_seed)
         self.shuffle = shuffle
+        self.balanced_ratio = balanced_ratio
+        self.min_samples = min_samples
+        self.min_percentage = min_percentage
         self.splitter = StratifiedKFold(n_splits=n_splits, shuffle=shuffle, random_state=random_seed)

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -298,7 +298,7 @@ def test_automl_str_search(mock_fit, mock_score, mock_predict_proba, mock_optimi
         'Allowed Pipelines': [],
         'Patience': search_params['patience'],
         'Tolerance': search_params['tolerance'],
-        'Data Splitting': ('BalancedClassificationDataCVSplit(balanced_ratio=None,', 'n_splits=5, random_seed=0'),
+        'Data Splitting': ('BalancedClassificationDataCVSplit(balanced_ratio=4,', 'n_splits=5, random_seed=0'),
         'Tuner': 'RandomSearchTuner',
         'Start Iteration Callback': '_dummy_callback',
         'Add Result Callback': None,

--- a/evalml/tests/preprocessing_tests/test_balanced_classification_data_splitter.py
+++ b/evalml/tests/preprocessing_tests/test_balanced_classification_data_splitter.py
@@ -14,6 +14,20 @@ from evalml.preprocessing.data_splitters import (
 @pytest.mark.parametrize("splitter",
                          [BalancedClassificationDataCVSplit,
                           BalancedClassificationDataTVSplit])
+def test_data_splitter_params(splitter):
+    bcs = splitter()
+    assert bcs.balanced_ratio == 4
+    assert bcs.min_samples == 100
+
+    bcs = splitter(balanced_ratio=3, min_samples=1, min_percentage=0.5)
+    assert bcs.balanced_ratio == 3
+    assert bcs.min_samples == 1
+    assert bcs.min_percentage == 0.5
+
+
+@pytest.mark.parametrize("splitter",
+                         [BalancedClassificationDataCVSplit,
+                          BalancedClassificationDataTVSplit])
 def test_data_splitter_nsplits(splitter):
     if "TV" in splitter.__name__:
         assert splitter().get_n_splits() == 1


### PR DESCRIPTION
With this change, when we call `automl.data_splitter`, we will see

```python
BalancedClassificationDataCVSplit(balanced_ratio=4, min_percentage=0.1,
                 min_samples=100, n_splits=3, random_seed=0, shuffle=True)
```
rather than 
```python
BalancedClassificationDataCVSplit(balanced_ratio=None, min_percentage=None,
                 min_samples=None, n_splits=3, random_seed=0, shuffle=True)
```