### PR TITLE
Support for Multiclass Classification in Class Imbalance data checks

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added multiple oversampling and undersampling sampling methods as data splitters for imbalanced classification :pr:`1775`
         * Added params to balanced classification data splitters for visibility :pr:`1966`
         * Updated ``make_pipeline`` to not add ``Imputer`` if input data does not have numeric or categorical columns :pr:`1967`
+        * Updated ``class_imbalance_data_check`` to better handle multiclass imbalances :pr:``
     * Fixes
     * Changes
         * Removed ``data_checks`` parameter, ``data_check_results`` and data checks logic from ``AutoMLSearch`` :pr:`1935`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
         * Added multiple oversampling and undersampling sampling methods as data splitters for imbalanced classification :pr:`1775`
         * Added params to balanced classification data splitters for visibility :pr:`1966`
         * Updated ``make_pipeline`` to not add ``Imputer`` if input data does not have numeric or categorical columns :pr:`1967`
-        * Updated ``class_imbalance_data_check`` to better handle multiclass imbalances :pr:``
+        * Updated ``class_imbalance_data_check`` to better handle multiclass imbalances :pr:`1986`
         * Added recommended actions for the output of data check's ``validate`` method :pr:`1968`
     * Fixes
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
         * Added multiple oversampling and undersampling sampling methods as data splitters for imbalanced classification :pr:`1775`
         * Added params to balanced classification data splitters for visibility :pr:`1966`
         * Updated ``make_pipeline`` to not add ``Imputer`` if input data does not have numeric or categorical columns :pr:`1967`
-        * Updated ``class_imbalance_data_check`` to better handle multiclass imbalances :pr:`1986`
+        * Updated ``ClassImbalanceDataCheck`` to better handle multiclass imbalances :pr:`1986`
         * Added recommended actions for the output of data check's ``validate`` method :pr:`1968`
     * Fixes
         * Updated binary classification pipelines to use objective decision function during scoring of custom objectives :pr:`1934`

--- a/evalml/data_checks/class_imbalance_data_check.py
+++ b/evalml/data_checks/class_imbalance_data_check.py
@@ -77,7 +77,7 @@ class ClassImbalanceDataCheck(DataCheck):
         y = infer_feature_types(y)
         y = _convert_woodwork_types_wrapper(y.to_series())
 
-        fold_counts = y.value_counts(normalize=False)
+        fold_counts = y.value_counts(normalize=False, sort=True)
         if len(fold_counts) == 0:
             return results
         # search for targets that occur less than twice the number of cv folds first

--- a/evalml/data_checks/class_imbalance_data_check.py
+++ b/evalml/data_checks/class_imbalance_data_check.py
@@ -17,8 +17,9 @@ class ClassImbalanceDataCheck(DataCheck):
 
         Arguments:
             threshold (float): The minimum threshold allowed for class imbalance before a warning is raised.
-                A perfectly balanced dataset would have a threshold of (1/n_classes), ie 0.50 for binary classes.
-                Defaults to 0.10
+                This threshold is calculated by comparing the number of samples in each class to the sum of samples in that class and the majority class.
+                For example, a multiclass case with [900, 900, 100] samples per classes 0, 1, and 2, respectively,
+                would have a 0.10 threshold for class 2 (100 / (900 + 100)). Defaults to 0.10.
             min_samples (int): The minimum number of samples per accepted class. If the minority class is both below the threshold and min_samples,
                 then we consider this severely imbalanced. Must be greater than 0. Defaults to 100.
             num_cv_folds (int): The number of cross-validation folds. Must be positive. Choose 0 to ignore this warning.
@@ -77,6 +78,8 @@ class ClassImbalanceDataCheck(DataCheck):
         y = _convert_woodwork_types_wrapper(y.to_series())
 
         fold_counts = y.value_counts(normalize=False)
+        if len(fold_counts) == 0:
+            return results
         # search for targets that occur less than twice the number of cv folds first
         below_threshold_folds = fold_counts.where(fold_counts < self.cv_folds).dropna()
         if len(below_threshold_folds):
@@ -86,8 +89,7 @@ class ClassImbalanceDataCheck(DataCheck):
                                                   data_check_name=self.name,
                                                   message_code=DataCheckMessageCode.CLASS_IMBALANCE_BELOW_FOLDS,
                                                   details={"target_values": below_threshold_values}), results)
