### PR TITLE
Fix `test_describe_pipeline` for pandas 1.2.4

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Fixes
         * Fixed ``BalancedClassificationDataCVSplit``, ``BalancedClassificationDataTVSplit``, and ``BalancedClassificationSampler`` to use ``minority:majority`` ratio instead of ``majority:minority`` :pr:`2077`
         * Fixed bug where two-way partial dependence plots with categorical variables were not working correctly :pr:`2117`
+
     * Changes
         * Removed ``hyperparameter_ranges`` from Undersampler and renamed ``balanced_ratio`` to ``sampling_ratio`` for samplers :pr:`2113`
         * Modified one-way partial dependence plots of categorical features to display data with a bar plot :pr:`2117`
@@ -15,6 +16,8 @@ Release Notes
         * Fixed ``conf.py`` file :pr:`2112`
         * Added a sentence to the automl user guide stating that our support for time series problems is still in beta. :pr:`2118`
     * Testing Changes
+        * Fixed ``test_describe_pipeline`` for ``pandas`` ``v1.2.4`` :pr:`2129`
+
 
 .. warning::
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -794,7 +794,7 @@ class AutoMLSearch:
 
         for c in all_objective_scores:
             if c in ["# Training", "# Validation"]:
-                all_objective_scores[c] = all_objective_scores[c].astype("object")
+                all_objective_scores[c] = all_objective_scores[c].map(lambda x: '{:2,.0f}'.format(x) if not pd.isna(x) else np.nan)
                 continue
 
             mean = all_objective_scores[c].mean(axis=0)

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -930,9 +930,9 @@ def test_describe_pipeline(mock_fit, mock_score, return_dict, caplog, X_y_binary
     assert "* strategy : mode" in out
     assert "Total training time (including CV): " in out
     assert "Log Loss Binary # Training # Validation" in out
-    assert "0                      1.000       66.0         34.0" in out
-    assert "1                      1.000       67.0         33.0" in out
-    assert "2                      1.000       67.0         33.0" in out
+    assert "0                      1.000     66.000       34.000" in out
+    assert "1                      1.000     67.000       33.000" in out
+    assert "2                      1.000     67.000       33.000" in out
     assert "mean                   1.000          -            -" in out
     assert "std                    0.000          -            -" in out
     assert "coef of var            0.000          -            -" in out

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -930,9 +930,9 @@ def test_describe_pipeline(mock_fit, mock_score, return_dict, caplog, X_y_binary
     assert "* strategy : mode" in out
     assert "Total training time (including CV): " in out
     assert "Log Loss Binary # Training # Validation" in out
-    assert "0                      1.000     66.000       34.000" in out
-    assert "1                      1.000     67.000       33.000" in out
-    assert "2                      1.000     67.000       33.000" in out
+    assert "0                      1.000         66           34" in out
+    assert "1                      1.000         67           33" in out
+    assert "2                      1.000         67           33" in out
     assert "mean                   1.000          -            -" in out
     assert "std                    0.000          -            -" in out
     assert "coef of var            0.000          -            -" in out

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -13,7 +13,7 @@ matplotlib==3.4.1
 networkx==2.5.1
 nlp-primitives==1.1.0
 numpy==1.20.2
-pandas==1.2.3
+pandas==1.2.4
 plotly==4.14.3
 psutil==5.8.0
 pyzmq==21.0.2


### PR DESCRIPTION
Fixes test for latest dependency bot. Apparently each time the PR is created, it wipes any other changes so I needed to open my own PR 😬 

Pandas' update to 1.2.4 broke test_describe_pipeline tests. I believe this is because of the way that pandas treats object columns with float precision via https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.2.4.html. We call logger.info on the pandas DataFrame, which calls to_string. I've updated this PR to update our test to conform to pandas 1.2.4 since this is simply a difference in printing/logging, but it's worth updating test_describe_pipeline to be tolerant to such changes with pandas behavior in the future (could look into setting some pandas options hardcoded on our end). Unfortunately, this doesn't work here since the float config has also changed here :d