### PR TITLE
Add method to convert actions to a preprocessing pipeline

### DIFF
--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -80,9 +80,10 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
 
         self.input_feature_names = {}
         self.input_target_name = None
-
-        final_component = self._component_graph.get_last_component()
-        self.estimator = final_component if isinstance(final_component, Estimator) else None
+        self.estimator = None
+        if len(self._component_graph.compute_order) > 0:
+            final_component = self._component_graph.get_last_component()
+            self.estimator = final_component if isinstance(final_component, Estimator) else None
         self._estimator_name = self._component_graph.compute_order[-1] if self.estimator is not None else None
 
         self._validate_estimator_problem_type()

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -34,7 +34,11 @@ from evalml.pipelines.components import (  # noqa: F401
     TargetImputer,
     TextFeaturizer
 )
-from evalml.pipelines.components.utils import all_components, get_estimators
+from evalml.pipelines.components.utils import (
+    all_components,
+    get_estimators,
+    handle_component_class
+)
 from evalml.problem_types import (
     ProblemTypes,
     handle_problem_types,
@@ -278,29 +282,29 @@ def make_pipeline_from_actions(actions, problem_type):
                 components.append(TargetImputer(impute_strategy=metadata["impute_strategy"]))
     return make_pipeline_from_components(components, problem_type)
 
-from evalml.pipelines.components.utils import handle_component_class
 
-def combine_two_pipelines(pipeline, pipeline_to_prepend, problem_type):
-    component_list = pipeline_to_prepend.component_graph + pipeline.component_graph
+
+def combine_pipelines(pipelines, problem_type):
     component_set = set()
-    component_list_ordered = []
+    component_list = []
+    component_name_to_parameters = []
     idx = 0
-    for component in pipeline_to_prepend.component_graph:
-        component_name_to_use = component.name
-        if component_name_to_use in component_set:
-            component_name_to_use = f'{component_name_to_use}_{idx}'
-        component_set.add(component_name_to_use)
-        component_list_ordered.append((component_name_to_use, pipeline_to_prepend.parameters[component.name]))        
-        idx += 1
-    for component in pipeline.component_graph:
-        component_name_to_use = component.name
-        if component_name_to_use in component_set:
-            component_name_to_use = f'{component_name_to_use}_{idx}'
-        component_set.add(component_name_to_use)
-        component_list_ordered.append((component_name_to_use, pipeline.parameters[component.name]))        
-        idx += 1
+    problem_type = handle_problem_types(problem_type)
 
-    class TemplatedPipeline(_get_pipeline_base_class(problem_type)):
+    for pipeline in pipelines:
+        pipeline_problem_type = handle_problem_types(problem_type)
+        if pipeline_problem_type != problem_type:
+            raise ValueError(f"Pipelines must be for problem type: {problem_type}")
+        for component in pipeline.component_graph:
+            component_name_to_use = component.name
+            if component_name_to_use in component_set:
+                component_name_to_use = f'{component_name_to_use}_{idx}'
+            component_set.add(component_name_to_use)
+            component_list.append(component.name)
+            component_name_to_parameters.append((component_name_to_use, pipeline.parameters[component.name]))
+            idx += 1
+
+    class CombinedPipeline(_get_pipeline_base_class(problem_type)):
         component_graph = component_list
-    import pdb; pdb.set_trace()
-    return TemplatedPipeline({c[0]: c[1] for c in component_list_ordered}, random_seed=0)
+
+    return CombinedPipeline({c[0]: c[1] for c in component_name_to_parameters}, random_seed=0)

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -254,7 +254,7 @@ def _make_stacked_ensemble_pipeline(input_pipelines, problem_type, n_jobs=-1, ra
                                              random_seed=random_seed)
 
 
-def _make_component_list_from_actions(actions):
+def make_pipeline_from_actions(actions, problem_type):
     """
     Creates a list of components from the input DataCheckAction list
 
@@ -268,4 +268,4 @@ def _make_component_list_from_actions(actions):
     for action in actions:
         if action.action_code == DataCheckActionCode.DROP_COL:
             components.append(DropColumns(columns=action.metadata["columns"]))
-    return components
+    return make_pipeline_from_components(components, problem_type)

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -30,7 +30,7 @@ from evalml.pipelines.components import (
 )
 from evalml.pipelines.utils import (
     _get_pipeline_base_class,
-    _make_component_list_from_actions,
+    make_pipeline_from_actions,
     get_estimators,
     make_pipeline,
     make_pipeline_from_components
@@ -515,13 +515,23 @@ def test_stacked_estimator_in_pipeline(problem_type, X_y_binary, X_y_multi, X_y_
         assert (pipeline_score >= comparison_pipeline_score)
 
 
-def test_make_component_list_from_actions():
-    assert _make_component_list_from_actions([]) == []
+@pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS, ProblemTypes.REGRESSION])
+def test_make_pipeline_from_actions(problem_type):
+    # Skipping because make_pipeline_from_components does not yet work for time series.
 
-    actions = [DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some col']})]
-    assert _make_component_list_from_actions(actions) == [DropColumns(columns=['some col'])]
+    pipeline_base_class = _get_pipeline_base_class(problem_type)
+    class ExpectedEmptyActionsPipeline(pipeline_base_class):
+        component_graph = []
 
-    actions_same_code = [DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some col']}),
-                         DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some other col']})]
-    assert _make_component_list_from_actions(actions_same_code) == [DropColumns(columns=['some col']),
-                                                                    DropColumns(columns=['some other col'])]
+    import pdb; pdb.set_trace()
+    action_pipeline = make_pipeline_from_actions([], problem_type)
+    assert action_pipeline.component_graph == []
+    assert action_pipeline.parameters == {}
+    # actions = [DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some col']})]
+
+    # assert make_pipeline_from_actions(actions, problem_type) == [DropColumns(columns=['some col'])]
+
+    # actions_same_code = [DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some col']}),
+    #                      DataCheckAction(DataCheckActionCode.DROP_COL, {"columns": ['some other col']})]
+    # assert make_pipeline_from_actions(actions_same_code, problem_type) == [DropColumns(columns=['some col']),
+    #                                                                 DropColumns(columns=['some other col'])]

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -31,11 +31,11 @@ from evalml.pipelines.components import (
 )
 from evalml.pipelines.utils import (
     _get_pipeline_base_class,
+    combine_pipelines,
     get_estimators,
     make_pipeline,
     make_pipeline_from_actions,
-    make_pipeline_from_components,
-    combine_two_pipelines
+    make_pipeline_from_components
 )
 from evalml.problem_types import ProblemTypes, is_time_series
 
@@ -579,16 +579,19 @@ def test_make_pipeline_from_actions(problem_type):
 
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS, ProblemTypes.REGRESSION])
-def test_combine_two_pipelines(problem_type):
-    actions = [DataCheckAction(DataCheckActionCode.DROP_COL, metadata={"columns": ['some col']}),
-               DataCheckAction(DataCheckActionCode.IMPUTE_COL, metadata={"column": None, "is_target": True, "impute_strategy": "most_frequent"})]
-    action_pipeline = make_pipeline_from_actions(actions, problem_type)
-    assert action_pipeline.component_graph == [DropColumns, TargetImputer]
-    assert action_pipeline.parameters == {'Drop Columns Transformer': {'columns': ['some col']},
-                                          'Target Imputer': {'fill_value': None, 'impute_strategy': 'most_frequent'}}
-    
-    actions_2 = [DataCheckAction(DataCheckActionCode.DROP_COL, metadata={"columns": ['some other col']}),
-               DataCheckAction(DataCheckActionCode.IMPUTE_COL, metadata={"column": None, "is_target": True, "impute_strategy": "mean"})]
-    
-    action_pipeline_2 = make_pipeline_from_actions(actions_2, problem_type)
-    combine_two_pipelines(action_pipeline, action_pipeline_2, problem_type)
+def test_combine_pipelines(problem_type):
+    class PreprocessingPipeline(_get_pipeline_base_class(problem_type)):
+        component_graph = [DropColumns, TargetImputer]
+
+    pipeline = PreprocessingPipeline({'Drop Columns Transformer': {'columns': ['some col']},
+                                      'Target Imputer': {'fill_value': None, 'impute_strategy': 'most_frequent'}})
+    pipeline_2 = PreprocessingPipeline({'Drop Columns Transformer': {'columns': ['some other col']},
+                                        'Target Imputer': {'fill_value': None, 'impute_strategy': 'mean'}})
+
+    combined_pipeline = combine_pipelines([pipeline, pipeline_2], problem_type)
+    assert isinstance(combined_pipeline, _get_pipeline_base_class(problem_type))
+    assert combined_pipeline.component_graph == ['Drop Columns Transformer', 'Target Imputer', 'Drop Columns Transformer', 'Target Imputer']
+    X = pd.DataFrame({"some col": [1, 2], "some other col": [2, 4], "another col": [4, 1]})
+    y = pd.Series([1, np.nan])
+    combined_pipeline.fit(X, y)
+    t = combined_pipeline.predict(X)


### PR DESCRIPTION
Closes #2058

To enable this, the following were also changed:
- Updates `PipelineBase` to accept empty component graphs (len(ComponentGraph) == 0), previously had ugly stack trace
- Updates `make_pipeline_from_components` to allow creating pipelines where an estimator is not the last component. EDIT: will be blocked on #2103 
