### PR TITLE
Allow precision-recall to handle 2d predicted probabilities; docs updates

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -68,6 +68,8 @@ Note that if you're on Mac, there are a few extra steps you'll want to keep trac
 
 * Please create your pull request initially as [a "Draft" PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). This signals the team to ignore it and to allow you to develop. When the checkin tests are passing and you're ready to get your pull request reviewed and merged, please convert it to a normal PR for review.
 
+* We use GitHub Actions to run our PR checkin tests. On creation of the PR and for every change you make to your PR, you'll need a maintainer to click "Approve and run" on your PR. This is a change [GitHub made in April 2021](https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/).
+
 * We ask that all contributors sign our contributor license agreement (CLA) the first time they contribute to evalml. The CLA assistant will place a message on your PR; follow the instructions there to sign the CLA.
 
 Add a description of your PR to the subsection that most closely matches your contribution:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,12 +6,15 @@ Release Notes
         * Added Oversampler transformer component to EvalML :pr:`2079`
         * Updated prediction explanations functions to allow pipelines with XGBoost estimators :pr:`2162`
         * Added partial dependence for datetime columns :pr:`2180`
+        * Update precision-recall curve with positive label index argument, and fix for 2d predicted probabilities :pr:`2090`
     * Fixes
         * Fixed partial dependence not respecting grid resolution parameter for numerical features :pr:`2180`
     * Changes
-            * Updated pipeline API to accept component graph and other class attributes as instance parameters. Old pipeline API still works but will not be supported long-term. :pr:`2091`
+        * Updated pipeline API to accept component graph and other class attributes as instance parameters. Old pipeline API still works but will not be supported long-term. :pr:`2091`
     * Documentation Changes
         * Rename dataset to clarify that its gzipped but not a tarball :pr:`2183`
+        * Updated contributing guide with a note about GitHub Actions permissions :pr:`2090`
+        * Updated automl and model understanding user guides :pr:`2090`
     * Testing Changes
         * Use machineFL user token for dependency update bot, and add more reviewers :pr:`2189`
 

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -368,6 +368,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Training and Scoring Multiple Pipelines using AutoMLSearch\n",
+    "\n",
+    "AutoMLSearch will automatically fit the best pipeline on the entire training data. It also provides an easy API for training and scoring other pipelines.\n",
+    "\n",
+    "If you'd like to train one or more pipelines on the entire training data, you can use the `train_pipelines`method\n",
+    "\n",
+    "Similarly, if you'd like to score one or more pipelines on a particular dataset, you can use the `train_pipelines`method\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trained_pipelines = automl.train_pipelines([automl.get_pipeline(i) for i in [0, 1, 2]])\n",
+    "trained_pipelines\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline_holdout_scores = automl.score_pipelines([trained_pipelines[name] for name in trained_pipelines.keys()])\n",
+    "pipeline_holdout_scores\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Saving AutoMLSearch and pipelines from AutoMLSearch\n",
     "\n",
     "There are two ways to save results from AutoMLSearch. \n",

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -384,8 +384,8 @@
    "outputs": [],
    "source": [
     "# saving the entire automl search\n",
-    "automl.save(\"automl.cloudpickle\")\n"
-    "automl2 = evalml.automl.AutoMLSearch.load(\"automl.cloudpickle\")\n"
+    "automl.save(\"automl.cloudpickle\")\n",
+    "automl2 = evalml.automl.AutoMLSearch.load(\"automl.cloudpickle\")\n",
     "# saving the best pipeline using .save()\n",
     "best_pipeline.save(\"pipeline.cloudpickle\")\n",
     "best_pipeline_copy = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -44,12 +44,27 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import evalml\n",
+    "from evalml.utils import infer_feature_types\n",
+    "X, y = evalml.demos.load_fraud(n_rows=1000, return_pandas=True)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__Note:__ To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/).\n",
+    "To provide data to EvalML, it is recommended that you create a `DataTable` object using [the Woodwork project](https://woodwork.alteryx.com/en/stable/). This allows you to easily control how EvalML will treat each of your features before training a model.\n",
     "\n",
-    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you'd like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method as follows. The `infer_feature_types` utility method takes pandas or numpy input and converts it to a Woodwork data structure. It takes in a `feature_types` parameter which can be used to specify what types specific columns should be. In the example below, we specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
+    "EvalML also accepts ``pandas`` input, and will run type inference on top of the input ``pandas`` data. If you'd like to change the types inferred by EvalML, you can use the `infer_feature_types` utility method, which takes pandas or numpy input and converts it to a Woodwork data structure. The `feature_types` parameter can be used to specify what types specific columns should be.\n",
+    "\n",
+    "In the example below, we reformat a couple features to make them easily consumable by the model, and then specify that the provider, which would have otherwise been inferred as a column with natural language, is a categorical column."
    ]
   },
   {
@@ -58,10 +73,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import evalml\n",
-    "from evalml.utils import infer_feature_types\n",
-    "X, y = evalml.demos.load_fraud(n_rows=1000, return_pandas=True)\n",
-    "X = infer_feature_types(X, feature_types={'provider': 'categorical'})"
+    "X['expiration_date'] = X['expiration_date'].apply(lambda x: '20{}-01-{}'.format(x.split(\"/\")[1], x.split(\"/\")[0]))\n",
+    "X[['lat', 'lng']] = X[['lat', 'lng']].astype('str')\n",
+    "X = infer_feature_types(X, feature_types= {'store_id': 'categorical',\n",
+    "                                           'expiration_date': 'datetime',\n",
+    "                                           'lat': 'categorical',\n",
+    "                                           'lng': 'categorical',\n",
+    "                                           'provider': 'categorical'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to validate the results of the pipeline creation and optimization process, we will save some of our data as a holdout set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, X_holdout, y_train, y_holdout = evalml.preprocessing.split_data(X, y, problem_type='binary', test_size=.2)"
    ]
   },
   {
@@ -84,7 +118,7 @@
     "from evalml.data_checks import DefaultDataChecks\n",
     "\n",
     "data_checks = DefaultDataChecks(\"binary\", \"log loss binary\")\n",
-    "data_checks.validate(X, y)"
+    "data_checks.validate(X_train, y_train)"
    ]
   },
   {
@@ -100,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl = evalml.automl.AutoMLSearch(X_train=X, y_train=y, problem_type='binary')\n",
+    "automl = evalml.automl.AutoMLSearch(X_train=X_train, y_train=y_train, problem_type='binary')\n",
     "automl.search()"
    ]
   },
