### PR TITLE
Remove 'warning' from docs tool output

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Release Notes
         * Renamed ``TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS`` data check message code to ``TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS`` :pr:`2126`
         * Modified one-way partial dependence plots of categorical features to display data with a bar plot :pr:`2117`
         * Renamed ``score`` column for ``automl.rankings`` as ``mean_cv_score`` :pr:`2135`
+        * Remove 'warning' from docs tool output :pr:`2031`
     * Documentation Changes
         * Fixed ``conf.py`` file :pr:`2112`
         * Added a sentence to the automl user guide stating that our support for time series problems is still in beta. :pr:`2118`
@@ -80,7 +81,6 @@ Release Notes
         * Removed ``data_checks`` parameter, ``data_check_results`` and data checks logic from ``AutoMLSearch`` :pr:`1935`
         * Deleted ``random_state`` argument :pr:`1985`
         * Updated Woodwork version requirement to ``v0.0.11`` :pr:`1996`
-        * Remove 'warning' from docs tool output :pr:`2031`
     * Documentation Changes
     * Testing Changes
         * Removed ``build_docs`` CI job in favor of RTD GH builder :pr:`1974`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -80,6 +80,7 @@ Release Notes
         * Removed ``data_checks`` parameter, ``data_check_results`` and data checks logic from ``AutoMLSearch`` :pr:`1935`
         * Deleted ``random_state`` argument :pr:`1985`
         * Updated Woodwork version requirement to ``v0.0.11`` :pr:`1996`
+        * Remove 'warning' from docs tool output :pr:`2031`
     * Documentation Changes
     * Testing Changes
         * Removed ``build_docs`` CI job in favor of RTD GH builder :pr:`1974`

--- a/tools/format_release_notes.sh
+++ b/tools/format_release_notes.sh
@@ -12,6 +12,6 @@ fi
 evalml_version=$(sed -n -E "s/.*version=\'([0-9A-Za-z\.\_]+)\'.*/\1/p" setup.py)
 content_raw=$(sed -n -E '/^\*\*v[A-Za-z0-9\., ]+\*\*$/,$p' docs/source/release_notes.rst | tail -n +2 | sed -E '/\*\*v[A-Za-z0-9\., ]+\*\*$/q' | sed '$ d' | awk 'NF')
 date_formatted=$(date '+%b. %-d, %Y')
-content_markdown=$(echo -n "${content_raw}" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E "s/:pr:\`([0-9]+)\`/#\1/g")
+content_markdown=$(echo -n "${content_raw}" | grep -v ".. warning::" | sed 's/^        \* /- /g' | sed 's/^    \* /### /g' | sed 's/    \*\*Breaking Changes\*\*/### Breaking Changes/g' | sed -E "s/:pr:\`([0-9]+)\`/#\1/g")
 full_markdown=$(echo -e "# v${evalml_version} ${date_formatted}\n${content_markdown}")
 echo -e "${full_markdown}"


### PR DESCRIPTION
Noticed while doing the 0.21.0 release formatting.