### PR TITLE
WW Accessor: Updating objectives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,24 +25,24 @@ git-test:
 	pytest evalml -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
 	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
-	--ignore evalml/tests/model_understanding_tests --ignore evalml/tests/objective_tests \
-	-k "not test_save"
+	--ignore evalml/tests/model_understanding_tests \
+	-k "not test_save and not objective_test_uses_automl"
 
 .PHONY: git-test-minimal-deps
 git-test-minimal-deps:
 	pytest evalml/ -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
 	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
-	--ignore evalml/tests/model_understanding_tests --ignore evalml/tests/objective_tests \
-	-k "not test_save" --has-minimal-dependencies
+	--ignore evalml/tests/model_understanding_tests \
+	-k "not test_save and not objective_test_uses_automl" --has-minimal-dependencies
 
 .PHONY: win-git-test
 win-git-test:
 	pytest evalml -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
 	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
-	--ignore evalml/tests/model_understanding_tests --ignore evalml/tests/objective_tests \
-	-k "not test_save"
+	--ignore evalml/tests/model_understanding_tests \
+	-k "not test_save and not objective_test_uses_automl"
 
 .PHONY: installdeps
 installdeps:

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -38,8 +38,8 @@ def confusion_matrix(y_true, y_predicted, normalize_method='true'):
     """Confusion matrix for binary and multiclass classification.
 
     Arguments:
-        y_true (ww.DataColumn, pd.Series or np.ndarray): True binary labels.
-        y_pred (ww.DataColumn, pd.Series or np.ndarray): Predictions from a binary classifier.
+        y_true (pd.Series or np.ndarray): True binary labels.
+        y_pred (pd.Series or np.ndarray): Predictions from a binary classifier.
         normalize_method ({'true', 'pred', 'all', None}): Normalization method to use, if not None. Supported options are: 'true' to normalize by row, 'pred' to normalize by column, or 'all' to normalize by all values. Defaults to 'true'.
 
     Returns:
@@ -47,8 +47,8 @@ def confusion_matrix(y_true, y_predicted, normalize_method='true'):
     """
     y_true = infer_feature_types(y_true)
     y_predicted = infer_feature_types(y_predicted)
-    y_true = _convert_woodwork_types_wrapper(y_true.to_series()).to_numpy()
-    y_predicted = _convert_woodwork_types_wrapper(y_predicted.to_series()).to_numpy()
+    y_true = y_true.to_numpy()
+    y_predicted = y_predicted.to_numpy()
     labels = unique_labels(y_true, y_predicted)
     conf_mat = sklearn_confusion_matrix(y_true, y_predicted)
     conf_mat = pd.DataFrame(conf_mat, index=labels, columns=labels)
@@ -61,14 +61,13 @@ def normalize_confusion_matrix(conf_mat, normalize_method='true'):
     """Normalizes a confusion matrix.
 
     Arguments:
-        conf_mat (ww.DataTable, pd.DataFrame or np.ndarray): Confusion matrix to normalize.
+        conf_mat (pd.DataFrame or np.ndarray): Confusion matrix to normalize.
         normalize_method ({'true', 'pred', 'all'}): Normalization method. Supported options are: 'true' to normalize by row, 'pred' to normalize by column, or 'all' to normalize by all values. Defaults to 'true'.
 
     Returns:
         pd.DataFrame: normalized version of the input confusion matrix. The column header represents the predicted labels while row header represents the actual labels.
     """
     conf_mat = infer_feature_types(conf_mat)
-    conf_mat = _convert_woodwork_types_wrapper(conf_mat.to_dataframe())
     col_names = conf_mat.columns
 
     conf_mat = conf_mat.to_numpy()

--- a/evalml/objectives/objective_base.py
+++ b/evalml/objectives/objective_base.py
@@ -2,10 +2,9 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import pandas as pd
-import woodwork as ww
 
 from evalml.problem_types import handle_problem_types
-from evalml.utils import _convert_woodwork_types_wrapper, classproperty
+from evalml.utils import classproperty
 
 
 class ObjectiveBase(ABC):