@@ -140,8 +174,8 @@
     "import pandas as pd\n",
     "from evalml.problem_types import detect_problem_type\n",
     "\n",
-    "y = pd.Series([0, 1, 1, 0, 1, 1])\n",
-    "detect_problem_type(y)"
+    "y_binary = pd.Series([0, 1, 1, 0, 1, 1])\n",
+    "detect_problem_type(y_binary)"
    ]
   },
   {
@@ -192,8 +226,8 @@
     "from evalml.pipelines import MulticlassClassificationPipeline\n",
     "\n",
     "\n",
-    "automl_custom = evalml.automl.AutoMLSearch(X_train=X,\n",
-    "                                           y_train=y,\n",
+    "automl_custom = evalml.automl.AutoMLSearch(X_train=X_train,\n",
+    "                                           y_train=y_train,\n",
     "                                           problem_type='multiclass',\n",
     "                                           allowed_pipelines=[MulticlassClassificationPipeline(component_graph=['Simple Imputer', 'Random Forest Classifier'])])"
    ]
@@ -361,7 +395,7 @@
     "best_pipeline = automl.best_pipeline\n",
     "print(best_pipeline.name)\n",
     "print(best_pipeline.parameters)\n",
-    "best_pipeline.predict(X)"
+    "best_pipeline.predict(X_train)"
    ]
   },
   {
@@ -393,7 +427,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline_holdout_scores = automl.score_pipelines([trained_pipelines[name] for name in trained_pipelines.keys()])\n",
+    "pipeline_holdout_scores = automl.score_pipelines([trained_pipelines[name] for name in trained_pipelines.keys()],\n",
+    "                                                X_holdout,\n",
+    "                                                y_holdout,\n",
+    "                                                ['Accuracy Binary', 'F1', 'AUC'])\n",
     "pipeline_holdout_scores\n"
    ]
   },
@@ -459,27 +496,7 @@
     "}}\n",
     "\n",
     "# using this pipeline parameter means that our Imputer components in the pipelines will only search through 'median' and 'most_frequent' stretegies for 'numeric_impute_strategy'\n",
