### PR TITLE
Spike: component graph upgrades

### DIFF
--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -25,7 +25,7 @@ import evalml
 from evalml.exceptions import NullsInColumnWarning
 from evalml.model_family import ModelFamily
 from evalml.objectives.utils import get_objective
-from evalml.problem_types import ProblemTypes, is_classification
+from evalml.problem_types import ProblemTypes
 from evalml.utils import (
     _convert_woodwork_types_wrapper,
     import_or_raise,

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -325,9 +325,6 @@ def _fast_permutation_importance(pipeline, X, y, objective, n_repeats=5, n_jobs=
 
     precomputed_features = _convert_woodwork_types_wrapper(pipeline.compute_estimator_features(X, y).to_dataframe())
 
-    if is_classification(pipeline.problem_type):
-        y = pipeline._encode_targets(y)
-
     def scorer(pipeline, features, y, objective):
         if objective.score_needs_proba:
             preds = pipeline.estimator.predict_proba(features)

--- a/evalml/model_understanding/prediction_explanations/explainers.py
+++ b/evalml/model_understanding/prediction_explanations/explainers.py
@@ -133,7 +133,7 @@ def explain_predictions_best_worst(pipeline, input_features, y_true, num_to_expl
                 y_pred = pipeline.predict_proba(input_features).to_dataframe()
                 y_pred_values = pipeline.predict(input_features).to_series()
             y_true_no_nan, y_pred_no_nan, y_pred_values_no_nan = drop_rows_with_nans(y_true, y_pred, y_pred_values)
-            errors = metric(pipeline._encode_targets(y_true_no_nan), y_pred_no_nan)
+            errors = metric(y_true_no_nan, y_pred_no_nan)
     except Exception as e:
         tb = traceback.format_tb(sys.exc_info()[2])
         raise PipelineScoreError(exceptions={metric.__name__: (e, tb)}, scored_successfully={})

--- a/evalml/pipelines/binary_classification_pipeline_mixin.py
+++ b/evalml/pipelines/binary_classification_pipeline_mixin.py
@@ -43,7 +43,7 @@ class BinaryClassificationPipelineMixin():
             objective (ObjectiveBase): The objective to threshold with. Must have a tunable threshold.
         """
         if self.can_tune_threshold_with_objective(objective):
-            targets = self._encode_targets(y.to_series())
+            targets = y.to_series()
             self.threshold = objective.optimize_threshold(y_pred_proba, targets, X)
         else:
             raise ValueError("Problem type must be binary and objective must be optimizable.")

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -43,9 +43,10 @@ class ClassificationPipeline(PipelineBase):
     @property
     def classes_(self):
         """Gets the class names for the problem."""
-        if not hasattr(self._encoder, "classes_"):
+        encoder = self._component_graph.get_component('Label Encoder')._encoder
+        if not hasattr(encoder, "classes_"):
             raise AttributeError("Cannot access class names before fitting the pipeline.")
-        return self._encoder.classes_
+        return encoder.classes_
 
     def _predict(self, X, objective=None):
         """Make predictions using selected features.
@@ -84,8 +85,11 @@ class ClassificationPipeline(PipelineBase):
         """
         X = self.compute_estimator_features(X, y=None)
         proba = self.estimator.predict_proba(X).to_dataframe()
-        if hasattr(self._encoder, "classes_"):
-            proba.columns = self._encoder.classes_
+        try:
+            classes = self.classes_
+            proba.columns = classes
+        except Exception:
+            pass
         return infer_feature_types(proba)
 
     def score(self, X, y, objectives):

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -71,7 +71,7 @@ class ClassificationPipeline(PipelineBase):
             ww.DataColumn: Estimated labels
         """
         predictions = self._predict(X, objective=objective).to_series()
-        predictions = pd.Series(self._decode_targets(predictions), name=self.input_target_name)
+        predictions = pd.Series(predictions, name=self.input_target_name)
         return infer_feature_types(predictions)
 
     def predict_proba(self, X):

--- a/evalml/pipelines/classification_pipeline.py
+++ b/evalml/pipelines/classification_pipeline.py
@@ -106,7 +106,6 @@ class ClassificationPipeline(PipelineBase):
         y = infer_feature_types(y)
         y = _convert_woodwork_types_wrapper(y.to_series())
         objectives = self.create_objectives(objectives)
-        y = self._encode_targets(y)
         y_predicted, y_predicted_proba = self._compute_predictions(X, y, objectives)
         if y_predicted is not None:
             y_predicted = _convert_woodwork_types_wrapper(y_predicted.to_series())

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -151,7 +151,9 @@ class ComponentGraph:
             ww.DataTable, ww.DataColumn: Transformed values, and the outputted target.
         """
         if len(self.compute_order) <= 1:
-            return infer_feature_types(X)
+            if y is not None:
+                y = infer_feature_types(y)
+            return infer_feature_types(X), y
         component_outputs = self._compute_features(self.compute_order[:-1], X, y=y, fit=needs_fitting)
         final_component_inputs, final_component_target = self._compute_inputs(X, y, self.compute_order[-1], component_outputs)
         if needs_fitting:

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -209,6 +209,8 @@ class ComponentGraph:
                     parent_input_type = 'x'
                 if parent_input.endswith('.y'):
                     parent_input_type = 'y'
+                if parent_input.endswith('.state'):
+                    parent_input_type = 'state'
                 if parent_input_type in ['both', 'x']:
                     parent_x = output_cache.get(parent_input, output_cache.get(f'{parent_input}.x'))
                     if isinstance(parent_x, ww.DataTable):
@@ -228,11 +230,6 @@ class ComponentGraph:
             if len(component_refs):
                 kwargs["dependent_components"] = component_refs
 
-            component_output_type = 'both'
-            if component_name.endswith('.x'):
-                component_output_type = 'x'
-            if component_name.endswith('.y'):
-                component_output_type = 'y'
             output_x = None
             output_y = None
             if isinstance(component_instance, Transformer):
@@ -252,14 +249,10 @@ class ComponentGraph:
                     output_y = component_instance.predict(input_x)
                 else:
                     output_y = None
-                output_cache[component_name] = output_y
-            if component_output_type == 'both':
+            if output_x is not None:
                 output_cache[f"{component_name}.x"] = output_x
+            if output_y is not None:
                 output_cache[f"{component_name}.y"] = output_y
-            elif component_output_type == 'x':
-                output_cache[f"{component_name}"] = output_x
-            elif component_output_type == 'y':
-                output_cache[f"{component_name}"] = output_y
         return output_cache
 
     def _get_feature_provenance(self, input_feature_names):

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -84,7 +84,7 @@ class ComponentGraph:
             for parent_name in parent_names:
                 if parent_name.endswith(".state"):
                     component_state_parents.append(parent_name[:-6])
-            if len(state_parents):
+            if len(component_state_parents):
                 state_parents[component_name] = component_state_parents
 
             try:

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -195,7 +195,7 @@ class ComponentGraph:
             return infer_feature_types(X)
         final_component = self.compute_order[-1]
         outputs = self._compute_features(self.compute_order, X)
-        return infer_feature_types(outputs.get(f'{final_component}.y', outputs.get(f'{final_component}.x')))
+        return infer_feature_types(outputs.get(f'{final_component}.y'))
 
     def transform(self, X):
         """Output the features after applying a series of transformations. Will error if an estimator is the final step.
@@ -212,7 +212,11 @@ class ComponentGraph:
         if not isinstance(self.component_instances[final_component], Transformer):
             raise Exception('Final component must be a transformer in order to use ComponentGraph.transform')
         outputs = self._compute_features(self.compute_order, X)
-        return infer_feature_types(outputs.get(f'{final_component}.x'))
+        X_out = infer_feature_types(outputs.get(f'{final_component}.x'))
+        y_out = outputs.get(f'{final_component}.y')
+        if y_out is not None:
+            y_out = infer_feature_types(y_out)
+        return X_out, y_out
 
     def _component_output_type(self, component_name):
         if component_name.endswith('.x'):

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -395,13 +395,17 @@ class ComponentGraph:
         return graph
 
     @staticmethod
-    def _get_edges(component_dict):
+    def _get_edges(component_dict, include_state_edges=False):
         edges = []
         for component_name, component_info in component_dict.items():
             if len(component_info) > 1:
                 for parent in component_info[1:]:
-                    if parent[-2:] == '.x' or parent[-2:] == '.y':
+                    if parent.endswith('.x') or parent.endswith('.y'):
                         parent = parent[:-2]
+                    if parent.endswith('.state'):
+                        if not include_state_edges:
+                            continue
+                        parent = parent[:-6]
                     edges.append((parent, component_name))
         return edges
 

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -197,6 +197,16 @@ class ComponentGraph:
         outputs = self._compute_features(self.compute_order, X)
         return infer_feature_types(outputs.get(f'{final_component}.x'))
 
+    @staticmethod
+    def _component_output_type(component_name):
+        if component_name.endswith('.x'):
+            return {'x'}
+        if component_name.endswith('.y'):
+            return {'y'}
+        if component_name.endswith('.state'):
+            return {'state'}
+        return {'x', 'y'}
+
     def _compute_features(self, component_list, X, y=None, fit=False):
         """Transforms the data by applying the given components.
 
@@ -221,21 +231,15 @@ class ComponentGraph:
             x_inputs = []
             y_input = None
             for parent_input in self.get_parents(component_name):
-                parent_input_type = 'both'
-                if parent_input.endswith('.x'):
-                    parent_input_type = 'x'
-                if parent_input.endswith('.y'):
-                    parent_input_type = 'y'
-                if parent_input.endswith('.state'):
-                    parent_input_type = 'state'
-                if parent_input_type in ['both', 'x']:
+                parent_input_type = self._component_output_type(parent_input)
+                if 'x' in parent_input_type:
                     parent_x = output_cache.get(parent_input, output_cache.get(f'{parent_input}.x'))
                     if isinstance(parent_x, ww.DataTable):
                         parent_x = _convert_woodwork_types_wrapper(parent_x.to_dataframe())
                     elif isinstance(parent_x, ww.DataColumn):
                         parent_x = pd.Series(_convert_woodwork_types_wrapper(parent_x.to_series()), name=parent_input)
                     x_inputs.append(parent_x)
-                if parent_input_type in ['both', 'y']:
+                if 'y' in parent_input_type:
                     if y_input is not None:
                         raise ValueError(f'Cannot have multiple `y` parents for a single component {component_name}')
                     y_input = output_cache[parent_input]
@@ -246,9 +250,7 @@ class ComponentGraph:
             component_refs = [self.get_component(name) for name in component_state_parents]
             if len(component_refs):
                 kwargs["dependent_components"] = component_refs
-
-            output_x = None
-            output_y = None
+            output_x, output_y = (None, None)
             if isinstance(component_instance, Transformer):
                 if fit:
                     output = component_instance.fit_transform(input_x, input_y, **kwargs)

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -136,7 +136,7 @@ class ComponentGraph:
         Returns:
             ww.DataTable: Transformed values.
         """
-        final_component_inputs, _ = self._fit_transform_features_helper(False, X, y)[0]
+        final_component_inputs, _ = self._fit_transform_features_helper(False, X, y)
         return final_component_inputs
 
     def _fit_transform_features_helper(self, needs_fitting, X, y=None):

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -390,6 +390,7 @@ class ComponentGraph:
                                         for key, val in component_class.parameters.items()])  # noqa: W605
                 label = '%s |%s\l' % (component_name, parameters)  # noqa: W605
             graph.node(component_name, shape='record', label=label)
+        # TODO figure out how to display state edges. Would be nice to use dotted lines
         edges = self._get_edges(self.component_dict)
         graph.edges(edges)
         return graph

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -242,7 +242,9 @@ class ComponentGraph:
                 if 'y' in parent_input_type:
                     if y_input is not None:
                         raise ValueError(f'Cannot have multiple `y` parents for a single component {component_name}')
-                    y_input = output_cache[parent_input]
+                    # don't error here if a y input isn't found; allow components to decide whether to error if y is None.
+                    if parent_input in output_cache:
+                        y_input = output_cache[parent_input]
             input_x, input_y = self._consolidate_inputs(x_inputs, y_input, X, y)
             self.input_feature_names.update({component_name: list(input_x.columns)})
             kwargs = dict()

--- a/evalml/pipelines/components/__init__.py
+++ b/evalml/pipelines/components/__init__.py
@@ -48,7 +48,9 @@ from .transformers import (
     DFSTransformer,
     Undersampler,
     TargetImputer,
-    PolynomialDetrender
+    PolynomialDetrender,
+    LabelEncoder,
+    LabelDecoder
 )
 from .ensemble import (
     StackedEnsembleClassifier,

--- a/evalml/pipelines/components/component_base_meta.py
+++ b/evalml/pipelines/components/component_base_meta.py
@@ -15,16 +15,16 @@ class ComponentBaseMeta(BaseMeta):
             It raises an exception if `False` and calls and returns the wrapped method if `True`.
         """
         @wraps(method)
-        def _check_for_fit(self, X=None, y=None):
+        def _check_for_fit(self, X=None, y=None, **kwargs):
             klass = type(self).__name__
             if not self._is_fitted and self.needs_fitting:
                 raise ComponentNotYetFittedError(f'This {klass} is not fitted yet. You must fit {klass} before calling {method.__name__}.')
             elif method.__name__ == 'inverse_transform':
-                return method(self, X, y)
+                return method(self, X, y, **kwargs)
             elif X is None and y is None:
-                return method(self)
+                return method(self, **kwargs)
             elif y is None:
-                return method(self, X)
+                return method(self, X, **kwargs)
             else:
-                return method(self, X, y)
+                return method(self, X, y, **kwargs)
         return _check_for_fit

--- a/evalml/pipelines/components/transformers/__init__.py
+++ b/evalml/pipelines/components/transformers/__init__.py
@@ -1,5 +1,5 @@
 from .transformer import Transformer
-from .encoders import OneHotEncoder, TargetEncoder
+from .encoders import OneHotEncoder, TargetEncoder, LabelEncoder, LabelDecoder
 from .feature_selection import FeatureSelector, RFClassifierSelectFromModel, RFRegressorSelectFromModel
 from .imputers import PerColumnImputer, SimpleImputer, Imputer, TargetImputer
 from .scalers import StandardScaler

--- a/evalml/pipelines/components/transformers/encoders/__init__.py
+++ b/evalml/pipelines/components/transformers/encoders/__init__.py
@@ -1,2 +1,3 @@
 from .onehot_encoder import OneHotEncoder
 from .target_encoder import TargetEncoder
+from .label_encoder import LabelEncoder, LabelDecoder

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -1,0 +1,42 @@
+from evalml.pipelines.components.transformers import Transformer
+
+
+class LabelEncoder(Transformer):
+    """Encodes target from string (or other dtype) to integers ranging from 0 to n-1."""
+    name = 'Label Encoder'
+    hyperparameter_ranges = {}
+
+    def __init__(self, random_seed=0):
+        super().init__(parameters={}, component_obj=None, random_seed=random_seed)
+
+    def fit(self, X, y):
+        self._encoder = LabelEncoder()
+        self._encoder.fit(y)
+
+    def transform(self, X, y=None):
+        try:
+            return X, pd.Series(self._encoder.transform(y), index=y.index, name=y.name)
+        except ValueError as e:
+            raise ValueError(str(e))
+
+
+class LabelDecoder(Transformer):
+    """Decodes target from integers from 0 to n-1 to string or other original dtype"""
+    name = 'Label Decoder'
+    hyperparameter_ranges = {}
+
+    def __init__(self, random_seed=0):
+        super().init__(parameters={}, component_obj=None, random_seed=random_seed)
+
+    def fit(self, X, y):
+        """No-op"""
+
+    def transform(self, X, y=None, dependent_components=None):
+        if dependent_components is None:
+            raise Exception('A reference to a previously-used label encoder component must be provided in order to decode labels.')
+        return X, self._encoder.inverse_transform(y.astype(int))
+
+    def fit_transform(self, X, y, dependent_components=None):
+        if dependent_components is None:
+            raise Exception('A reference to a previously-used label encoder component must be provided in order to decode labels.')
+        return self.fit(X, y).transform(X, y, dependent_components=dependent_components)

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder as SkLabelEncoder
+import woodwork as ww
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import _convert_woodwork_types_wrapper, _retain_custom_types_and_initalize_woodwork, infer_feature_types
@@ -11,6 +12,7 @@ class LabelEncoder(Transformer):
     hyperparameter_ranges = {}
 
     def __init__(self, random_seed=0):
+        self._y_logical_type = None
         super().__init__(parameters={}, component_obj=None, random_seed=random_seed)
 
     def fit(self, X, y):
@@ -19,6 +21,7 @@ class LabelEncoder(Transformer):
         if y is None:
             return X, None
         y_ww = infer_feature_types(y)
+        self._y_logical_type = y_ww.logical_type
 
         self._encoder = SkLabelEncoder()
         y_pd = _convert_woodwork_types_wrapper(y_ww.to_series())
@@ -69,7 +72,8 @@ class LabelDecoder(Transformer):
         y_pd = _convert_woodwork_types_wrapper(y_ww.to_series())
         y_decoded = label_encoder._encoder.inverse_transform(y_pd.astype(int))
         y_t = pd.Series(y_decoded, index=y_pd.index)
-        return X, _retain_custom_types_and_initalize_woodwork(y_ww, y_t)
+        y_t_ww = ww.DataColumn(y_t, logical_type=label_encoder._y_logical_type)
+        return X, y_t_ww
 
     def fit_transform(self, X, y, dependent_components=None):
         if dependent_components is None:

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -9,7 +9,7 @@ class LabelEncoder(Transformer):
     hyperparameter_ranges = {}
 
     def __init__(self, random_seed=0):
-        super().init__(parameters={}, component_obj=None, random_seed=random_seed)
+        super().__init__(parameters={}, component_obj=None, random_seed=random_seed)
 
     def fit(self, X, y):
         self._encoder = LabelEncoder()
@@ -28,7 +28,7 @@ class LabelDecoder(Transformer):
     hyperparameter_ranges = {}
 
     def __init__(self, random_seed=0):
-        super().init__(parameters={}, component_obj=None, random_seed=random_seed)
+        super().__init__(parameters={}, component_obj=None, random_seed=random_seed)
 
     def fit(self, X, y):
         """No-op"""

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from evalml.pipelines.components.transformers import Transformer
 
 

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -43,9 +43,11 @@ class LabelDecoder(Transformer):
         return self
 
     def transform(self, X, y=None, dependent_components=None):
-        if dependent_components is None:
+        if dependent_components is None or not len(dependent_components) or not isinstance(dependent_components[0], LabelEncoder):
             raise Exception('A reference to a previously-used label encoder component must be provided in order to decode labels.')
-        return X, self._encoder.inverse_transform(y.astype(int))
+        label_encoder = dependent_components[0]
+        y_pd = _convert_woodwork_types_wrapper(y.to_series())
+        return X, label_encoder._encoder.inverse_transform(y_pd.astype(int))
 
     def fit_transform(self, X, y, dependent_components=None):
         if dependent_components is None:

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -1,6 +1,8 @@
 import pandas as pd
+from sklearn.preprocessing import LabelEncoder as SkLabelEncoder
 
 from evalml.pipelines.components.transformers import Transformer
+from evalml.utils import _convert_woodwork_types_wrapper
 
 
 class LabelEncoder(Transformer):
@@ -12,14 +14,21 @@ class LabelEncoder(Transformer):
         super().__init__(parameters={}, component_obj=None, random_seed=random_seed)
 
     def fit(self, X, y):
-        self._encoder = LabelEncoder()
-        self._encoder.fit(y)
+        self._encoder = SkLabelEncoder()
+        y_pd = _convert_woodwork_types_wrapper(y.to_series())
+        self._encoder.fit(y_pd)
+        return self
 
     def transform(self, X, y=None):
+        y_pd = _convert_woodwork_types_wrapper(y.to_series())
         try:
-            return X, pd.Series(self._encoder.transform(y), index=y.index, name=y.name)
+            return X, pd.Series(self._encoder.transform(y_pd), index=y_pd.index, name=y.name)
         except ValueError as e:
             raise ValueError(str(e))
+
+    def fit_transform(self, X, y):
+        import pdb; pdb.set_trace()
+        return self.fit(X, y).transform(X, y)
 
 
 class LabelDecoder(Transformer):
@@ -32,6 +41,7 @@ class LabelDecoder(Transformer):
 
     def fit(self, X, y):
         """No-op"""
+        return self
 
     def transform(self, X, y=None, dependent_components=None):
         if dependent_components is None:

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -1,9 +1,13 @@
 import pandas as pd
-from sklearn.preprocessing import LabelEncoder as SkLabelEncoder
 import woodwork as ww
+from sklearn.preprocessing import LabelEncoder as SkLabelEncoder
 
 from evalml.pipelines.components.transformers import Transformer
-from evalml.utils import _convert_woodwork_types_wrapper, _retain_custom_types_and_initalize_woodwork, infer_feature_types
+from evalml.utils import (
+    _convert_woodwork_types_wrapper,
+    _retain_custom_types_and_initalize_woodwork,
+    infer_feature_types
+)
 
 
 class LabelEncoder(Transformer):

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -27,7 +27,6 @@ class LabelEncoder(Transformer):
             raise ValueError(str(e))
 
     def fit_transform(self, X, y):
-        import pdb; pdb.set_trace()
         return self.fit(X, y).transform(X, y)
 
 

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -23,7 +23,7 @@ class LabelEncoder(Transformer):
         if X is not None:
             X = infer_feature_types(X)
         if y is None:
-            return X, None
+            return self
         y_ww = infer_feature_types(y)
         self._y_logical_type = y_ww.logical_type
 

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -2,7 +2,7 @@ import pandas as pd
 from sklearn.preprocessing import LabelEncoder as SkLabelEncoder
 
 from evalml.pipelines.components.transformers import Transformer
-from evalml.utils import _convert_woodwork_types_wrapper
+from evalml.utils import _convert_woodwork_types_wrapper, _retain_custom_types_and_initalize_woodwork, infer_feature_types
 
 
 class LabelEncoder(Transformer):
@@ -14,17 +14,31 @@ class LabelEncoder(Transformer):
         super().__init__(parameters={}, component_obj=None, random_seed=random_seed)
 
     def fit(self, X, y):
+        if X is not None:
+            X = infer_feature_types(X)
+        if y is None:
+            return X, None
+        y_ww = infer_feature_types(y)
+
         self._encoder = SkLabelEncoder()
-        y_pd = _convert_woodwork_types_wrapper(y.to_series())
+        y_pd = _convert_woodwork_types_wrapper(y_ww.to_series())
         self._encoder.fit(y_pd)
         return self
 
     def transform(self, X, y=None):
-        y_pd = _convert_woodwork_types_wrapper(y.to_series())
+        if X is not None:
+            X = infer_feature_types(X)
+        if y is None:
+            return X, None
+        y_ww = infer_feature_types(y)
+
+        y_pd = _convert_woodwork_types_wrapper(y_ww.to_series())
         try:
-            return X, pd.Series(self._encoder.transform(y_pd), index=y_pd.index, name=y.name)
+            y_encoded = self._encoder.transform(y_pd)
         except ValueError as e:
             raise ValueError(str(e))
+        y_t = pd.Series(y_encoded, index=y_pd.index)
+        return X, _retain_custom_types_and_initalize_woodwork(y_ww, y_t)
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X, y)
@@ -46,8 +60,16 @@ class LabelDecoder(Transformer):
         if dependent_components is None or not len(dependent_components) or not isinstance(dependent_components[0], LabelEncoder):
             raise Exception('A reference to a previously-used label encoder component must be provided in order to decode labels.')
         label_encoder = dependent_components[0]
-        y_pd = _convert_woodwork_types_wrapper(y.to_series())
-        return X, label_encoder._encoder.inverse_transform(y_pd.astype(int))
+
+        if X is not None:
+            X = infer_feature_types(X)
+        if y is None:
+            return X, None
+        y_ww = infer_feature_types(y)
+        y_pd = _convert_woodwork_types_wrapper(y_ww.to_series())
+        y_decoded = label_encoder._encoder.inverse_transform(y_pd.astype(int))
+        y_t = pd.Series(y_decoded, index=y_pd.index)
+        return X, _retain_custom_types_and_initalize_woodwork(y_ww, y_t)
 
     def fit_transform(self, X, y, dependent_components=None):
         if dependent_components is None:

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -72,9 +72,6 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
         X_t_df = pd.DataFrame(X_t, columns=X.columns, index=X.index)
         return _retain_custom_types_and_initalize_woodwork(X_ww, X_t_df, ltypes_to_ignore=[Categorical])
 
-    def fit_transform(self, X, y):
-        return self.fit(X, y).transform(X, y)
-
     def get_feature_names(self):
         """Return feature names for the input features after fitting.
 

--- a/evalml/pipelines/pipeline_meta.py
+++ b/evalml/pipelines/pipeline_meta.py
@@ -15,16 +15,16 @@ class PipelineBaseMeta(BaseMeta):
             It raises an exception if `False` and calls and returns the wrapped method if `True`.
         """
         @wraps(method)
-        def _check_for_fit(self, X=None, objective=None):
+        def _check_for_fit(self, X=None, objective=None, **kwargs):
             klass = type(self).__name__
             if not self._is_fitted:
                 raise PipelineNotYetFittedError(f'This {klass} is not fitted yet. You must fit {klass} before calling {method.__name__}.')
             if method.__name__ == 'predict_proba':
-                return method(self, X)
+                return method(self, X, **kwargs)
             elif method.__name__ == 'predict':
-                return method(self, X, objective)
+                return method(self, X, objective, **kwargs)
             else:
-                return method(self)
+                return method(self, **kwargs)
         return _check_for_fit
 
 
@@ -37,12 +37,12 @@ class TimeSeriesPipelineBaseMeta(PipelineBaseMeta):
             It raises an exception if `False` and calls and returns the wrapped method if `True`.
         """
         @wraps(method)
-        def _check_for_fit(self, X=None, y=None, objective=None):
+        def _check_for_fit(self, X=None, y=None, objective=None, **kwargs):
             klass = type(self).__name__
             if not self._is_fitted:
                 raise PipelineNotYetFittedError(f'This {klass} is not fitted yet. You must fit {klass} before calling {method.__name__}.')
             if method.__name__ == 'predict_proba':
-                return method(self, X, y)
+                return method(self, X, y, **kwargs)
             elif method.__name__ == 'predict':
-                return method(self, X, y, objective)
+                return method(self, X, y, objective, **kwargs)
         return _check_for_fit

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -119,7 +119,7 @@ class TimeSeriesClassificationPipeline(ClassificationPipeline, metaclass=TimeSer
         predictions = _convert_woodwork_types_wrapper(predictions.to_series())
         # In case gap is 0 and this is a baseline pipeline, we drop the nans in the
         # predictions before decoding them
-        predictions = pd.Series(self._decode_targets(predictions.dropna()), name=self.input_target_name)
+        predictions = pd.Series(predictions.dropna(), name=self.input_target_name)
         padded = pad_with_nans(predictions, max(0, n_features - predictions.shape[0]))
         return infer_feature_types(padded)
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -26,6 +26,8 @@ from evalml.pipelines.components import (  # noqa: F401
     DropNullColumns,
     Estimator,
     Imputer,
+    LabelDecoder,
+    LabelEncoder,
     OneHotEncoder,
     RandomForestClassifier,
     StackedEnsembleClassifier,
@@ -38,6 +40,7 @@ from evalml.pipelines.components.utils import all_components, get_estimators
 from evalml.problem_types import (
     ProblemTypes,
     handle_problem_types,
+    is_classification,
     is_time_series
 )
 from evalml.utils import get_logger, infer_feature_types
@@ -130,6 +133,8 @@ def make_pipeline(X, y, estimator, problem_type, custom_hyperparameters=None):
         raise ValueError(f"{estimator.name} is not a valid estimator for problem type")
     preprocessing_components = _get_preprocessing_components(X, y, problem_type, estimator)
     complete_component_graph = preprocessing_components + [estimator]
+    if is_classification(problem_type):
+        complete_component_graph = ['Label Encoder'] + complete_component_graph + ['Label Decoder']
 
     if custom_hyperparameters and not isinstance(custom_hyperparameters, dict):
         raise ValueError(f"if custom_hyperparameters provided, must be dictionary. Received {type(custom_hyperparameters)}")

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -48,50 +48,6 @@ from evalml.utils import get_logger, infer_feature_types
 logger = get_logger(__file__)
 
 
-def _get_preprocessing_components(X, y, problem_type, estimator_class):
-    """Given input data, target data and an estimator class, construct a recommended preprocessing chain to be combined with the estimator and trained on the provided data.
-
-    Arguments:
-        X (ww.DataTable): The input data of shape [n_samples, n_features]
-        y (ww.DataColumn): The target data of length [n_samples]
-        problem_type (ProblemTypes or str): Problem type
-        estimator_class (class): A class which subclasses Estimator estimator for pipeline
-
-    Returns:
-        list[Transformer]: A list of applicable preprocessing components to use with the estimator
-    """
-
-    X_pd = X.to_dataframe()
-    pp_components = []
-    all_null_cols = X_pd.columns[X_pd.isnull().all()]
-    if len(all_null_cols) > 0:
-        pp_components.append(DropNullColumns)
-    input_logical_types = set(X.logical_types.values())
-    types_imputer_handles = {logical_types.Boolean, logical_types.Categorical, logical_types.Double, logical_types.Integer}
-    if len(input_logical_types.intersection(types_imputer_handles)) > 0:
-        pp_components.append(Imputer)
-
-    text_columns = list(X.select('natural_language').columns)
-    if len(text_columns) > 0:
-        pp_components.append(TextFeaturizer)
-
-    datetime_cols = X.select(["Datetime"])
-    add_datetime_featurizer = len(datetime_cols.columns) > 0
-    if add_datetime_featurizer:
-        pp_components.append(DateTimeFeaturizer)
-
-    if is_time_series(problem_type):
-        pp_components.append(DelayedFeatureTransformer)
-
-    categorical_cols = X.select('category')
-    if len(categorical_cols.columns) > 0 and estimator_class not in {CatBoostClassifier, CatBoostRegressor}:
-        pp_components.append(OneHotEncoder)
-
-    if estimator_class.model_family == ModelFamily.LINEAR_MODEL:
-        pp_components.append(StandardScaler)
-    return pp_components
-
-
 def _get_pipeline_base_class(problem_type):
     """Returns pipeline base class for problem_type"""
     if problem_type == ProblemTypes.BINARY:
@@ -127,24 +83,58 @@ def make_pipeline(X, y, estimator, problem_type, custom_hyperparameters=None):
     """
     X = infer_feature_types(X)
     y = infer_feature_types(y)
-
     problem_type = handle_problem_types(problem_type)
     if estimator not in get_estimators(problem_type):
         raise ValueError(f"{estimator.name} is not a valid estimator for problem type")
-    preprocessing_components = _get_preprocessing_components(X, y, problem_type, estimator)
-    complete_component_graph = preprocessing_components + [estimator]
+
+    graph_dict = dict()
     if is_classification(problem_type):
-        complete_component_graph = ['Label Encoder'] + complete_component_graph + ['Label Decoder']
+        graph_dict['Label Encoder'] = [LabelEncoder]
+
+    X_pd = X.to_dataframe()
+    preprocessing_components = []
+    all_null_cols = X_pd.columns[X_pd.isnull().all()]
+    if len(all_null_cols) > 0:
+        preprocessing_components.append(DropNullColumns)
+    input_logical_types = set(X.logical_types.values())
+    types_imputer_handles = {logical_types.Boolean, logical_types.Categorical, logical_types.Double, logical_types.Integer}
+    if len(input_logical_types.intersection(types_imputer_handles)) > 0:
+        preprocessing_components.append(Imputer)
+    text_columns = list(X.select('natural_language').columns)
+    if len(text_columns) > 0:
+        preprocessing_components.append(TextFeaturizer)
+    datetime_cols = X.select(["Datetime"])
+    add_datetime_featurizer = len(datetime_cols.columns) > 0
+    if add_datetime_featurizer:
+        preprocessing_components.append(DateTimeFeaturizer)
+    if is_time_series(problem_type):
+        preprocessing_components.append(DelayedFeatureTransformer)
+    categorical_cols = X.select('category')
+    if len(categorical_cols.columns) > 0 and estimator not in {CatBoostClassifier, CatBoostRegressor}:
+        preprocessing_components.append(OneHotEncoder)
+    if estimator.model_family == ModelFamily.LINEAR_MODEL:
+        preprocessing_components.append(StandardScaler)
+
+    for i, component in enumerate(preprocessing_components):
+        if i == 0:
+            inputs = []
+            if is_classification(problem_type):
+                inputs = ['Label Encoder.y']
+        else:
+            inputs = [preprocessing_components[i - 1] + '.x']
+        graph_dict[component.name] = [component] + inputs
+    graph_dict[estimator] = [estimator.name] + [component.name + '.x']
+    if is_classification(problem_type):
+        graph_dict['Label Decoder'] = [LabelDecoder, estimator.name + '.y', 'Label Encoder.state']
 
     if custom_hyperparameters and not isinstance(custom_hyperparameters, dict):
         raise ValueError(f"if custom_hyperparameters provided, must be dictionary. Received {type(custom_hyperparameters)}")
-
     hyperparameters = custom_hyperparameters
     base_class = _get_pipeline_base_class(problem_type)
 
     class GeneratedPipeline(base_class):
         custom_name = f"{estimator.name} w/ {' + '.join([component.name for component in preprocessing_components])}"
-        component_graph = complete_component_graph
+        component_graph = graph_dict
         custom_hyperparameters = hyperparameters
 
     return GeneratedPipeline

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -36,6 +36,8 @@ from evalml.pipelines.components import (
     ExtraTreesClassifier,
     ExtraTreesRegressor,
     Imputer,
+    LabelDecoder,
+    LabelEncoder,
     LightGBMClassifier,
     LightGBMRegressor,
     LinearDiscriminantAnalysis,
@@ -522,8 +524,9 @@ def test_transformer_transform_output_type(X_y_binary):
                        (X_df_no_col_names, y_series_no_name, range_index),
                        (X_df_with_col_names, y_series_with_name, X_df_with_col_names.columns)]
 
+    components_which_transform_y = (TargetImputer, LabelEncoder, LabelDecoder)
     for component_class in _all_transformers():
-        if component_class == PolynomialDetrender:
+        if component_class in [PolynomialDetrender]:
             # Skipping because this test is handled in test_polynomial_detrender
             continue
         print('Testing transformer {}'.format(component_class.name))
@@ -534,10 +537,14 @@ def test_transformer_transform_output_type(X_y_binary):
                           y.name if isinstance(y, pd.Series) else None))
 
             component = component_class()
-
             component.fit(X, y=y)
-            transform_output = component.transform(X, y=y)
-            if isinstance(component, TargetImputer) or 'sampler' in component.name:
+            kwargs = dict()
+            if isinstance(component, (LabelDecoder)):
+                label_encoder = LabelEncoder()
+                label_encoder.fit(X, y=y)
+                kwargs['dependent_components'] = [label_encoder]
+            transform_output = component.transform(X, y=y, **kwargs)
+            if isinstance(component, components_which_transform_y) or 'sampler' in component.name:
                 assert isinstance(transform_output[0], ww.DataTable)
                 assert isinstance(transform_output[1], ww.DataColumn)
             else:
@@ -555,7 +562,7 @@ def test_transformer_transform_output_type(X_y_binary):
                 # We just want to check that DelayedFeaturesTransformer outputs a DataFrame
                 # The dataframe shape and index are checked in test_delayed_features_transformer.py
                 continue
-            elif isinstance(component, TargetImputer):
+            elif isinstance(component, components_which_transform_y):
                 assert transform_output[0].shape == X.shape
                 assert transform_output[1].shape[0] == X.shape[0]
                 assert len(transform_output[1].shape) == 1
@@ -566,8 +573,8 @@ def test_transformer_transform_output_type(X_y_binary):
                 assert transform_output.shape == X.shape
                 assert (list(transform_output.columns) == list(X_cols_expected))
 
-            transform_output = component.fit_transform(X, y=y)
-            if isinstance(component, TargetImputer) or 'sampler' in component.name:
+            transform_output = component.fit_transform(X, y=y, **kwargs)
+            if isinstance(component, components_which_transform_y) or 'sampler' in component.name:
                 assert isinstance(transform_output[0], ww.DataTable)
                 assert isinstance(transform_output[1], ww.DataColumn)
             else:
@@ -581,7 +588,7 @@ def test_transformer_transform_output_type(X_y_binary):
             elif isinstance(component, DFSTransformer):
                 assert transform_output.shape[0] == X.shape[0]
                 assert transform_output.shape[1] >= X.shape[1]
-            elif isinstance(component, TargetImputer):
+            elif isinstance(component, components_which_transform_y):
                 assert transform_output[0].shape == X.shape
                 assert transform_output[1].shape[0] == X.shape[0]
                 assert len(transform_output[1].shape) == 1
@@ -731,12 +738,17 @@ def test_all_transformers_check_fit(X_y_binary):
         with pytest.raises(ComponentNotYetFittedError, match=f'You must fit {component_class.__name__}'):
             component.transform(X, y)
 
+        kwargs = dict()
+        if isinstance(component, (LabelDecoder)):
+            label_encoder = LabelEncoder()
+            label_encoder.fit(X, y=y)
+            kwargs['dependent_components'] = [label_encoder]
         component.fit(X, y)
-        component.transform(X, y)
+        component.transform(X, y, **kwargs)
 
         component = component_class()
-        component.fit_transform(X, y)
-        component.transform(X, y)
+        component.fit_transform(X, y, **kwargs)
+        component.transform(X, y, **kwargs)
 
 
 def test_all_estimators_check_fit(X_y_binary, ts_data, test_estimator_needs_fitting_false, helper_functions):
@@ -1086,18 +1098,24 @@ def test_transformer_fit_and_transform_respect_custom_indices(use_custom_index, 
     X_original_index = X.index.copy()
     y_original_index = y.index.copy()
 
+    kwargs = dict()
+    if transformer_class == LabelDecoder:
+        label_encoder = LabelEncoder()
+        label_encoder.fit(X, y=y)
+        kwargs['dependent_components'] = [label_encoder]
+
     transformer = transformer_class()
 
     transformer.fit(X, y)
     pd.testing.assert_index_equal(X.index, X_original_index)
     pd.testing.assert_index_equal(y.index, y_original_index)
 
-    if 'sampler' in transformer.name or transformer_class == TargetImputer:
-        X_t, y_t = transformer.transform(X, y)
+    if 'sampler' in transformer.name or transformer_class in [TargetImputer, LabelEncoder, LabelDecoder]:
+        X_t, y_t = transformer.transform(X, y, **kwargs)
         X_t = X_t.to_dataframe()
         pd.testing.assert_index_equal(y_t.to_series().index, y_original_index, check_names=check_names)
     else:
-        X_t = transformer.transform(X, y).to_dataframe()
+        X_t = transformer.transform(X, y, **kwargs).to_dataframe()
         pd.testing.assert_index_equal(y.index, y_original_index, check_names=check_names)
     pd.testing.assert_index_equal(X_t.index, X_original_index, check_names=check_names)
 

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -18,9 +18,9 @@ from evalml.problem_types import ProblemTypes
 
 def test_all_components(has_minimal_dependencies, is_running_py_39_or_above):
     if has_minimal_dependencies:
-        assert len(all_components()) == 37
+        assert len(all_components()) == 39
     else:
-        n_components = 45 if is_running_py_39_or_above else 46
+        n_components = 47 if is_running_py_39_or_above else 48
         assert len(all_components()) == n_components
 
 

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -17,8 +17,6 @@ from evalml.pipelines.components import (
     ElasticNetClassifier,
     Estimator,
     Imputer,
-    LabelEncoder,
-    LabelDecoder,
     LogisticRegressionClassifier,
     OneHotEncoder,
     RandomForestClassifier,
@@ -574,8 +572,11 @@ def test_predict_transformer_end(mock_fit_transform, mock_transform, X_y_binary)
     mock_transform.return_value = tuple((pd.DataFrame(X), pd.Series(y)))
 
     component_graph.fit(X, y)
-    output = component_graph.predict(X)
-    assert_frame_equal(pd.DataFrame(X), output.to_dataframe())
+    X_out, y_out = component_graph.transform(X)
+    assert_frame_equal(pd.DataFrame(X), X_out.to_dataframe())
+    assert_series_equal(pd.Series(y, dtype='Int64'), y_out.to_series())
+    y_out = component_graph.predict(X)
+    assert_series_equal(pd.Series(y, dtype='Int64'), y_out.to_series())
 
 
 def test_no_instantiate_before_fit(X_y_binary):

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -17,6 +17,8 @@ from evalml.pipelines.components import (
     ElasticNetClassifier,
     Estimator,
     Imputer,
+    LabelEncoder,
+    LabelDecoder,
     LogisticRegressionClassifier,
     OneHotEncoder,
     RandomForestClassifier,
@@ -88,6 +90,27 @@ def example_graph():
              'Elastic Net': [ElasticNetClassifier, 'OneHot_ElasticNet.x'],
              'Logistic Regression': [LogisticRegressionClassifier, 'Random Forest', 'Elastic Net']}
     return graph
+
+
+def test_label_encoder_pass_state():
+    np.random.seed(13117)
+    # n_rows, n_cols
+    shape = (10, 3)
+    X = pd.DataFrame(np.random.randint(0, 10, shape))
+
+    # string target
+    repeat_factor = 2.0
+    y = pd.Series(np.arange(shape[0] / repeat_factor, dtype=int).repeat(repeat_factor))
+    alpha = "abcdefghijklmnopqrstuvwxyz"
+    y = y.apply(lambda x: alpha[x % len(alpha)])
+
+    cg = ComponentGraph(component_dict={
+        'label_encoder_0': ['Label Encoder'],
+        'rf': ['Random Forest Classifier', 'label_encoder_0.y'],
+        'label_decoder_0': ['Label Decoder', 'rf.y', 'label_encoder_0.state']
+    })
+    cg.instantiate({})
+    cg.fit(X, y)
 
 
 def test_init(example_graph):

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -718,9 +718,9 @@ def test_iteration(example_graph):
 
 
 def test_custom_input_feature_types(example_graph):
-    X = pd.DataFrame({'column_1': ['a', 'b', 'c', 'd', 'a', 'a', 'b', 'c', 'b'],
-                      'column_2': [1, 2, 3, 4, 5, 6, 5, 4, 3]})
-    y = pd.Series([1, 0, 1, 0, 1, 1, 0, 0, 0])
+    X = pd.DataFrame({'column_1': ['a', 'b', 'b', 'c', 'c', 'c', 'd', 'd', 'd', 'd'],
+                      'column_2': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]})
+    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
     X = infer_feature_types(X, {"column_2": "categorical"})
 
     component_graph = ComponentGraph(example_graph)
@@ -733,8 +733,8 @@ def test_custom_input_feature_types(example_graph):
     assert input_feature_names['Imputer'] == ['column_1', 'column_2']
     assert input_feature_names['OneHot_RandomForest'] == ['column_1', 'column_2']
     assert input_feature_names['OneHot_ElasticNet'] == ['column_1', 'column_2']
-    assert input_feature_names['Random Forest'] == ['column_1_a', 'column_1_b', 'column_2_4', 'column_2_5']
-    assert input_feature_names['Elastic Net'] == ['column_1_a', 'column_1_b', 'column_1_c', 'column_2_3', 'column_2_4', 'column_2_5']
+    assert input_feature_names['Random Forest'] == ['column_1_c', 'column_1_d', 'column_2_3', 'column_2_4']
+    assert input_feature_names['Elastic Net'] == ['column_1_b', 'column_1_c', 'column_1_d', 'column_2_2', 'column_2_3', 'column_2_4']
     assert input_feature_names['Logistic Regression'] == ['Random Forest', 'Elastic Net']
 
 

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -103,6 +103,7 @@ def label_encoder_data_str():
     y = y.apply(lambda x: alpha[x % len(alpha)])
     return X, y
 
+
 @pytest.mark.parametrize("dtype", ['pd', 'ww'])
 def test_label_encoder_pass_state(dtype, label_encoder_data_str):
     X, y = label_encoder_data_str

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -522,47 +522,39 @@ def test_score_nonlinear_regression(mock_predict, mock_fit, nonlinear_regression
     assert scores == {'R2': 1.0}
 
 
-@patch('evalml.pipelines.BinaryClassificationPipeline._encode_targets')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_binary_single(mock_predict, mock_fit, mock_encode, X_y_binary):
+def test_score_binary_single(mock_predict, mock_fit, X_y_binary):
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_binary_pipeline()
     clf.fit(X, y)
     objective_names = ['f1']
     scores = clf.score(X, y, objective_names)
-    mock_encode.assert_called()
     mock_fit.assert_called()
     mock_predict.assert_called()
     assert scores == {'F1': 1.0}
 
 
-@patch('evalml.pipelines.MulticlassClassificationPipeline._encode_targets')
 @patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_multiclass_single(mock_predict, mock_fit, mock_encode, X_y_binary):
+def test_score_multiclass_single(mock_predict, mock_fit, X_y_binary):
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_multiclass_pipeline()
     clf.fit(X, y)
     objective_names = ['f1 micro']
     scores = clf.score(X, y, objective_names)
-    mock_encode.assert_called()
     mock_fit.assert_called()
     mock_predict.assert_called()
     assert scores == {'F1 Micro': 1.0}
 
 
-@patch('evalml.pipelines.MulticlassClassificationPipeline._encode_targets')
 @patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
 @patch('evalml.pipelines.ComponentGraph.predict')
-def test_score_nonlinear_multiclass(mock_predict, mock_fit, mock_encode, nonlinear_multiclass_pipeline_class, X_y_multi):
+def test_score_nonlinear_multiclass(mock_predict, mock_fit, nonlinear_multiclass_pipeline_class, X_y_multi):
     X, y = X_y_multi
     mock_predict.return_value = ww.DataColumn(y)
-    mock_encode.return_value = y
     clf = nonlinear_multiclass_pipeline_class({})
     clf.fit(X, y)
     objective_names = ['f1 micro', 'precision micro']
@@ -584,30 +576,25 @@ def test_score_regression_list(mock_predict, mock_fit, X_y_binary):
     assert scores == {'R2': 1.0, 'MSE': 0.0}
 
 
-@patch('evalml.pipelines.BinaryClassificationPipeline._encode_targets')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_binary_list(mock_predict, mock_fit, mock_encode, X_y_binary):
+def test_score_binary_list(mock_predict, mock_fit, X_y_binary):
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_binary_pipeline()
     clf.fit(X, y)
     objective_names = ['f1', 'precision']
     scores = clf.score(X, y, objective_names)
     mock_fit.assert_called()
-    mock_encode.assert_called()
     mock_predict.assert_called()
     assert scores == {'F1': 1.0, 'Precision': 1.0}
 
 
-@patch('evalml.pipelines.MulticlassClassificationPipeline._encode_targets')
 @patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_multi_list(mock_predict, mock_fit, mock_encode, X_y_binary):
+def test_score_multi_list(mock_predict, mock_fit, X_y_binary):
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_multiclass_pipeline()
     clf.fit(X, y)
     objective_names = ['f1 micro', 'precision micro']
@@ -637,15 +624,13 @@ def test_score_regression_objective_error(mock_predict, mock_fit, mock_objective
         assert "R2" in e.exceptions
 
 
-@patch('evalml.pipelines.BinaryClassificationPipeline._encode_targets')
 @patch('evalml.objectives.F1.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_binary_objective_error(mock_predict, mock_fit, mock_objective_score, mock_encode, X_y_binary):
+def test_score_binary_objective_error(mock_predict, mock_fit, mock_objective_score, X_y_binary):
     mock_objective_score.side_effect = Exception('finna kabooom 💣')
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_binary_pipeline()
     clf.fit(X, y)
     objective_names = ['f1', 'precision']
@@ -659,15 +644,13 @@ def test_score_binary_objective_error(mock_predict, mock_fit, mock_objective_sco
         assert 'finna kabooom 💣' in e.message
 
 
-@patch('evalml.pipelines.BinaryClassificationPipeline._encode_targets')
 @patch('evalml.objectives.F1.score')
 @patch('evalml.pipelines.BinaryClassificationPipeline.fit')
 @patch('evalml.pipelines.ComponentGraph.predict')
-def test_score_nonlinear_binary_objective_error(mock_predict, mock_fit, mock_objective_score, mock_encode, nonlinear_binary_pipeline_class, X_y_binary):
+def test_score_nonlinear_binary_objective_error(mock_predict, mock_fit, mock_objective_score, nonlinear_binary_pipeline_class, X_y_binary):
     mock_objective_score.side_effect = Exception('finna kabooom 💣')
     X, y = X_y_binary
     mock_predict.return_value = ww.DataColumn(y)
-    mock_encode.return_value = y
     clf = nonlinear_binary_pipeline_class({})
     clf.fit(X, y)
     objective_names = ['f1', 'precision']
@@ -681,15 +664,13 @@ def test_score_nonlinear_binary_objective_error(mock_predict, mock_fit, mock_obj
         assert 'finna kabooom 💣' in e.message
 
 
-@patch('evalml.pipelines.MulticlassClassificationPipeline._encode_targets')
 @patch('evalml.objectives.F1Micro.score')
 @patch('evalml.pipelines.MulticlassClassificationPipeline.fit')
 @patch('evalml.pipelines.components.Estimator.predict')
-def test_score_multiclass_objective_error(mock_predict, mock_fit, mock_objective_score, mock_encode, X_y_binary):
+def test_score_multiclass_objective_error(mock_predict, mock_fit, mock_objective_score, X_y_binary):
     mock_objective_score.side_effect = Exception('finna kabooom 💣')
     X, y = X_y_binary
     mock_predict.return_value = y
-    mock_encode.return_value = y
     clf = make_mock_multiclass_pipeline()
     clf.fit(X, y)
     objective_names = ['f1 micro', 'precision micro']

--- a/evalml/utils/base_meta.py
+++ b/evalml/utils/base_meta.py
@@ -14,8 +14,8 @@ class BaseMeta(ABCMeta):
     @classmethod
     def set_fit(cls, method):
         @wraps(method)
-        def _set_fit(self, X, y=None):
-            return_value = method(self, X, y)
+        def _set_fit(self, X, y=None, **kwargs):
+            return_value = method(self, X, y, **kwargs)
             self._is_fitted = True
             return return_value
         return _set_fit


### PR DESCRIPTION
Fix #2103 #1576 #1962 

Relates to #2046 #712 . I think this also clears the way for #2059 (target imputer) but we should leave that open as separate verification.

Changes:
* Update component graph to support passing state between components, specified using ".state" suffix in graph input
* Move label encoding out of `ClassificationPipeline` into two components, `LabelEncoder` and `LabelDecoder`, which are connected during evaluation.
* Update automl (`make_pipelines`) to include these components in classification pipelines by default.
* Simplified component graph evaluation logic, with some changes in behavior
* Add component graph `transform` method and simplify `predict` to only return final estimator predictions

---
Demo
```python
import evalml
import pandas as pd
import numpy as np

np.random.seed(13117)
# n_rows, n_cols
shape = (10, 3)
X = pd.DataFrame(np.random.randint(0, 10, shape))

# string target
repeat_factor = 2.0
y = pd.Series(np.arange(shape[0] / repeat_factor, dtype=int).repeat(repeat_factor))
alpha = "abcdefghijklmnopqrstuvwxyz"
y = y.apply(lambda x: alpha[x % len(alpha)])

cg = evalml.pipelines.ComponentGraph(component_dict={
    'label_encoder_0': ['Label Encoder'],
    'rf': ['Random Forest Classifier', 'label_encoder_0.y'],
    'label_decoder_0': ['Label Decoder', 'rf.y', 'label_encoder_0.state']
})
cg.instantiate({})
cg.fit(X, y)
print(cg.predict(X).to_series())
assert (cg.predict(X).to_series().unique() == ['a', 'b', 'c', 'd', 'e']).all()
```