@@ -91,11 +90,7 @@ class ObjectiveBase(ABC):
             pd.DataFrame or pd.Series: a pd.Series, or pd.DataFrame object if predicted probabilities were provided.
         """
         if isinstance(input_data, (pd.Series, pd.DataFrame)):
-            return _convert_woodwork_types_wrapper(input_data)
-        if isinstance(input_data, ww.DataTable):
-            return _convert_woodwork_types_wrapper(input_data.to_dataframe())
-        if isinstance(input_data, ww.DataColumn):
-            return _convert_woodwork_types_wrapper(input_data.to_series())
+            return input_data
         if isinstance(input_data, list):
             if isinstance(input_data[0], list):
                 return pd.DataFrame(input_data)

--- a/evalml/tests/objective_tests/test_cost_benefit_matrix.py
+++ b/evalml/tests/objective_tests/test_cost_benefit_matrix.py
@@ -21,6 +21,7 @@ def test_cbm_init():
                           false_positive=-7, false_negative=None)
 
 
+@pytest.mark.objective_test_uses_automl
 @pytest.mark.parametrize("optimize_thresholds", [True, False])
 def test_cbm_objective_automl(optimize_thresholds, X_y_binary):
     X, y = X_y_binary
@@ -32,8 +33,8 @@ def test_cbm_objective_automl(optimize_thresholds, X_y_binary):
     pipeline = automl.best_pipeline
     pipeline.fit(X, y)
     predictions = pipeline.predict(X, cbm)
-    assert not np.isnan(predictions.to_series()).values.any()
-    assert not np.isnan(pipeline.predict_proba(X).to_dataframe()).values.any()
+    assert not np.isnan(predictions).values.any()
+    assert not np.isnan(pipeline.predict_proba(X)).values.any()
     assert not np.isnan(pipeline.score(X, y, [cbm])['Cost Benefit Matrix'])
 
 

--- a/evalml/tests/objective_tests/test_fraud_detection.py
+++ b/evalml/tests/objective_tests/test_fraud_detection.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 
 from evalml import AutoMLSearch
 from evalml.objectives import FraudCost
 
 
+@pytest.mark.objective_test_uses_automl
 def test_fraud_objective(X_y_binary):
     X, y = X_y_binary
 
@@ -121,8 +121,8 @@ def test_fraud_objective_score(X_y_binary):
     score = fraud_cost.score(y_true, out, extra_columns)
     assert (score == 0.0)
 
-    out = ww.DataColumn(fraud_cost.decision_function(y_predicted, 5, extra_columns))
-    pd.testing.assert_series_equal(out.to_series(), y_true, check_dtype=False, check_names=False)
+    out = pd.Series(fraud_cost.decision_function(y_predicted, 5, extra_columns))
+    pd.testing.assert_series_equal(out, y_true, check_dtype=False, check_names=False)
     score = fraud_cost.score(y_true, out, extra_columns)
     assert (score == 0.0)
 

--- a/evalml/tests/objective_tests/test_fraud_detection.py
+++ b/evalml/tests/objective_tests/test_fraud_detection.py
@@ -121,7 +121,7 @@ def test_fraud_objective_score(X_y_binary):
     score = fraud_cost.score(y_true, out, extra_columns)
     assert (score == 0.0)
 
-    out = pd.Series(fraud_cost.decision_function(y_predicted, 5, extra_columns))
+    out = fraud_cost.decision_function(y_predicted, 5, extra_columns)
     pd.testing.assert_series_equal(out, y_true, check_dtype=False, check_names=False)
     score = fraud_cost.score(y_true, out, extra_columns)
     assert (score == 0.0)

--- a/evalml/tests/objective_tests/test_lead_scoring.py
+++ b/evalml/tests/objective_tests/test_lead_scoring.py
@@ -6,7 +6,9 @@ from evalml import AutoMLSearch
 from evalml.objectives import LeadScoring
 
 
-def test_lead_scoring_objective(X_y_binary):
+@pytest.mark.objective_test_uses_automl
+def test_lead_scoring_works_during_automl_search(X_y_binary):
+
     X, y = X_y_binary
 
     objective = LeadScoring(true_positives=1,
@@ -20,6 +22,12 @@ def test_lead_scoring_objective(X_y_binary):
     pipeline.predict(X)
     pipeline.predict_proba(X)
     pipeline.score(X, y, [objective])
+
+
+def test_lead_scoring_objective():
+
+    objective = LeadScoring(true_positives=1,
+                            false_positives=-1)
 
     predicted = pd.Series([1, 10, .5, 5])
     out = objective.decision_function(predicted, 1)

--- a/evalml/tests/objective_tests/test_sla.py
+++ b/evalml/tests/objective_tests/test_sla.py
@@ -14,6 +14,7 @@ class TestSLA(TestBinaryObjective):
     def assign_objective(self, alert_rate):
         self.objective = SensitivityLowAlert(alert_rate)
 
+    @pytest.mark.objective_test_uses_automl
     def test_sla_objective(self, X_y_binary):
         self.assign_problem_type()
         self.assign_objective(0.1)


### PR DESCRIPTION
### Pull Request Description

Updates objectives (and confusion_matrix implementation for the cost-benefit objective). Had to manually deselect some tests because they actually run automl.

See the roadmap [here](https://github.com/alteryx/evalml/pull/2181#issue-621551559)


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