-    "automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', pipeline_parameters=pipeline_hyperparameters)\n",
-    "automl.search()\n",
-    "automl.best_pipeline.hyperparameters"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Access raw results\n",
-    "\n",
-    "The `AutoMLSearch` class records detailed results information under the `results` field, including information about the cross-validation scoring and parameters."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "automl.results"
+    "automl_constrained = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', pipeline_parameters=pipeline_hyperparameters)"
    ]
   },
   {
@@ -528,6 +545,24 @@
    "outputs": [],
    "source": [
     "automl_with_ensembling.best_pipeline.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Access raw results\n",
+    "\n",
+    "The `AutoMLSearch` class records detailed results information under the `results` field, including information about the cross-validation scoring and parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "automl.results"
    ]
   }
  ],

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -383,9 +383,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# saving the entire automl search\n",
+    "automl.save(\"automl.cloudpickle\")\n"
+    "automl2 = evalml.automl.AutoMLSearch.load(\"automl.cloudpickle\")\n"
     "# saving the best pipeline using .save()\n",
-    "best_pipeline.save(\"pipeline.cloudpickle\")\n"
-    "best_pipeline = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
+    "best_pipeline.save(\"pipeline.cloudpickle\")\n",
+    "best_pipeline_copy = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
    ]
   },
   {

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -384,7 +384,8 @@
    "outputs": [],
    "source": [
     "# saving the best pipeline using .save()\n",
-    "best_pipeline.save(\"file_path_here\")"
+    "best_pipeline.save(\"pipeline.cloudpickle\")\n"
+    "best_pipeline = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
    ]
   },
   {

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -36,6 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import evalml\n",
+    "from evalml.pipelines import BinaryClassificationPipeline\n",
     "X, y = evalml.demos.load_breast_cancer()\n",
     "\n",
     "pipeline = BinaryClassificationPipeline(['Simple Imputer', 'Random Forest Classifier'])\n",
@@ -349,12 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import evalml\n",
-    "\n",
-    "class DTBinaryClassificationPipeline(evalml.pipelines.BinaryClassificationPipeline):\n",
-    "    component_graph = ['Simple Imputer', 'Decision Tree Classifier']\n",
-    "\n",
-    "pipeline_dt = DTBinaryClassificationPipeline({})\n",
+    "pipeline_dt = BinaryClassificationPipeline(['Simple Imputer', 'Decision Tree Classifier'])\n",
     "pipeline_dt.fit(X, y)"
    ]
   },

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -36,6 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "X, y = evalml.demos.load_breast_cancer()\n",
+    "\n",
     "pipeline = BinaryClassificationPipeline(['Simple Imputer', 'Random Forest Classifier'])\n",
     "pipeline.fit(X, y)\n",
     "print(pipeline.score(X, y, objectives=['log loss binary']))"
@@ -351,8 +353,6 @@
     "\n",
     "class DTBinaryClassificationPipeline(evalml.pipelines.BinaryClassificationPipeline):\n",
     "    component_graph = ['Simple Imputer', 'Decision Tree Classifier']\n",
