### PR TITLE
Using latest_release_changes branch in build_conda_pkg job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
     steps:
       - run: |
             git clone https://github.com/conda-forge/evalml-core-feedstock
-            git checkout -t latest_release_changes origin/latest_release_changes
+            git checkout -t origin/latest_release_changes
             source test_python/bin/activate
             mkdir evalml-core-feedstock/evalml
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,7 @@ commands:
   build_pkg:
     steps:
       - run: |
-            git clone https://github.com/conda-forge/evalml-core-feedstock
-            git checkout -t origin/latest_release_changes
+            git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
             source test_python/bin/activate
             mkdir evalml-core-feedstock/evalml
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
     steps:
       - run: |
             git clone https://github.com/conda-forge/evalml-core-feedstock
-            git branch -t latest_release_changes origin/latest_release_changes
+            git checkout -t latest_release_changes origin/latest_release_changes
             source test_python/bin/activate
             mkdir evalml-core-feedstock/evalml
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,4 +166,4 @@ workflows:
             - shellcheck/check
           filters:
             branches:
-              only: conda-ci-use-working-changes-branch
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ commands:
     steps:
       - run: |
             git clone https://github.com/conda-forge/evalml-core-feedstock
+            git checkout latest_release_changes
             source test_python/bin/activate
             mkdir evalml-core-feedstock/evalml
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/
@@ -166,4 +167,4 @@ workflows:
             - shellcheck/check
           filters:
             branches:
-              only: main
+              only: conda-ci-use-working-changes-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
     steps:
       - run: |
             git clone https://github.com/conda-forge/evalml-core-feedstock
-            git checkout latest_release_changes
+            git branch -t latest_release_changes origin/latest_release_changes
             source test_python/bin/activate
             mkdir evalml-core-feedstock/evalml
             cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
     * Testing Changes
         * Removed ``build_docs`` CI job in favor of RTD GH builder :pr:`1974`
         * Added tests to confirm support for Python 3.9 :pr:`1724`
+        * Changed ``build_conda_pkg`` job to use ``latest_release_changes`` branch in the feedstock. :pr:`1979`
 
 .. warning::
 

--- a/release.md
+++ b/release.md
@@ -95,9 +95,17 @@ package:
   version: '{{ version }}'
 ```
 For help on how to push changes to the bot's PR please read this [document.](https://conda-forge.org/docs/maintainer/updating_pkgs.html#pushing-to-regro-cf-autotick-bot-branch)
-If the `build_conda_pkg` job passed on the `main` branch before the release, then no further changes are needed and you can merge the bot's PR once the tests pass.
 
-After you merge the PR, our latest package will be deployed to conda-forge! To verify, run this in a fresh conda environment:
+You may need to make other changes to the bot's PR. For example, we sometimes add new dependencies or change the allowed
+versions of our existing dependencies. These changes will break our conda-forge CI, so it's important to add them to the
+bot's PR beffore merging. To see the changes you need to make, compare the bot's branch to the `latest_release_changes` branch.
+
+```shell script
+git diff <bot-pr-branch-name> latest_release_changes -- recipe/meta.yaml
+```
+
+
+After you make the necessary changes and merge the PR, our latest package will be deployed to conda-forge! To verify, run this in a fresh conda environment:
 
 ```shell
 conda install -c conda-forge evalml
@@ -108,3 +116,5 @@ Verify the latest version of `evalml` got installed by running
 ```shell
 python -c "import evalml; print(evalml.__version__)"
 ``` 
+
+Our `build_conda_pkg` job is based off of the `latest_release_changes` branch of our feedstock repo. In order to 

--- a/release.md
+++ b/release.md
@@ -116,5 +116,3 @@ Verify the latest version of `evalml` got installed by running
 ```shell
 python -c "import evalml; print(evalml.__version__)"
 ``` 
-
-Our `build_conda_pkg` job is based off of the `latest_release_changes` branch of our feedstock repo. In order to 

--- a/release.md
+++ b/release.md
@@ -115,4 +115,4 @@ Verify the latest version of `evalml` got installed by running
 
 ```shell
 python -c "import evalml; print(evalml.__version__)"
-``` 
+```

--- a/release.md
+++ b/release.md
@@ -98,7 +98,7 @@ For help on how to push changes to the bot's PR please read this [document.](htt
 
 You may need to make other changes to the bot's PR. For example, we sometimes add new dependencies or change the allowed
 versions of our existing dependencies. These changes will break our conda-forge CI, so it's important to add them to the
-bot's PR beffore merging. To see the changes you need to make, compare the bot's branch to the `latest_release_changes` branch.
+bot's PR before merging. To see the changes you need to make, compare the bot's branch to the `latest_release_changes` branch.
 
 ```shell script
 git diff <bot-pr-branch-name> latest_release_changes -- recipe/meta.yaml


### PR DESCRIPTION
### Pull Request Description
We sometimes make changes to our dependencies mid-sprint that break our conda ci job. We sometimes have to do a release to fix this because our ci job builds the package based on the feedstock's main branch and each commit to main on the feedstock will make a new conda release.

Rather than run the ci job on the main branch, I propose we run against the `latest_release_changes` branch. This branch will accumulate all changes that need to be added to the recipe during the sprint. When we go to release, we'll just add these changes to the bot's PR.

Since the ci on the bot PR will fail unless we make these changes, the `latest_release_changes` branch and the `master` branch will always be in synch, at least in the dependency versions. 


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
