### PR TITLE
Remove build_docs CI job in favor of RTD GH builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,27 +138,10 @@ jobs:
             - run: |
                 source test_python/bin/activate
                 codecov --required
-  build_docs:
-    working_directory: ~/evalml/
-    executor:
-      name: python
-      python_version: "3.8"
-    steps:
-      - checkout
-      - install_dependencies_docs
-      - run: sudo apt update && sudo apt install -y pandoc && sudo apt install -y graphviz
-      - run: |
-          source test_python/bin/activate
-          make -C docs/ html
-      - run: ls docs/build/html
 
 
 workflows:
   version: 2
-  build_docs:
-    jobs:
-      - build_docs:
-          name: "build docs"
   test_all_python_versions:
     jobs:
       - unit_tests:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Remove ``build_docs`` CI job in favor of RTD GH builder :pr:`1974`
 
 **v0.20.0 Mar. 10, 2021**
     * Enhancements


### PR DESCRIPTION
We were waiting on resolution of an RTD builder bug (timeout after ~60sec). Not resolved yet, but rerunning seems to fix that typically, so I think its time!