-    "\n",
-    "X, y = evalml.demos.load_breast_cancer()\n",
     "\n",
     "pipeline_dt = DTBinaryClassificationPipeline({})\n",
     "pipeline_dt.fit(X, y)"

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -27,48 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's train a pipeline on some data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import evalml\n",
-    "from evalml.pipelines import BinaryClassificationPipeline\n",
-    "X, y = evalml.demos.load_breast_cancer()\n",
-    "\n",
-    "pipeline_dt = BinaryClassificationPipeline(['Simple Imputer', 'Decision Tree Classifier'], parameters={})\n",
-    "pipeline_dt.fit(X, y)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Tree Visualization\n",
-    "\n",
-    "We can visualize the structure of the Decision Tree that was fit to that data, and save it if necessary."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from evalml.model_understanding.graphs import visualize_decision_tree\n",
-    "\n",
-    "visualize_decision_tree(pipeline_dt.estimator, max_depth=2, rotate=False, filled=True, filepath=None)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Lets replace the Decision Tree Classifier with a Random Forest Classifier."
+    "First let's train a pipeline on some data."
    ]
   },
   {
@@ -373,6 +332,50 @@
     "\n",
     "y_pred = pipeline_regress.predict(X_test)\n",
     "graph_prediction_vs_actual(y_test, y_pred, outlier_threshold=50)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's train a decision tree on some data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import evalml\n",
+    "\n",
+    "class DTBinaryClassificationPipeline(evalml.pipelines.BinaryClassificationPipeline):\n",
+    "    component_graph = ['Simple Imputer', 'Decision Tree Classifier']\n",
+    "\n",
+    "X, y = evalml.demos.load_breast_cancer()\n",
+    "\n",
+    "pipeline_dt = DTBinaryClassificationPipeline({})\n",
+    "pipeline_dt.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tree Visualization\n",
+    "\n",
+    "We can visualize the structure of the Decision Tree that was fit to that data, and save it if necessary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from evalml.model_understanding.graphs import visualize_decision_tree\n",
+    "\n",
+    "visualize_decision_tree(pipeline_dt.estimator, max_depth=2, rotate=False, filled=True, filepath=None)"
    ]
   },
   {

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First let's train a pipeline on some data."
+    "First, let's train a pipeline on some data."
    ]
   },
   {

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -278,8 +278,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from evalml.pipelines import PipelineBase\n",
     "pipeline.save(\"pipeline.cloudpickle\")\n",
-    "pipeline2 = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
+    "pipeline2 = PipelineBase.load(\"pipeline.cloudpickle\")\n",
+    "assert pipeline == pipeline2"
    ]
   },
   {

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -269,6 +269,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can save and load trained or untrained pipeline instances using the [cloudpickle](https://github.com/cloudpipe/cloudpickle) format, like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.save(\"pipeline.cloudpickle\")\n"
+    "pipeline = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Component Graph"
    ]
   },

--- a/docs/source/user_guide/pipelines.ipynb
+++ b/docs/source/user_guide/pipelines.ipynb
@@ -278,8 +278,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline.save(\"pipeline.cloudpickle\")\n"
-    "pipeline = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
+    "pipeline.save(\"pipeline.cloudpickle\")\n",
+    "pipeline2 = evalml.pipelines.PipelineBase.load(\"pipeline.cloudpickle\")"
    ]
   },
   {

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -11,5 +11,6 @@ from .exceptions import (
     DataCheckInitError,
     EnsembleMissingPipelinesError,
     NullsInColumnWarning,
-    ObjectiveCreationError
+    ObjectiveCreationError,
+    NoPositiveLabelException
 )

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -11,6 +11,5 @@ from .exceptions import (
     DataCheckInitError,
     EnsembleMissingPipelinesError,
     NullsInColumnWarning,
-    ObjectiveCreationError,
-    NoPositiveLabelException
+    ObjectiveCreationError
 )

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -73,3 +73,7 @@ class NullsInColumnWarning(UserWarning):
 
 class ObjectiveCreationError(Exception):
     """Exception when get_objective tries to instantiate an objective and required args are not provided."""
+
+
+class NoPositiveLabelException(Exception):
+    """Exception when a particular classification label for the 'positive' class cannot be found in the column index or unique values"""

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -73,7 +73,3 @@ class NullsInColumnWarning(UserWarning):
 
 class ObjectiveCreationError(Exception):
     """Exception when get_objective tries to instantiate an objective and required args are not provided."""
-
-
-class NoPositiveLabelException(Exception):
-    """Exception when a particular classification label for the 'positive' class cannot be found in the column index or unique values"""

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -156,7 +156,10 @@ def precision_recall_curve(y_true, y_pred_proba):
     y_true = infer_feature_types(y_true)
     y_pred_proba = infer_feature_types(y_pred_proba)
     y_true = _convert_woodwork_types_wrapper(y_true.to_series())
-    y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series())
+    if isinstance(y_pred_proba, ww.DataTable):
+        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe()).to_numpy()
+    else:
+        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series()).to_numpy()
 
     precision, recall, thresholds = sklearn_precision_recall_curve(y_true, y_pred_proba)
     auc_score = sklearn_auc(recall, precision)

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -137,13 +137,14 @@ def graph_confusion_matrix(y_true, y_pred, normalize_method='true', title_additi
     return fig
 
 
-def precision_recall_curve(y_true, y_pred_proba, pos_label):
+def precision_recall_curve(y_true, y_pred_proba, pos_label_idx=-1):
     """
     Given labels and binary classifier predicted probabilities, compute and return the data representing a precision-recall curve.
 
     Arguments:
         y_true (ww.DataColumn, pd.Series or np.ndarray): True binary labels.
         y_pred_proba (ww.DataColumn, pd.Series or np.ndarray): Predictions from a binary classifier, before thresholding has been applied. Note this should be the predicted probability for the "true" label.
+        pos_label_idx (int): the column index corresponding to the positive class. If predicted probabilities are two-dimensional, this will be used to access the probabilities for the positive class.
 
     Returns:
         list: Dictionary containing metrics used to generate a precision-recall plot, with the following keys:
@@ -158,13 +159,13 @@ def precision_recall_curve(y_true, y_pred_proba, pos_label):
     y_true = _convert_woodwork_types_wrapper(y_true.to_series())
     if isinstance(y_pred_proba, ww.DataTable):
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe())
+        y_pred_proba_shape = y_pred_proba.shape
+        try:
+            y_pred_proba = y_pred_proba.iloc[:, pos_label_idx]
+        except IndexError:
+            raise NoPositiveLabelException(f"Predicted probabilities of shape {y_pred_proba_shape} don't contain a column at index {pos_label_idx}")
     else:
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series())
-
-    if pos_label not in y_true.unique():
-        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
-    if pos_label not in y_pred_proba.columns:
-        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
 
     precision, recall, thresholds = sklearn_precision_recall_curve(y_true, y_pred_proba)
     auc_score = sklearn_auc(recall, precision)

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -22,7 +22,7 @@ from sklearn.tree import export_graphviz
 from sklearn.utils.multiclass import unique_labels
 
 import evalml
-from evalml.exceptions import NullsInColumnWarning
+from evalml.exceptions import NoPositiveLabelException, NullsInColumnWarning
 from evalml.model_family import ModelFamily
 from evalml.objectives.utils import get_objective
 from evalml.problem_types import ProblemTypes, is_classification
@@ -137,7 +137,7 @@ def graph_confusion_matrix(y_true, y_pred, normalize_method='true', title_additi
     return fig
 
 
-def precision_recall_curve(y_true, y_pred_proba):
+def precision_recall_curve(y_true, y_pred_proba, pos_label):
     """
     Given labels and binary classifier predicted probabilities, compute and return the data representing a precision-recall curve.
 
@@ -160,6 +160,11 @@ def precision_recall_curve(y_true, y_pred_proba):
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe())
     else:
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series())
+
+    if pos_label not in y_true.unique():
+        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
+    if pos_label not in y_pred_proba.columns:
+        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
 
     precision, recall, thresholds = sklearn_precision_recall_curve(y_true, y_pred_proba)
     auc_score = sklearn_auc(recall, precision)

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -22,7 +22,7 @@ from sklearn.tree import export_graphviz
 from sklearn.utils.multiclass import unique_labels
 
 import evalml