-
-        counts = fold_counts / fold_counts.sum()
+        counts = fold_counts / (fold_counts + fold_counts.values[0])
         below_threshold = counts.where(counts < self.threshold).dropna()
         # if there are items that occur less than the threshold, add them to the list of results
         if len(below_threshold):

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -99,8 +99,8 @@ def test_class_imbalance_data_check_multiclass(input_type):
     y = pd.Series([0, 2, 1, 1])
     y_imbalanced_default_threshold = pd.Series([0, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
     y_imbalanced_set_threshold = pd.Series([0, 2, 2, 2, 2, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    y_imbalanced_cv = pd.Series([0, 0, 1, 2, 2, 1, 1, 1])
-    y_long = pd.Series([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4])
+    y_imbalanced_cv = pd.Series([0, 1, 2, 2, 1, 1, 1])
+    y_long = pd.Series([0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4])
 
     if input_type == "np":
         X = X.to_numpy()

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -98,9 +98,9 @@ def test_class_imbalance_data_check_multiclass(input_type):
     X = pd.DataFrame()
     y = pd.Series([0, 2, 1, 1])
     y_imbalanced_default_threshold = pd.Series([0, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    y_imbalanced_set_threshold = pd.Series([0, 2, 2, 2, 3, 3, 1, 1, 1, 1])
+    y_imbalanced_set_threshold = pd.Series([0, 2, 2, 2, 3, 1, 1, 1, 1, 1])
     y_imbalanced_cv = pd.Series([0, 0, 1, 2, 2, 1, 1, 1])
-    y_long = pd.Series([0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4])
+    y_long = pd.Series([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4])
 
     if input_type == "np":
         X = X.to_numpy()
@@ -145,10 +145,10 @@ def test_class_imbalance_data_check_multiclass(input_type):
     class_imbalance_check = ClassImbalanceDataCheck(num_cv_folds=2)
     assert class_imbalance_check.validate(X, y_imbalanced_cv) == {
         "warnings": [],
-        "errors": [DataCheckError(message="The number of instances of these targets is less than 2 * the number of cross folds = 4 instances: [0, 2]",
+        "errors": [DataCheckError(message="The number of instances of these targets is less than 2 * the number of cross folds = 4 instances: [2, 0]",
                                   data_check_name=class_imbalance_data_check_name,
                                   message_code=DataCheckMessageCode.CLASS_IMBALANCE_BELOW_FOLDS,
-                                  details={"target_values": [0, 2]}).to_dict()],
+                                  details={"target_values": [2, 0]}).to_dict()],
         "actions": []
     }
 
@@ -236,7 +236,7 @@ def test_class_imbalance_nonnumeric(input_type):
     X = pd.DataFrame()
     y_bools = pd.Series([True, False, False, False, False])
     y_binary = pd.Series(["yes", "no", "yes", "yes", "yes"])
-    y_multiclass = pd.Series(["red", "green", "red", "red", "blue", "green", "red", "blue", "green", "red"])
+    y_multiclass = pd.Series(["red", "green", "red", "red", "blue", "green", "red", "blue", "green", "red", "red", "red"])
     y_multiclass_imbalanced_folds = pd.Series(["No", "Maybe", "Maybe", "No", "Yes"])
     y_binary_imbalanced_folds = pd.Series(["No", "Yes", "No", "Yes", "No"])
     if input_type == "ww":
@@ -300,10 +300,10 @@ def test_class_imbalance_nonnumeric(input_type):
 
     assert class_imbalance_check.validate(X, y_multiclass) == {
         "warnings": [],
-        "errors": [DataCheckError(message="The number of instances of these targets is less than 2 * the number of cross folds = 6 instances: ['red', 'green', 'blue']",
+        "errors": [DataCheckError(message="The number of instances of these targets is less than 2 * the number of cross folds = 6 instances: ['green', 'blue']",
                                   data_check_name=class_imbalance_data_check_name,
                                   message_code=DataCheckMessageCode.CLASS_IMBALANCE_BELOW_FOLDS,
-                                  details={"target_values": ["red", "green", "blue"]}).to_dict()],
+                                  details={"target_values": ["green", "blue"]}).to_dict()],
         "actions": []
     }
 
@@ -332,7 +332,7 @@ def test_class_imbalance_severe(min_samples, input_type):
     X = pd.DataFrame()
     # 0 will be < 10% of the data, but there will be 50 samples of it
     y_values_binary = pd.Series([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] * 50)
-    y_values_multiclass = pd.Series([0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2] * 50)
+    y_values_multiclass = pd.Series([0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2] * 50)
     if input_type == "ww":
         X = ww.DataTable(X)
         y_values_binary = ww.DataColumn(y_values_binary)
@@ -356,6 +356,46 @@ def test_class_imbalance_severe(min_samples, input_type):
 
     assert class_imbalance_check.validate(X, y_values_multiclass) == {
         "warnings": warnings,
+        "errors": [],
+        "actions": []
+    }
+
+
+def test_class_imbalance_large_multiclass():
+    X = pd.DataFrame()
+    y_values_multiclass_large = pd.Series([0] * 20 + [1] * 20 + [2] * 99 + [3] * 105 + [4] * 900 + [5] * 900)
+    y_multiclass_huge = pd.Series([i % 200 for i in range(100000)])
+    y_imbalanced_multiclass_huge = y_multiclass_huge.append(pd.Series([200] * 10), ignore_index=True)
+
+    class_imbalance_check = ClassImbalanceDataCheck(num_cv_folds=1)
+    assert class_imbalance_check.validate(X, y_values_multiclass_large) == {
+        "warnings": [DataCheckWarning(message="The following labels fall below 10% of the target: [2, 1, 0]",
+                                      data_check_name=class_imbalance_data_check_name,
+                                      message_code=DataCheckMessageCode.CLASS_IMBALANCE_BELOW_THRESHOLD,
+                                      details={"target_values": [2, 1, 0]}).to_dict(),
+                     DataCheckWarning(message=f"The following labels in the target have severe class imbalance because they fall under 10% of the target and have less than 100 samples: [2, 1, 0]",
+                                      data_check_name=class_imbalance_data_check_name,
+                                      message_code=DataCheckMessageCode.CLASS_IMBALANCE_SEVERE,
+                                      details={"target_values": [2, 1, 0]}).to_dict()],
+        "errors": [],
+        "actions": []
+    }
+
+    assert class_imbalance_check.validate(X, y_multiclass_huge) == {
+        "warnings": [],
+        "errors": [],
+        "actions": []
+    }
+
+    assert class_imbalance_check.validate(X, y_imbalanced_multiclass_huge) == {
+        "warnings": [DataCheckWarning(message="The following labels fall below 10% of the target: [200]",
+                                      data_check_name=class_imbalance_data_check_name,
+                                      message_code=DataCheckMessageCode.CLASS_IMBALANCE_BELOW_THRESHOLD,
+                                      details={"target_values": [200]}).to_dict(),
+                     DataCheckWarning(message=f"The following labels in the target have severe class imbalance because they fall under 10% of the target and have less than 100 samples: [200]",
+                                      data_check_name=class_imbalance_data_check_name,
+                                      message_code=DataCheckMessageCode.CLASS_IMBALANCE_SEVERE,
+                                      details={"target_values": [200]}).to_dict()],
         "errors": [],
         "actions": []
     }

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -366,6 +366,7 @@ def test_class_imbalance_large_multiclass():
     y_values_multiclass_large = pd.Series([0] * 20 + [1] * 25 + [2] * 99 + [3] * 105 + [4] * 900 + [5] * 900)
     y_multiclass_huge = pd.Series([i % 200 for i in range(100000)])
     y_imbalanced_multiclass_huge = y_multiclass_huge.append(pd.Series([200] * 10), ignore_index=True)
+    y_imbalanced_multiclass_nan = y_multiclass_huge.append(pd.Series([np.nan] * 10), ignore_index=True)
 
     class_imbalance_check = ClassImbalanceDataCheck(num_cv_folds=1)
     assert class_imbalance_check.validate(X, y_values_multiclass_large) == {
@@ -396,6 +397,12 @@ def test_class_imbalance_large_multiclass():
                                       data_check_name=class_imbalance_data_check_name,
                                       message_code=DataCheckMessageCode.CLASS_IMBALANCE_SEVERE,
                                       details={"target_values": [200]}).to_dict()],
+        "errors": [],
+        "actions": []
+    }
+
+    assert class_imbalance_check.validate(X, y_imbalanced_multiclass_nan) == {
+        "warnings": [],
         "errors": [],
         "actions": []
     }

--- a/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
+++ b/evalml/tests/data_checks_tests/test_class_imbalance_data_check.py
@@ -98,7 +98,7 @@ def test_class_imbalance_data_check_multiclass(input_type):
     X = pd.DataFrame()
     y = pd.Series([0, 2, 1, 1])
     y_imbalanced_default_threshold = pd.Series([0, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    y_imbalanced_set_threshold = pd.Series([0, 2, 2, 2, 3, 1, 1, 1, 1, 1])
+    y_imbalanced_set_threshold = pd.Series([0, 2, 2, 2, 2, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
     y_imbalanced_cv = pd.Series([0, 0, 1, 2, 2, 1, 1, 1])
     y_long = pd.Series([0, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4])
 
@@ -363,7 +363,7 @@ def test_class_imbalance_severe(min_samples, input_type):
 
 def test_class_imbalance_large_multiclass():
     X = pd.DataFrame()
-    y_values_multiclass_large = pd.Series([0] * 20 + [1] * 20 + [2] * 99 + [3] * 105 + [4] * 900 + [5] * 900)
+    y_values_multiclass_large = pd.Series([0] * 20 + [1] * 25 + [2] * 99 + [3] * 105 + [4] * 900 + [5] * 900)
     y_multiclass_huge = pd.Series([i % 200 for i in range(100000)])
     y_imbalanced_multiclass_huge = y_multiclass_huge.append(pd.Series([200] * 10), ignore_index=True)
 


### PR DESCRIPTION
fix #1864 

Summary:
* Compute the number of samples in each class of the training data
* Identify the majority class which has the largest number of samples
* For each class, compute the ratio of majority class samples to that classes sample count
* If that ratio exceeds a threshold (default 9:1), raise a class imbalance warning
* If that ratio exceeds a threshold AND the number of samples for that class < 100, raise a severe class imbalance warning

Did not incorporate steps for number of classes in order to keep this data check a little simpler and keep the logic in line with what users would expect. (ie at larger numbers of classes, we don't automatically lower the threshold, even though it might be imbalanced for the model to learn).  