### PR TITLE
Fix AutoMLSearch so users can specify custom hyperparameters to pipelines with duplicate components

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,9 @@ Release Notes
     * Fixes
         * Fixed ``BalancedClassificationDataCVSplit``, ``BalancedClassificationDataTVSplit``, and ``BalancedClassificationSampler`` to use ``minority:majority`` ratio instead of ``majority:minority`` :pr:`2077`
         * Fixed bug where two-way partial dependence plots with categorical variables were not working correctly :pr:`2117`
+        * Fixed bug where ``hyperparameters`` were not displaying properly for pipelines with a list ``component_graph`` and duplicate components :pr:`2133`
+        * Fixed bug where ``pipeline_parameters`` argument in ``AutoMLSearch`` was not applied to pipelines passed in as ``allowed_pipelines`` :pr:`2133`
+        * Fixed bug where ``AutoMLSearch`` was not applying custom hyperparameters to pipelines with a list ``component_graph`` and duplicate components :pr:`2133`
     * Changes
         * Removed ``hyperparameter_ranges`` from Undersampler and renamed ``balanced_ratio`` to ``sampling_ratio`` for samplers :pr:`2113`
         * Renamed ``TARGET_BINARY_NOT_TWO_EXAMPLES_PER_CLASS`` data check message code to ``TARGET_MULTICLASS_NOT_TWO_EXAMPLES_PER_CLASS`` :pr:`2126`

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -7,7 +7,6 @@ from skopt.space import Categorical, Integer, Real
 from .automl_algorithm import AutoMLAlgorithm, AutoMLAlgorithmException
 
 from evalml.model_family import ModelFamily
-from evalml.pipelines.components.utils import handle_component_class
 from evalml.pipelines.utils import _make_stacked_ensemble_pipeline
 
 

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -127,9 +127,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         parameters = {}
         if 'pipeline' in self._pipeline_params:
             parameters['pipeline'] = self._pipeline_params['pipeline']
-        component_graph = [handle_component_class(c) for c in pipeline_class.linearized_component_graph]
-        for component_class in component_graph:
-            component_parameters = proposed_parameters.get(component_class.name, {})
+        for name, component_class in pipeline_class.linearized_component_graph:
+            component_parameters = proposed_parameters.get(name, {})
             init_params = inspect.signature(component_class.__init__).parameters
 
             # Inspects each component and adds the following parameters when needed
@@ -138,8 +137,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
             if 'number_features' in init_params:
                 component_parameters['number_features'] = self.number_features
             # For first batch, pass the pipeline params to the components that need them
-            if component_class.name in self._pipeline_params and self._batch_number == 0:
-                for param_name, value in self._pipeline_params[component_class.name].items():
+            if name in self._pipeline_params and self._batch_number == 0:
+                for param_name, value in self._pipeline_params[name].items():
                     if isinstance(value, (Integer, Real)):
                         # get a random value in the space
                         component_parameters[param_name] = value.rvs(random_state=self.random_seed)[0]
@@ -151,5 +150,6 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                 for param_name, value in self._pipeline_params['pipeline'].items():
                     if param_name in init_params:
                         component_parameters[param_name] = value
-            parameters[component_class.name] = component_parameters
+            breakpoint()
+            parameters[name] = component_parameters
         return parameters

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -150,6 +150,5 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                 for param_name, value in self._pipeline_params['pipeline'].items():
                     if param_name in init_params:
                         component_parameters[param_name] = value
-            breakpoint()
             parameters[name] = component_parameters
         return parameters

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -298,7 +298,11 @@ class AutoMLSearch:
         else:
             for pipeline_class in self.allowed_pipelines:
                 if self.pipeline_parameters:
-                    pipeline_class.custom_hyperparameters = self.pipeline_parameters
+                    if pipeline_class.custom_hyperparameters:
+                        for component_name, params in self.pipeline_parameters.items():
+                            pipeline_class.custom_hyperparameters[component_name] = params
+                    else:
+                        pipeline_class.custom_hyperparameters = self.pipeline_parameters
 
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -291,7 +291,8 @@ class AutoMLSearch:
             self.allowed_pipelines = [make_pipeline(self.X_train, self.y_train, estimator, self.problem_type, custom_hyperparameters=self.pipeline_parameters) for estimator in allowed_estimators]
         else:
             for pipeline_class in self.allowed_pipelines:
-                pipeline_class.custom_hyperparameters = self.pipeline_parameters
+                if self.pipeline_parameters:
+                    pipeline_class.custom_hyperparameters = self.pipeline_parameters
 
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import sys
 import time
 import traceback