-from evalml.exceptions import NullsInColumnWarning
+from evalml.exceptions import NoPositiveLabelException, NullsInColumnWarning
 from evalml.model_family import ModelFamily
 from evalml.objectives.utils import get_objective
 from evalml.problem_types import ProblemTypes, is_classification
@@ -137,7 +137,7 @@ def graph_confusion_matrix(y_true, y_pred, normalize_method='true', title_additi
     return fig
 
 
-def precision_recall_curve(y_true, y_pred_proba):
+def precision_recall_curve(y_true, y_pred_proba, pos_label):
     """
     Given labels and binary classifier predicted probabilities, compute and return the data representing a precision-recall curve.
 
@@ -157,9 +157,14 @@ def precision_recall_curve(y_true, y_pred_proba):
     y_pred_proba = infer_feature_types(y_pred_proba)
     y_true = _convert_woodwork_types_wrapper(y_true.to_series())
     if isinstance(y_pred_proba, ww.DataTable):
-        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe()).to_numpy()
+        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe())
     else:
-        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series()).to_numpy()
+        y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series())
+
+    if pos_label not in y_true.unique():
+        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
+    if pos_label not in y_pred_proba.columns:
+        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
 
     precision, recall, thresholds = sklearn_precision_recall_curve(y_true, y_pred_proba)
     auc_score = sklearn_auc(recall, precision)

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -22,7 +22,7 @@ from sklearn.tree import export_graphviz
 from sklearn.utils.multiclass import unique_labels
 
 import evalml
-from evalml.exceptions import NoPositiveLabelException, NullsInColumnWarning
+from evalml.exceptions import NullsInColumnWarning
 from evalml.model_family import ModelFamily
 from evalml.objectives.utils import get_objective
 from evalml.problem_types import ProblemTypes, is_classification
@@ -137,7 +137,7 @@ def graph_confusion_matrix(y_true, y_pred, normalize_method='true', title_additi
     return fig
 
 
-def precision_recall_curve(y_true, y_pred_proba, pos_label):
+def precision_recall_curve(y_true, y_pred_proba):
     """
     Given labels and binary classifier predicted probabilities, compute and return the data representing a precision-recall curve.
 
@@ -160,11 +160,6 @@ def precision_recall_curve(y_true, y_pred_proba, pos_label):
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_dataframe())
     else:
         y_pred_proba = _convert_woodwork_types_wrapper(y_pred_proba.to_series())
