### PR TITLE
Build_conda_pkg: fix shell syntax for dockerhub login

### DIFF
--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -45,7 +45,7 @@ jobs:
           python .github/conda_config.py "$(python setup.py --version)"
           cd evalml-core-feedstock
           echo "Pre docker login"
-          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+          echo "${secrets.DOCKERHUB_PASSWORD}" | docker login -u "${secrets.DOCKERHUB_USER}" --password-stdin
           echo "Post docker login"
           export DOCKER_CONTAINERID="$(docker run -td condaforge/linux-anvil-cos7-x86_64)"
           echo "Created container ${DOCKER_CONTAINERID}"

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -35,6 +35,9 @@ jobs:
           source test_python/bin/activate
           make installdeps-test
       - name: Clone Feedstock, Copy to Container, and Run Update
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
           pip install virtualenv
@@ -45,16 +48,16 @@ jobs:
           python .github/conda_config.py "$(python setup.py --version)"
           cd evalml-core-feedstock
           echo "Pre docker login"
-          echo "${secrets.DOCKERHUB_PASSWORD}" | docker login -u "${secrets.DOCKERHUB_USER}" --password-stdin
+          echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USER}" --password-stdin
           echo "Post docker login"
           export DOCKER_CONTAINERID="$(docker run -td condaforge/linux-anvil-cos7-x86_64)"
           echo "Created container ${DOCKER_CONTAINERID}"
           chmod -R 777 ./
-          docker cp . ${DOCKER_CONTAINERID}:/home/conda/feedstock_root/
-          docker cp ./recipe/. ${DOCKER_CONTAINERID}:/home/conda/recipe_root/
+          docker cp . "${DOCKER_CONTAINERID}":/home/conda/feedstock_root/
+          docker cp ./recipe/. "${DOCKER_CONTAINERID}":/home/conda/recipe_root/
           echo "COMMITING UPDATED IMAGE"
-          docker commit ${DOCKER_CONTAINERID} psalter/build:latest
-          docker stop ${DOCKER_CONTAINERID}
+          docker commit "${DOCKER_CONTAINERID}" psalter/build:latest
+          docker stop "${DOCKER_CONTAINERID}"
           export CONFIG=linux_64_
           export UPLOAD_PACKAGES=False
           export HOST_USER_ID=$(id -u)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,6 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
-        * Added a GitHub Action for building the conda package :pr:`1870`
         * Refactored ``EngineBase`` and ``SequentialEngine`` api. Adding ``DaskEngine`` :pr:`1975`.
         * Added optional ``engine`` argument to ``AutoMLSearch`` :pr:`1975`
         * Added a warning about how time series support is still in beta when a user passes in a time series problem to ``AutoMLSearch`` :pr:`2118`
@@ -21,6 +20,7 @@ Release Notes
         * Added a sentence to the automl user guide stating that our support for time series problems is still in beta. :pr:`2118`
     * Testing Changes
         * Fixed ``test_describe_pipeline`` for ``pandas`` ``v1.2.4`` :pr:`2129`
+        * Added a GitHub Action for building the conda package :pr:`1870` :pr:`2148`
 
 
 .. warning::


### PR DESCRIPTION
Building off #1870 

I updated our dockerhub password yesterday. The updated password happened to contain special characters. The current syntax used to pass the password into the docker login command breaks if the password contains special characters!

I was able to confirm the above by changing the password to not contain special chars, and then observing that the job ran successfully. However, I get different behavior from the command in question locally. To avoid future problems, and to make this work when we next change our dockerhub password, I'd like to change the syntax of the command. The double-curly braces are a github actions syntax.

On bash locally:
```bash
bash-5.1$ ENV_VAR=abcd1234
bash-5.1$ echo ${{ENV_VAR}}
bash: ${{ENV_VAR}}: bad substitution
bash-5.1$ echo $ENV_VAR
abcd1234
bash-5.1$ echo ${ENV_VAR}
LYuApz5H7c27C2
bash-5.1$ echo "${ENV_VAR}"
LYuApz5H7c27C2
```

I found [this](https://unix.stackexchange.com/questions/4899/var-vs-var-and-to-quote-or-not-to-quote) to be a useful reference.

Update: to prove this change works, I changed config to run the job in my PR, waited until [the action ran green](https://github.com/alteryx/evalml/runs/2365029639?check_suite_focus=true), then reverted the change.