### PR TITLE
Use machineFL user token for dependency update bot. 

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Create Pull Request
         uses: FeatureLabs/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.MACHINEFL_DEPENDENCY_CHECKER_TOKEN }}
           commit-message: Update latest dependencies
           title: Automated Latest Dependency Updates
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
@@ -29,4 +29,4 @@ jobs:
           branch: dep-update
           branch-suffix: short-commit-hash
           base: main
-          reviewers: angela97lin, dsherry, jeremyliweishih
+          reviewers: angela97lin, dsherry, jeremyliweishih, freddyaboulton, bchen1116, chukarsten, ParthivNaresh

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
     * Documentation Changes
         * Rename dataset to clarify that its gzipped but not a tarball :pr:`2183`
     * Testing Changes
+        * Use machineFL user token for dependency update bot, and add more reviewers :pr:`2189`
 
 
 .. warning::


### PR DESCRIPTION
Fix #2045 

Not sure if this will work since `github-actions` is the PR author but the token was generated with `machineFL` user. But we'll see.

Also adds more reviewers to deps update PRs