-
-    if pos_label not in y_true.unique():
-        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
-    if pos_label not in y_pred_proba.columns:
-        raise NoPositiveLabelException(f'Positive label "{pos_label}" not found in y_true')
 
     precision, recall, thresholds = sklearn_precision_recall_curve(y_true, y_pred_proba)
     auc_score = sklearn_auc(recall, precision)

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -379,7 +379,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             graphviz.Digraph().pipe()
         except graphviz.backend.ExecutableNotFound:
             raise RuntimeError(
-                "To graph entity sets, a graphviz backend is required.\n" +
+                "To graph pipelines, a graphviz backend is required.\n" +
                 "Install the backend using one of the following commands:\n" +
                 "  Mac OS: brew install graphviz\n" +
                 "  Linux (Ubuntu): sudo apt-get install graphviz\n" +

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -214,12 +214,31 @@ def test_precision_recall_curve_return_type():
     assert isinstance(precision_recall_curve_data['auc_score'], float)
 
 
-@pytest.mark.parametrize("data_type", ['np', 'pd', 'ww'])
+@pytest.mark.parametrize("data_type", ['np', 'pd', 'li', 'ww'])
 def test_precision_recall_curve(data_type, make_data_type):
     y_true = np.array([0, 0, 1, 1])
     y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
     y_true = make_data_type(data_type, y_true)
     y_predict_proba = make_data_type(data_type, y_predict_proba)
+
+    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba)
+
+    precision = precision_recall_curve_data.get('precision')
+    recall = precision_recall_curve_data.get('recall')
+    thresholds = precision_recall_curve_data.get('thresholds')
+
+    precision_expected = np.array([0.66666667, 0.5, 1, 1])
+    recall_expected = np.array([1, 0.5, 0.5, 0])
+    thresholds_expected = np.array([0.35, 0.4, 0.8])
+
+    np.testing.assert_almost_equal(precision_expected, precision, decimal=5)
+    np.testing.assert_almost_equal(recall_expected, recall, decimal=5)
+    np.testing.assert_almost_equal(thresholds_expected, thresholds, decimal=5)
+
+
+def test_precision_recall_curve_1d_y_pred_proba(make_data_type):
+    y_true = np.array([0, 0, 1, 1])
+    y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
 
     precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba)
 

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -240,7 +240,7 @@ def test_precision_recall_curve_1d_y_pred_proba(make_data_type):
     y_true = np.array([0, 0, 1, 1])
     y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
 
-    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba)
+    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, 1)
 
     precision = precision_recall_curve_data.get('precision')
     recall = precision_recall_curve_data.get('recall')

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -10,6 +10,7 @@ import woodwork as ww
 from sklearn.exceptions import NotFittedError, UndefinedMetricWarning
 from sklearn.preprocessing import label_binarize
 
+from evalml.exceptions import NoPositiveLabelException
 from evalml.model_understanding.graphs import (
     binary_objective_vs_threshold,
     calculate_permutation_importance,
@@ -220,10 +221,10 @@ def test_precision_recall_curve(data_type, make_data_type):
     y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
     if data_type == 'pd2d':
         data_type = 'pd'
-        y_predict_proba = np.array([[0.1, 0.9],
-                                    [0.4, 0.6],
-                                    [0.35, 0.65],
-                                    [0.8, 0.2]])
+        y_predict_proba = np.array([[0.9, 0.1],
+                                    [0.6, 0.4],
+                                    [0.65, 0.35],
+                                    [0.2, 0.8]])
     y_true = make_data_type(data_type, y_true)
     y_predict_proba = make_data_type(data_type, y_predict_proba)
 
@@ -242,11 +243,13 @@ def test_precision_recall_curve(data_type, make_data_type):
     np.testing.assert_almost_equal(thresholds_expected, thresholds, decimal=5)
 
 
-def test_precision_recall_curve_1d_y_pred_proba(make_data_type):
-    y_true = np.array([0, 0, 1, 1])
-    y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
-
-    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, 1)
+def test_precision_recall_curve_pos_label_idx():
+    y_true = pd.Series(np.array([0, 0, 1, 1]))
+    y_predict_proba = pd.DataFrame(np.array([[0.9, 0.1],
+                                             [0.6, 0.4],
+                                             [0.65, 0.35],
+                                             [0.2, 0.8]]))
+    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, pos_label_idx=1)
 
     precision = precision_recall_curve_data.get('precision')
     recall = precision_recall_curve_data.get('recall')
