### PR TITLE
Rename `TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS` to `TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
         * Fixed ``BalancedClassificationDataCVSplit``, ``BalancedClassificationDataTVSplit``, and ``BalancedClassificationSampler`` to use ``minority:majority`` ratio instead of ``majority:minority`` :pr:`2077`
     * Changes
         * Removed ``hyperparameter_ranges`` from Undersampler and renamed ``balanced_ratio`` to ``sampling_ratio`` for samplers :pr:`2113`
+        * Renamed ``TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS`` data check message code to ``TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS`` :pr:`2126`
     * Documentation Changes
         * Fixed ``conf.py`` file :pr:`2112`
         * Added a sentence to the automl user guide stating that our support for time series problems is still in beta. :pr:`2118`

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -31,7 +31,7 @@ class DataCheckMessageCode(Enum):
     TARGET_BINARY_INVALID_VALUES = "target_binary_invalid_values"
     """Message code for target data for a binary classification problem with numerical values not equal to {0, 1}."""
 
-    TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS = "target_multiclass_not_two_examples_per_class"
+    TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS = "target_multiclass_not_two_examples_per_class"
     """Message code for target data for a multi classification problem that does not have two examples per class."""
 
     TARGET_MULTICLASS_NOT_ENOUGH_CLASSES = "target_multiclass_not_enough_classes"

--- a/evalml/data_checks/invalid_targets_data_check.py
+++ b/evalml/data_checks/invalid_targets_data_check.py
@@ -132,7 +132,7 @@ class InvalidTargetDataCheck(DataCheck):
                 details = {"least_populated_class_labels": least_populated.index.tolist()}
                 results["errors"].append(DataCheckError(message="Target does not have at least two instances per class which is required for multiclass classification",
                                                         data_check_name=self.name,
-                                                        message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
+                                                        message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS,
                                                         details=details).to_dict())
             if len(unique_values) <= 2:
                 details = {"num_classes": len(unique_values)}

--- a/evalml/tests/data_checks_tests/test_data_checks.py
+++ b/evalml/tests/data_checks_tests/test_data_checks.py
@@ -150,7 +150,7 @@ def test_default_data_checks_classification(input_type):
                                 details={"target_values": [0.0, 2.0, 1.0]}).to_dict()]
     min_2_class_count = [DataCheckError(message="Target does not have at least two instances per class which is required for multiclass classification",
                                         data_check_name="InvalidTargetDataCheck",
-                                        message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
+                                        message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS,
                                         details={"least_populated_class_labels": [2.0, 1.0]}).to_dict()]
     high_class_to_sample_ratio = [DataCheckWarning(
         message="Target has a large number of unique values, could be regression type problem.",

--- a/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
+++ b/evalml/tests/data_checks_tests/test_invalid_targets_data_check.py
@@ -67,7 +67,7 @@ def test_invalid_target_data_check_multiclass_two_examples_per_class():
         "warnings": [],
         "errors": [DataCheckError(message=expected_message,
                                   data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
+                                  message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS,
                                   details={"least_populated_class_labels": [0]}).to_dict()],
         "actions": []
     }
@@ -79,7 +79,7 @@ def test_invalid_target_data_check_multiclass_two_examples_per_class():
         "warnings": [],
         "errors": [DataCheckError(message=expected_message,
                                   data_check_name=invalid_targets_data_check_name,
-                                  message_code=DataCheckMessageCode.TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS,
+                                  message_code=DataCheckMessageCode.TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS,
                                   details={"least_populated_class_labels": [0, 1]}).to_dict()],
         "actions": []
     }


### PR DESCRIPTION
Closes #2052. This PR confirms that `TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS` actually refers to the multiclass case where there are not at least two examples per class, and thus it makes sense to rename the code to `TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS`.