@@ -37,6 +38,7 @@ from evalml.pipelines import (
     MeanBaselineRegressionPipeline,
     ModeBaselineBinaryPipeline,
     ModeBaselineMulticlassPipeline,
+    PipelineBase,
     TimeSeriesBaselineBinaryPipeline,
     TimeSeriesBaselineMulticlassPipeline,
     TimeSeriesBaselineRegressionPipeline
@@ -260,6 +262,10 @@ class AutoMLSearch:
         except ImportError:
             logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
 
+        if allowed_pipelines is not None and not isinstance(allowed_pipelines, list):
+            raise ValueError("Parameter allowed_pipelines must be either None or a list!")
+        if allowed_pipelines is not None and not all(inspect.isclass(p) and issubclass(p, PipelineBase) for p in allowed_pipelines):
+            raise ValueError("Every element of allowed_pipelines must be a subclass of PipelineBase!")
         self.allowed_pipelines = allowed_pipelines
         self.allowed_model_families = allowed_model_families
         self._automl_algorithm = None

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -289,6 +289,9 @@ class AutoMLSearch:
             allowed_estimators = get_estimators(self.problem_type, self.allowed_model_families)
             logger.debug(f"allowed_estimators set to {[estimator.name for estimator in allowed_estimators]}")
             self.allowed_pipelines = [make_pipeline(self.X_train, self.y_train, estimator, self.problem_type, custom_hyperparameters=self.pipeline_parameters) for estimator in allowed_estimators]
+        else:
+            for pipeline_class in self.allowed_pipelines:
+                pipeline_class.custom_hyperparameters = self.pipeline_parameters
 
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -36,6 +36,26 @@ class ComponentGraph:
         self._i = 0
 
     @classmethod
+    def linearized_component_graph(cls, components):
+        """Return a list of (component name, component class) tuples from a pre-initialized component graph defined
+        as either a list or a dictionary. The component names are guaranteed to be unique."""
+        names = []
+        if isinstance(components, list):
+            seen = set()
+            for idx, component in enumerate(components):
+                component_class = handle_component_class(component)
+                component_name = component_class.name
+
+                if component_name in seen:
+                    component_name = f'{component_name}_{idx}'
+                seen.add(component_name)
+                names.append((component_name, component_class))
+        else:
+            for k, v in components.items():
+                names.append((k, handle_component_class(v[0])))
+        return names
+
+    @classmethod
     def from_list(cls, component_list, random_seed=0):
         """Constructs a linear ComponentGraph from a given list, where each component in the list feeds its X transformed output to the next component
 
@@ -45,12 +65,7 @@ class ComponentGraph:
         """
         component_dict = {}
         previous_component = None
-        for idx, component in enumerate(component_list):
-            component_class = handle_component_class(component)
-            component_name = component_class.name
-
-            if component_name in component_dict.keys():
-                component_name = f'{component_name}_{idx}'
+        for component_name, component_class in cls.linearized_component_graph(component_list):
 
             component_dict[component_name] = [component_class]
             if previous_component is not None:

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -38,7 +38,16 @@ class ComponentGraph:
     @classmethod
     def linearized_component_graph(cls, components):
         """Return a list of (component name, component class) tuples from a pre-initialized component graph defined
-        as either a list or a dictionary. The component names are guaranteed to be unique."""
+        as either a list or a dictionary. The component names are guaranteed to be unique.
+
+        Args:
+            components (list(ComponentBase) or Dict[str, ComponentBase]): Components in the pipeline.
+
+        Returns:
+            list((component name, ComponentBase)) - tuples with the unique component name as the first element and the
+                component class as the second element. When the input is a list, the components will be returned in
+                the order they appear in the input.
+        """
         names = []
         if isinstance(components, list):
             seen = set()

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -53,7 +53,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         """Returns list or dictionary of components representing pipeline graph structure
 
         Returns:
-            list(str / ComponentBase subclass): List of ComponentBase subclasses or strings denotes graph structure of this pipeline
+            list(str / ComponentBase subclass): List of ComponentBase subclasses or strings denotes graph structure of this pipeline.
         """
 
     custom_hyperparameters = None
@@ -64,7 +64,11 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         """Machine learning pipeline made out of transformers and a estimator.
 
         Required Class Variables:
-            component_graph (list): List of components in order. Accepts strings or ComponentBase subclasses in the list
+            component_graph (list or dict): List of components in order. Accepts strings or ComponentBase subclasses in the list.
+                Note that when duplicate components are specified in a list, the duplicate component names will be modified with the
+                component's index in the list. For example, the component graph
+                [Imputer, One Hot Encoder, Imputer, Logistic Regression Classifier] will have names
+                ["Imputer", "One Hot Encoder", "Imputer_2", "Logistic Regression Classifier"]
 
         Arguments:
             parameters (dict): Dictionary with component names as keys and dictionary of that component's parameters as values.
@@ -309,8 +313,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
     def hyperparameters(cls):
         """Returns hyperparameter ranges from all components as a dictionary"""
         hyperparameter_ranges = dict()
-        component_graph = copy.copy(cls.component_graph)
-        for component_name, component_class in ComponentGraph.linearized_component_graph(component_graph):
+        for component_name, component_class in cls.linearized_component_graph:
             component_hyperparameters = copy.copy(component_class.hyperparameter_ranges)
             if cls.custom_hyperparameters and component_name in cls.custom_hyperparameters:
                 component_hyperparameters.update(cls.custom_hyperparameters.get(component_name, {}))

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -108,7 +108,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         """Returns a short summary of the pipeline structure, describing the list of components used.
         Example: Logistic Regression Classifier w/ Simple Imputer + One Hot Encoder
         """
-        component_graph = [handle_component_class(component_class) for component_class in copy.copy(cls.linearized_component_graph)]
+        component_graph = [handle_component_class(component_class) for _, component_class in copy.copy(cls.linearized_component_graph)]
         if len(component_graph) == 0:
             return "Empty Pipeline"
         summary = "Pipeline"
@@ -126,9 +126,9 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
     def linearized_component_graph(cls):
         """Returns a component graph in list form. Note: this is not guaranteed to be in proper component computation order"""
         if isinstance(cls.component_graph, list):
-            return cls.component_graph
+            return [(handle_component_class(c).name, handle_component_class(c)) for c in cls.component_graph]
         else:
-            return [component_info[0] for component_info in cls.component_graph.values()]
+            return [(k, handle_component_class(v[0])) for k, v in cls.component_graph.items()]
 
     def _validate_estimator_problem_type(self):
         """Validates this pipeline's problem_type against that of the estimator from `self.component_graph`"""

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -137,6 +137,7 @@ def make_pipeline(X, y, estimator, problem_type, custom_hyperparameters=None):
     hyperparameters = custom_hyperparameters
     base_class = _get_pipeline_base_class(problem_type)
 
+    breakpoint()
     class GeneratedPipeline(base_class):
         custom_name = f"{estimator.name} w/ {' + '.join([component.name for component in preprocessing_components])}"
         component_graph = complete_component_graph

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -137,7 +137,6 @@ def make_pipeline(X, y, estimator, problem_type, custom_hyperparameters=None):
     hyperparameters = custom_hyperparameters
     base_class = _get_pipeline_base_class(problem_type)
 
-    breakpoint()
     class GeneratedPipeline(base_class):
         custom_name = f"{estimator.name} w/ {' + '.join([component.name for component in preprocessing_components])}"
         component_graph = complete_component_graph

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -964,6 +964,26 @@ def test_hyperparameters_none(dummy_classifier_estimator_class):
     assert MockPipelineNone(parameters={}).hyperparameters == {'Mock Classifier': {}}
 
 
+def test_hyperparameters_linear_pipeline_duplicate_components():
+
+    class PipeLineLinear(BinaryClassificationPipeline):
+        component_graph = ["One Hot Encoder", "One Hot Encoder", "Random Forest Classifier"]
+
+    assert PipeLineLinear.hyperparameters == {'One Hot Encoder': {},
+                                              "One Hot Encoder_1": {},
+                                              'Random Forest Classifier': {'n_estimators': Integer(10, 1000),
+                                                                           'max_depth': Integer(1, 10)}}
+
+    class PipeLineLinear(BinaryClassificationPipeline):
+        custom_hyperparameters = {"One Hot Encoder_1": {"top_n": Integer(10, 50)}}
+        component_graph = ["One Hot Encoder", "One Hot Encoder", "Random Forest Classifier"]
+
+    assert PipeLineLinear.hyperparameters == {'One Hot Encoder': {},
+                                              "One Hot Encoder_1": {"top_n": Integer(10, 50)},
+                                              'Random Forest Classifier': {'n_estimators': Integer(10, 1000),
+                                                                           'max_depth': Integer(1, 10)}}
+
+
 @patch('evalml.pipelines.components.Estimator.predict')
 def test_score_with_objective_that_requires_predict_proba(mock_predict, dummy_regression_pipeline_class, X_y_binary):
     X, y = X_y_binary


### PR DESCRIPTION
### Pull Request Description
Fixes #2049, #2132, #2125

When I started, I wasn't planning on a three-in-one PR but we can't fix #2049 without fixing #2132.

Without fixing #2125 , users can't apply custom hyperparameters by attaching them to the pipeline definition so automl support for pipelines with duplicate components would still be broken. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