@@ -255,10 +258,29 @@ def test_precision_recall_curve_1d_y_pred_proba(make_data_type):
     precision_expected = np.array([0.66666667, 0.5, 1, 1])
     recall_expected = np.array([1, 0.5, 0.5, 0])
     thresholds_expected = np.array([0.35, 0.4, 0.8])
-
     np.testing.assert_almost_equal(precision_expected, precision, decimal=5)
     np.testing.assert_almost_equal(recall_expected, recall, decimal=5)
     np.testing.assert_almost_equal(thresholds_expected, thresholds, decimal=5)
+
+    y_predict_proba = pd.DataFrame(np.array([[0.1, 0.9],
+                                             [0.4, 0.6],
+                                             [0.35, 0.65],
+                                             [0.8, 0.2]]))
+    precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, pos_label_idx=0)
+    np.testing.assert_almost_equal(precision_expected, precision, decimal=5)
+    np.testing.assert_almost_equal(recall_expected, recall, decimal=5)
+    np.testing.assert_almost_equal(thresholds_expected, thresholds, decimal=5)
+
+
+def test_precision_recall_curve_pos_label_idx_error(make_data_type):
+    y_true = np.array([0, 0, 1, 1])
+    y_predict_proba = np.array([[0.9, 0.1],
+                                [0.6, 0.4],
+                                [0.65, 0.35],
+                                [0.2, 0.8]])
+    with pytest.raises(NoPositiveLabelException,
+                       match="Predicted probabilities of shape \(4, 2\) don't contain a column at index 9001"):
+        precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, pos_label_idx=9001)
 
 
 @pytest.mark.parametrize("data_type", ['np', 'pd', 'ww'])

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -279,8 +279,8 @@ def test_precision_recall_curve_pos_label_idx_error(make_data_type):
                                 [0.65, 0.35],
                                 [0.2, 0.8]])
     with pytest.raises(NoPositiveLabelException,
-                       match="Predicted probabilities of shape \(4, 2\) don't contain a column at index 9001"):
-        precision_recall_curve_data = precision_recall_curve(y_true, y_predict_proba, pos_label_idx=9001)
+                       match="Predicted probabilities of shape \\(4, 2\\) don't contain a column at index 9001"):
+        precision_recall_curve(y_true, y_predict_proba, pos_label_idx=9001)
 
 
 @pytest.mark.parametrize("data_type", ['np', 'pd', 'ww'])

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -214,10 +214,16 @@ def test_precision_recall_curve_return_type():
     assert isinstance(precision_recall_curve_data['auc_score'], float)
 
 
-@pytest.mark.parametrize("data_type", ['np', 'pd', 'li', 'ww'])
+@pytest.mark.parametrize("data_type", ['np', 'pd', 'pd2d', 'li', 'ww'])
 def test_precision_recall_curve(data_type, make_data_type):
     y_true = np.array([0, 0, 1, 1])
     y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
+    if data_type == 'pd2d':
+        data_type = 'pd'
+        y_predict_proba = np.array([[0.1, 0.9],
+                                    [0.4, 0.6],
+                                    [0.35, 0.65],
+                                    [0.8, 0.2]])
     y_true = make_data_type(data_type, y_true)
     y_predict_proba = make_data_type(data_type, y_predict_proba)
 


### PR DESCRIPTION
Changes:
* Minor fix to precision-recall graph method: use same code as ROC method to process input data
* User guide updates: `train_pipelines`/`score_pipelines`, automl and pipeline save/load (fix #2083 ), move DT viz lower in model understanding guide. Update automl guide to use training-holdout split. 
* Add note to contributers guide about GitHub Actions permissions
* Fix typo in `PipelineBase` error.