### PR TITLE
Add top-level search method

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -84,7 +84,7 @@ Exceptions
 AutoML
 ======
 
-AutoML Search Classes
+AutoML Search Interface
 ~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: generated
@@ -100,6 +100,7 @@ AutoML Utils
     :toctree: generated
     :nosignatures:
 
+    search
     get_default_primary_search_objective
     make_data_splitter
 

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -85,7 +85,7 @@ AutoML
 ======
 
 AutoML Search Interface
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: generated
     :template: class_with_properties.rst

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Added partial dependence for datetime columns :pr:`2180`
         * Update precision-recall curve with positive label index argument, and fix for 2d predicted probabilities :pr:`2090`
         * Add pct_null_rows to ``HighlyNullDataCheck`` :pr:`2211`
+        * Added a standalone AutoML `search` method for convenience, which runs data checks and then runs automl :pr:`2152`
     * Fixes
         * Fixed partial dependence not respecting grid resolution parameter for numerical features :pr:`2180`
     * Changes

--- a/docs/source/start.ipynb
+++ b/docs/source/start.ipynb
@@ -142,6 +142,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We also provide [a standalone `search` method](../generated/evalml.automl.search.html) which does all of the above in a single line, and returns the `AutoMLSearch` instance and data check results. If there were data check errors, AutoML will not be run and no `AutoMLSearch` instance will be returned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "After the search is finished we can view all of the pipelines searched, ranked by score. Internally, EvalML performs cross validation to score the pipelines. If it notices a high variance across cross validation folds, it will warn you. EvalML also provides additional [data checks](user_guide/data_checks.ipynb) to analyze your data to assist you in producing the best performing pipeline. "
    ]
   },

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -158,6 +158,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We also provide [a standalone `search` method](../generated/evalml.automl.search.html) which does all of the above in a single line, and returns the `AutoMLSearch` instance and data check results. If there were data check errors, AutoML will not be run and no `AutoMLSearch` instance will be returned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Detecting Problem Type\n",
     "\n",
     "EvalML includes a simple method, `detect_problem_type`, to help determine the problem type given the target data. \n",

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -11,7 +11,7 @@ import evalml.preprocessing
 import evalml.problem_types
 import evalml.utils
 import evalml.data_checks
-from evalml.automl import AutoMLSearch
+from evalml.automl import AutoMLSearch, search
 from evalml.utils import print_info
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", FutureWarning)

