### PR TITLE
Update test badge in README to use GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img width=50% src="https://evalml-web-images.s3.amazonaws.com/evalml_horizontal.svg" alt="Featuretools" />
 </p>
 
-[![GitHub Actions](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml/badge.svg)](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml)
+[![GitHub Actions](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml/badge.svg?branch=main)](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml)
 [![Codecov.io](https://codecov.io/gh/alteryx/evalml/branch/main/graph/badge.svg?token=JDc0Ib7kYL)](https://codecov.io/gh/alteryx/evalml)
 [![PyPI](https://badge.fury.io/py/evalml.svg?maxAge=2592000)](https://badge.fury.io/py/evalml)
 [![PyPI Stats](https://img.shields.io/pypi/dm/evalml.svg)](https://pypistats.org/packages/evalml)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img width=50% src="https://evalml-web-images.s3.amazonaws.com/evalml_horizontal.svg" alt="Featuretools" />
 </p>
 
-[![GitHub Actions](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml/badge.svg?branch=main)](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml)
+[![GitHub Actions](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml/badge.svg?branch=main)](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml?query=branch%3Amain)
 [![Codecov.io](https://codecov.io/gh/alteryx/evalml/branch/main/graph/badge.svg?token=JDc0Ib7kYL)](https://codecov.io/gh/alteryx/evalml)
 [![PyPI](https://badge.fury.io/py/evalml.svg?maxAge=2592000)](https://badge.fury.io/py/evalml)
 [![PyPI Stats](https://img.shields.io/pypi/dm/evalml.svg)](https://pypistats.org/packages/evalml)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 <img width=50% src="https://evalml-web-images.s3.amazonaws.com/evalml_horizontal.svg" alt="Featuretools" />
 </p>
 
-[![CircleCI](https://circleci.com/gh/alteryx/evalml/tree/main.svg?style=svg&circle-token=9e0ce5e5f2db05f96fe92238fcde6d13963188b6)](https://circleci.com/gh/alteryx/evalml/tree/main)
-[![codecov](https://codecov.io/gh/alteryx/evalml/branch/main/graph/badge.svg?token=JDc0Ib7kYL)](https://codecov.io/gh/alteryx/evalml)
-[![PyPI version](https://badge.fury.io/py/evalml.svg?maxAge=2592000)](https://badge.fury.io/py/evalml)
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/evalml.svg)](https://pypistats.org/packages/evalml)
+[![GitHub Actions](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml/badge.svg)](https://github.com/alteryx/evalml/actions/workflows/linux_unit_tests.yml)
+[![Codecov.io](https://codecov.io/gh/alteryx/evalml/branch/main/graph/badge.svg?token=JDc0Ib7kYL)](https://codecov.io/gh/alteryx/evalml)
+[![PyPI](https://badge.fury.io/py/evalml.svg?maxAge=2592000)](https://badge.fury.io/py/evalml)
+[![PyPI Stats](https://img.shields.io/pypi/dm/evalml.svg)](https://pypistats.org/packages/evalml)
 
 EvalML is an AutoML library which builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,6 +18,7 @@ Release Notes
     * Documentation Changes
         * Fixed ``conf.py`` file :pr:`2112`
         * Added a sentence to the automl user guide stating that our support for time series problems is still in beta. :pr:`2118`
+        * Update test badge in README to use GitHub Actions :pr:`2150`
     * Testing Changes
         * Fixed ``test_describe_pipeline`` for ``pandas`` ``v1.2.4`` :pr:`2129`
         * Added a GitHub Action for building the conda package :pr:`1870` :pr:`2148`


### PR DESCRIPTION
Updating this now that @ParthivNaresh has moved us to GH actions :)

https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge

Preview: https://github.com/alteryx/evalml/blob/ds_change_badge/README.md

I couldn't figure out a way to have the badge reflect the status of *all* our CI, heh. So its linked to our linux tests.