--- a/evalml/automl/__init__.py
+++ b/evalml/automl/__init__.py
@@ -1,3 +1,3 @@
-from .automl_search import AutoMLSearch
+from .automl_search import AutoMLSearch, search
 from .utils import get_default_primary_search_objective, make_data_splitter, tune_binary_threshold
 from .engine import SequentialEngine, EngineBase

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -87,7 +87,7 @@ def search(X_train=None, y_train=None, problem_type=None, objective='auto', **kw
     Other keyword arguments which are provided will be passed to AutoMLSearch.
 
     Returns:
-        (AutoMLSearch, dict): the automl search object containing pipelines and rankings, and the results from running the data checks. If the data check results contain errors, the automl
+        (AutoMLSearch, dict): the automl search object containing pipelines and rankings, and the results from running the data checks. If the data check results contain errors, automl search will not be run and an automl search object will not be returned.
     """
     X_train = infer_feature_types(X_train)
     y_train = infer_feature_types(y_train)

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -22,6 +22,7 @@ from evalml.automl.utils import (
     get_default_primary_search_objective,
     make_data_splitter
 )
+from evalml.data_checks import DefaultDataChecks
 from evalml.exceptions import (
     AutoMLSearchException,
     PipelineNotFoundError,
@@ -60,6 +61,21 @@ from evalml.utils.logger import (
 )
 
 logger = get_logger(__file__)
+
+
+def search(X_train=None, y_train=None, problem_type=None, objective='auto'):
+    """Given data and configuration, run an automl search"""
+    X_train = infer_feature_types(X_train)
+    y_train = infer_feature_types(y_train)
+
+    data_checks = DefaultDataChecks()
+    data_check_results = data_checks.validate(X_train, y=y_train)
+    if len(data_check_results['errors']):
+        raise Exception('Errors')
+    automl = AutoMLSearch(X_train=X_train, y_train=y_train, problem_type=problem_type, objective=objective,
+                          max_batches=1)
+    automl.search()
+    return automl
 
 
 class AutoMLSearch:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -63,17 +63,21 @@ from evalml.utils.logger import (
 logger = get_logger(__file__)
 
 
-def search(X_train=None, y_train=None, problem_type=None, objective='auto'):
+def search(X_train=None, y_train=None, problem_type=None, objective='auto', **kwargs):
     """Given data and configuration, run an automl search"""
     X_train = infer_feature_types(X_train)
     y_train = infer_feature_types(y_train)
+
+    automl_config = kwargs
+    automl_config.update({'X_train': X_train, 'y_train': y_train, 'problem_type': problem_type, 'objective': objective,
+                          'max_batches': 1})
 
     data_checks = DefaultDataChecks()
     data_check_results = data_checks.validate(X_train, y=y_train)
     if len(data_check_results['errors']):
         raise Exception('Errors')
-    automl = AutoMLSearch(X_train=X_train, y_train=y_train, problem_type=problem_type, objective=objective,
-                          max_batches=1)
+
+    automl = AutoMLSearch(**automl_config)
     automl.search()
     return automl
 

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -69,8 +69,8 @@ def search(X_train=None, y_train=None, problem_type=None, objective='auto', **kw
     y_train = infer_feature_types(y_train)
 
     automl_config = kwargs
-    automl_config.update({'X_train': X_train, 'y_train': y_train, 'problem_type': problem_type, 'objective': objective,
-                          'max_batches': 1})
+    automl_config.update({'X_train': X_train, 'y_train': y_train, 'problem_type': problem_type,
+                          'objective': objective, 'max_batches': 1})
 
     data_checks = DefaultDataChecks()
     data_check_results = data_checks.validate(X_train, y=y_train)

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -64,22 +64,50 @@ logger = get_logger(__file__)
 
 
 def search(X_train=None, y_train=None, problem_type=None, objective='auto', **kwargs):
-    """Given data and configuration, run an automl search"""
+    """Given data and configuration, run an automl search.
+
+    This method will run EvalML's default suite of data checks. If the data checks produce errors, the data check results will be returned before running the automl search. In that case we recommend you alter your data to address these errors and try again.
+
+    This method is provided for convenience. If you'd like more control over when each of these steps is run, consider making calls directly to the various pieces like the data checks and AutoMLSearch, instead of using this method.
+
+    Arguments:
+        X_train (pd.DataFrame, ww.DataTable): The input training data of shape [n_samples, n_features]. Required.
+
+        y_train (pd.Series, ww.DataColumn): The target training data of length [n_samples]. Required for supervised learning tasks.
+
+        problem_type (str or ProblemTypes): type of supervised learning problem. See evalml.problem_types.ProblemType.all_problem_types for a full list.
+
+        objective (str, ObjectiveBase): The objective to optimize for. Used to propose and rank pipelines, but not for optimizing each pipeline during fit-time.
+            When set to 'auto', chooses:
+
+            - LogLossBinary for binary classification problems,
+            - LogLossMulticlass for multiclass classification problems, and
+            - R2 for regression problems.
+
+    Other keyword arguments which are provided will be passed to AutoMLSearch.
+
+    Returns:
+        (AutoMLSearch, dict): the automl search object containing pipelines and rankings, and the results from running the data checks. If the data check results contain errors, the automl
+    """
     X_train = infer_feature_types(X_train)
     y_train = infer_feature_types(y_train)
+    problem_type = handle_problem_types(problem_type)
+    if objective == 'auto':
+        objective = get_default_primary_search_objective(problem_type)
+    objective = get_objective(objective, return_instance=False)
 
     automl_config = kwargs
     automl_config.update({'X_train': X_train, 'y_train': y_train, 'problem_type': problem_type,
                           'objective': objective, 'max_batches': 1})
 
-    data_checks = DefaultDataChecks()
+    data_checks = DefaultDataChecks(problem_type=problem_type, objective=objective)
     data_check_results = data_checks.validate(X_train, y=y_train)
-    if len(data_check_results['errors']):
-        raise Exception('Errors')
+    if len(data_check_results.get('errors', [])):
+        return None, data_check_results
 
     automl = AutoMLSearch(**automl_config)
     automl.search()
-    return automl
+    return automl, data_check_results
 
 
 class AutoMLSearch:

--- a/evalml/tests/automl_tests/test_search.py
+++ b/evalml/tests/automl_tests/test_search.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from evalml.automl import AutoMLSearch, search
+from evalml.utils import infer_feature_types
+
+
+@patch('evalml.data_checks.default_data_checks.DefaultDataChecks.validate')
+@patch('evalml.automl.AutoMLSearch.search')
+def test_search(mock_automl_search, mock_data_checks_validate, X_y_binary):
+    X, y = X_y_binary
+    # this doesn't exactly match the data check results schema but its enough to trigger the error in search()
+    data_check_results_expected = {'warnings': ['Warning 1', 'Warning 2']}
+    mock_data_checks_validate.return_value = data_check_results_expected
+    automl, data_check_results = search(X_train=X, y_train=y, problem_type='binary')
+    assert isinstance(automl, AutoMLSearch)
+    assert data_check_results is data_check_results_expected
+    mock_data_checks_validate.assert_called_once()
+    mock_data_checks_validate.assert_called_with(infer_feature_types(X), y=infer_feature_types(y))
+    mock_automl_search.assert_called_once()
+
+
+@patch('evalml.data_checks.default_data_checks.DefaultDataChecks.validate')
+@patch('evalml.automl.AutoMLSearch.search')
+def test_search_data_check_error(mock_automl_search, mock_data_checks_validate, X_y_binary):
+    X, y = X_y_binary
+    # this doesn't exactly match the data check results schema but its enough to trigger the error in search()
+    data_check_results_expected = {'errors': ['Error 1', 'Error 2']}
+    mock_data_checks_validate.return_value = data_check_results_expected
+    automl, data_check_results = search(X_train=X, y_train=y, problem_type='binary')
+    assert automl is None
+    assert data_check_results == data_check_results_expected
+    mock_data_checks_validate.assert_called_once()
+    mock_data_checks_validate.assert_called_with(infer_feature_types(X), y=infer_feature_types(y))
+    mock_automl_search.assert_not_called()
+
+
+@patch('evalml.data_checks.default_data_checks.DefaultDataChecks.validate')
+@patch('evalml.automl.AutoMLSearch.search')
+def test_search_kwargs(mock_automl_search, mock_data_checks_validate, X_y_binary):
+    X, y = X_y_binary
+    automl, data_check_results = search(X_train=X, y_train=y, problem_type='binary', max_iterations=42)
+    assert automl.max_iterations == 42


### PR DESCRIPTION
First draft of a top-level search method. This method is our recommendation for how to use woodwork, data checks and automl search together. It defines an interface which sets up the woodwork schema (if the input didn't already set woodwork types), runs our default data checks and then if there are no errors runs automl search.

Once data check actions have been added, we can add support for that here as well.