### PR TITLE
WW Accessor: Updating Components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,26 +23,23 @@ test:
 .PHONY: git-test
 git-test:
 	pytest evalml -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
-	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
 	--ignore evalml/tests/model_understanding_tests \
-	-k "not test_save and not objective_test_uses_automl"
+	-k "not test_save and not objective_test_uses_automl and not test_stacked and not test_scikit_learn_wrapper"
 
 .PHONY: git-test-minimal-deps
 git-test-minimal-deps:
 	pytest evalml/ -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
-	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
 	--ignore evalml/tests/model_understanding_tests \
-	-k "not test_save and not objective_test_uses_automl" --has-minimal-dependencies
+	-k "not test_save and not objective_test_uses_automl and not test_stacked and not test_scikit_learn_wrapper" --has-minimal-dependencies
 
 .PHONY: win-git-test
 win-git-test:
 	pytest evalml -n 4 --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure \
-	--ignore evalml/tests/component_tests \
 	--ignore evalml/tests/pipeline_tests --ignore evalml/tests/automl_tests \
 	--ignore evalml/tests/model_understanding_tests \
-	-k "not test_save and not objective_test_uses_automl"
+	-k "not test_save and not objective_test_uses_automl and not test_stacked and not test_scikit_learn_wrapper"
 
 .PHONY: installdeps
 installdeps:

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -78,8 +78,8 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
         """Fits component to data
 
         Arguments:
-            X (list, ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
-            y (list, ww.DataColumn, pd.Series, np.ndarray, optional): The target training data of length [n_samples]
+            X (list, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
+            y (list, pd.Series, np.ndarray, optional): The target training data of length [n_samples]
 
         Returns:
             self

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -6,7 +6,6 @@ import cloudpickle
 from evalml.exceptions import MethodPropertyNotFoundError
 from evalml.pipelines.components.component_base_meta import ComponentBaseMeta
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     classproperty,
     get_logger,
     infer_feature_types,
@@ -86,10 +85,8 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
             self
         """
         X = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         if y is not None:
             y = infer_feature_types(y)
-            y = _convert_woodwork_types_wrapper(y.to_series())
         try:
             self._component_obj.fit(X, y)
             return self

--- a/evalml/pipelines/components/estimators/classifiers/baseline_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/baseline_classifier.py
@@ -5,11 +5,7 @@ import pandas as pd
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    get_random_state,
-    infer_feature_types
-)
+from evalml.utils import get_random_state, infer_feature_types
 
 
 class BaselineClassifier(Estimator):
@@ -47,7 +43,6 @@ class BaselineClassifier(Estimator):
             raise ValueError("Cannot fit Baseline classifier if y is None")
         X = infer_feature_types(X)
         y = infer_feature_types(y)
-        y = _convert_woodwork_types_wrapper(y.to_series())
 
         vals, counts = np.unique(y, return_counts=True)
         self._classes = list(vals)

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -8,11 +8,7 @@ from skopt.space import Integer, Real
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    import_or_raise,
-    infer_feature_types
-)
+from evalml.utils import import_or_raise, infer_feature_types
 
 
 class CatBoostClassifier(Estimator):
@@ -57,7 +53,7 @@ class CatBoostClassifier(Estimator):
 
     def fit(self, X, y=None):
         X = infer_feature_types(X)
-        cat_cols = list(X.select('category').columns)
+        cat_cols = list(X.ww.select('category').columns)
         self.input_feature_names = list(X.columns)
         X, y = super()._manage_woodwork(X, y)
         # For binary classification, catboost expects numeric values, so encoding before.
@@ -69,7 +65,6 @@ class CatBoostClassifier(Estimator):
 
     def predict(self, X):
         X = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         predictions = self._component_obj.predict(X)
         if predictions.ndim == 2 and predictions.shape[1] == 1:
             predictions = predictions.flatten()

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -11,7 +11,6 @@ from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
 from evalml.utils import (
     SEED_BOUNDS,
-    _convert_woodwork_types_wrapper,
     _rename_column_names_to_numeric,
     import_or_raise,
     infer_feature_types
@@ -76,8 +75,7 @@ class LightGBMClassifier(Estimator):
     def _encode_categories(self, X, fit=False):
         """Encodes each categorical feature using ordinal encoding."""
         X = infer_feature_types(X)
-        cat_cols = list(X.select('category').columns)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        cat_cols = map(str, list(X.ww.select('category').columns))
         if fit:
             self.input_feature_names = list(X.columns)
         X_encoded = _rename_column_names_to_numeric(X)
@@ -97,7 +95,6 @@ class LightGBMClassifier(Estimator):
 
     def _encode_labels(self, y):
         y_encoded = infer_feature_types(y)
-        y_encoded = _convert_woodwork_types_wrapper(y_encoded.to_series())
         # change only if dtype isn't int
         if not is_integer_dtype(y_encoded):
             self._label_encoder = LabelEncoder()
@@ -116,7 +113,7 @@ class LightGBMClassifier(Estimator):
         predictions = super().predict(X_encoded)
         if not self._label_encoder:
             return predictions
-        predictions = pd.Series(self._label_encoder.inverse_transform(predictions.to_series().astype(np.int64)))
+        predictions = pd.Series(self._label_encoder.inverse_transform(predictions.astype(np.int64)))
         return infer_feature_types(predictions)
 
     def predict_proba(self, X):

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -75,7 +75,7 @@ class LightGBMClassifier(Estimator):
     def _encode_categories(self, X, fit=False):
         """Encodes each categorical feature using ordinal encoding."""
         X = infer_feature_types(X)
-        cat_cols = map(str, list(X.ww.select('category').columns))
+        cat_cols = X.ww.select('category').columns
         if fit:
             self.input_feature_names = list(X.columns)
         X_encoded = _rename_column_names_to_numeric(X)
@@ -102,7 +102,7 @@ class LightGBMClassifier(Estimator):
         return y_encoded
 
     def fit(self, X, y=None):
-        X_encoded = infer_feature_types(X)
+        X = infer_feature_types(X)
         X_encoded = self._encode_categories(X, fit=True)
         y_encoded = self._encode_labels(y)
         self._component_obj.fit(X_encoded, y_encoded)

--- a/evalml/pipelines/components/estimators/estimator.py
+++ b/evalml/pipelines/components/estimators/estimator.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from evalml.exceptions import MethodPropertyNotFoundError
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components import ComponentBase
-from evalml.utils import _convert_woodwork_types_wrapper, infer_feature_types
+from evalml.utils import infer_feature_types
 
 
 class Estimator(ComponentBase):
@@ -35,10 +35,8 @@ class Estimator(ComponentBase):
         """Function to convert the input and target data to Pandas data structures."""
         if X is not None:
             X = infer_feature_types(X)
-            X = _convert_woodwork_types_wrapper(X.to_dataframe())
         if y is not None:
             y = infer_feature_types(y)
-            y = _convert_woodwork_types_wrapper(y.to_series())
         return X, y
 
     def fit(self, X, y=None):
@@ -58,7 +56,6 @@ class Estimator(ComponentBase):
         """
         try:
             X = infer_feature_types(X)
-            X = _convert_woodwork_types_wrapper(X.to_dataframe())
             predictions = self._component_obj.predict(X)
         except AttributeError:
             raise MethodPropertyNotFoundError("Estimator requires a predict method or a component_obj that implements predict")
@@ -75,7 +72,6 @@ class Estimator(ComponentBase):
         """
         try:
             X = infer_feature_types(X)
-            X = _convert_woodwork_types_wrapper(X.to_dataframe())
             pred_proba = self._component_obj.predict_proba(X)
         except AttributeError:
             raise MethodPropertyNotFoundError("Estimator requires a predict_proba method or a component_obj that implements predict_proba")

--- a/evalml/pipelines/components/estimators/estimator.py
+++ b/evalml/pipelines/components/estimators/estimator.py
@@ -49,10 +49,10 @@ class Estimator(ComponentBase):
         """Make predictions using selected features.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, or np.ndarray): Data of shape [n_samples, n_features]
+            X (pd.DataFrame, np.ndarray): Data of shape [n_samples, n_features]
 
         Returns:
-            ww.DataColumn: Predicted values
+            pd.Series: Predicted values
         """
         try:
             X = infer_feature_types(X)
@@ -65,10 +65,10 @@ class Estimator(ComponentBase):
         """Make probability estimates for labels.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, or np.ndarray): Features
+            X (pd.DataFrame, or np.ndarray): Features
 
         Returns:
-            ww.DataTable: Probability estimates
+            pd.Series: Probability estimates
         """
         try:
             X = infer_feature_types(X)

--- a/evalml/pipelines/components/estimators/regressors/baseline_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/baseline_regressor.py
@@ -4,7 +4,7 @@ import pandas as pd
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
-from evalml.utils import _convert_woodwork_types_wrapper, infer_feature_types
+from evalml.utils import infer_feature_types
 
 
 class BaselineRegressor(Estimator):
@@ -40,7 +40,6 @@ class BaselineRegressor(Estimator):
             raise ValueError("Cannot fit Baseline regressor if y is None")
         X = infer_feature_types(X)
         y = infer_feature_types(y)
-        y = _convert_woodwork_types_wrapper(y.to_series())
 
         if self.parameters["strategy"] == "mean":
             self._prediction_value = y.mean()

--- a/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
@@ -48,7 +48,7 @@ class CatBoostRegressor(Estimator):
 
     def fit(self, X, y=None):
         X = infer_feature_types(X)
-        cat_cols = list(X.select('category').columns)
+        cat_cols = list(X.ww.select('category').columns)
         self.input_feature_names = list(X.columns)
         X, y = super()._manage_woodwork(X, y)
         self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)

--- a/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
@@ -9,7 +9,6 @@ from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
 from evalml.utils import (
     SEED_BOUNDS,
-    _convert_woodwork_types_wrapper,
     _rename_column_names_to_numeric,
     import_or_raise,
     infer_feature_types
@@ -73,8 +72,7 @@ class LightGBMRegressor(Estimator):
     def _encode_categories(self, X, fit=False):
         """Encodes each categorical feature using ordinal encoding."""
         X = infer_feature_types(X)
-        cat_cols = list(X.select('category').columns)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
+        cat_cols = map(str, list(X.ww.select('category').columns))
         if fit:
             self.input_feature_names = list(X.columns)
         X_encoded = _rename_column_names_to_numeric(X)
@@ -96,7 +94,6 @@ class LightGBMRegressor(Estimator):
         X_encoded = self._encode_categories(X, fit=True)
         if y is not None:
             y = infer_feature_types(y)
-            y = _convert_woodwork_types_wrapper(y.to_series())
         self._component_obj.fit(X_encoded, y)
         return self
 

--- a/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
@@ -72,7 +72,7 @@ class LightGBMRegressor(Estimator):
     def _encode_categories(self, X, fit=False):
         """Encodes each categorical feature using ordinal encoding."""
         X = infer_feature_types(X)
-        cat_cols = map(str, list(X.ww.select('category').columns))
+        cat_cols = list(X.ww.select('category').columns)
         if fit:
             self.input_feature_names = list(X.columns)
         X_encoded = _rename_column_names_to_numeric(X)

--- a/evalml/pipelines/components/estimators/regressors/time_series_baseline_estimator.py
+++ b/evalml/pipelines/components/estimators/regressors/time_series_baseline_estimator.py
@@ -4,11 +4,7 @@ import pandas as pd
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
 from evalml.problem_types import ProblemTypes
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    infer_feature_types,
-    pad_with_nans
-)
+from evalml.utils import infer_feature_types, pad_with_nans
 
 
 class TimeSeriesBaselineEstimator(Estimator):
@@ -57,7 +53,6 @@ class TimeSeriesBaselineEstimator(Estimator):
         if y is None:
             raise ValueError("Cannot predict Time Series Baseline Estimator if y is None")
         y = infer_feature_types(y)
-        y = _convert_woodwork_types_wrapper(y.to_series())
 
         if self.gap == 0:
             y = y.shift(periods=1)
@@ -68,8 +63,7 @@ class TimeSeriesBaselineEstimator(Estimator):
         if y is None:
             raise ValueError("Cannot predict Time Series Baseline Estimator if y is None")
         y = infer_feature_types(y)
-        y = _convert_woodwork_types_wrapper(y.to_series())
-        preds = self.predict(X, y).to_series().dropna(axis=0, how='any').astype('int')
+        preds = self.predict(X, y).dropna(axis=0, how='any').astype('int')
         proba_arr = np.zeros((len(preds), y.max() + 1))
         proba_arr[np.arange(len(preds)), preds] = 1
         padded = pad_with_nans(pd.DataFrame(proba_arr), len(y) - len(preds))

--- a/evalml/pipelines/components/transformers/column_selectors.py
+++ b/evalml/pipelines/components/transformers/column_selectors.py
@@ -65,7 +65,7 @@ class DropColumns(ColumnSelector):
     needs_fitting = False
 
     def _modify_columns(self, cols, X, y=None):
-        return X.drop(columns=cols)
+        return X.ww.drop(cols)
 
     def transform(self, X, y=None):
         """Transforms data X by dropping columns.
@@ -87,7 +87,7 @@ class SelectColumns(ColumnSelector):
     needs_fitting = False
 
     def _modify_columns(self, cols, X, y=None):
-        return X[cols]
+        return X.ww[cols]
 
     def transform(self, X, y=None):
         """Transforms data X by selecting columns.

--- a/evalml/pipelines/components/transformers/column_selectors.py
+++ b/evalml/pipelines/components/transformers/column_selectors.py
@@ -40,8 +40,8 @@ class ColumnSelector(Transformer):
         """Fits the transformer by checking if column names are present in the dataset.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to check.
-            y (ww.DataColumn, pd.Series, optional): Targets.
+            X (pd.DataFrame): Data to check.
+            y (pd.Series, optional): Targets.
 
         Returns:
             self
@@ -71,11 +71,11 @@ class DropColumns(ColumnSelector):
         """Transforms data X by dropping columns.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform.
-            y (ww.DataColumn, pd.Series, optional): Targets.
+            X (pd.DataFrame): Data to transform.
+            y (pd.Series, optional): Targets.
 
         Returns:
-            ww.DataTable: Transformed X.
+            pd.DataFrame: Transformed X.
         """
         return super().transform(X, y)
 
@@ -93,10 +93,10 @@ class SelectColumns(ColumnSelector):
         """Transforms data X by selecting columns.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform.
-            y (ww.DataColumn, pd.Series, optional): Targets.
+            X (pd.DataFrame): Data to transform.
+            y (pd.Series, optional): Targets.
 
         Returns:
-            ww.DataTable: Transformed X.
+            pd.DataFrame: Transformed X.
         """
         return super().transform(X, y)

--- a/evalml/pipelines/components/transformers/dimensionality_reduction/lda.py
+++ b/evalml/pipelines/components/transformers/dimensionality_reduction/lda.py
@@ -3,7 +3,6 @@ from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as SkLDA
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types,
     is_all_numeric
@@ -36,8 +35,6 @@ class LinearDiscriminantAnalysis(Transformer):
         if not is_all_numeric(X):
             raise ValueError("LDA input must be all numeric")
         y = infer_feature_types(y)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_series())
         n_features = X.shape[1]
         n_classes = y.nunique()
         n_components = self.parameters['n_components']
@@ -51,9 +48,8 @@ class LinearDiscriminantAnalysis(Transformer):
         X_ww = infer_feature_types(X)
         if not is_all_numeric(X_ww):
             raise ValueError("LDA input must be all numeric")
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         X_t = self._component_obj.transform(X)
-        X_t = pd.DataFrame(X_t, index=X.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
+        X_t = pd.DataFrame(X_t, index=X_ww.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
         return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)
 
     def fit_transform(self, X, y=None):
@@ -61,9 +57,7 @@ class LinearDiscriminantAnalysis(Transformer):
         if not is_all_numeric(X_ww):
             raise ValueError("LDA input must be all numeric")
         y = infer_feature_types(y)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
-        y = _convert_woodwork_types_wrapper(y.to_series())
 
         X_t = self._component_obj.fit_transform(X, y)
-        X_t = pd.DataFrame(X_t, index=X.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
+        X_t = pd.DataFrame(X_t, index=X_ww.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
         return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)

--- a/evalml/pipelines/components/transformers/dimensionality_reduction/pca.py
+++ b/evalml/pipelines/components/transformers/dimensionality_reduction/pca.py
@@ -4,7 +4,6 @@ from skopt.space import Real
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types,
     is_all_numeric
@@ -42,7 +41,6 @@ class PCA(Transformer):
         X = infer_feature_types(X)
         if not is_all_numeric(X):
             raise ValueError("PCA input must be all numeric")
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         self._component_obj.fit(X)
         return self
 
@@ -50,16 +48,14 @@ class PCA(Transformer):
         X_ww = infer_feature_types(X)
         if not is_all_numeric(X_ww):
             raise ValueError("PCA input must be all numeric")
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         X_t = self._component_obj.transform(X)
-        X_t = pd.DataFrame(X_t, index=X.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
+        X_t = pd.DataFrame(X_t, index=X_ww.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
         return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)
 
     def fit_transform(self, X, y=None):
         X_ww = infer_feature_types(X)
         if not is_all_numeric(X_ww):
             raise ValueError("PCA input must be all numeric")
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         X_t = self._component_obj.fit_transform(X, y)
-        X_t = pd.DataFrame(X_t, index=X.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
+        X_t = pd.DataFrame(X_t, index=X_ww.index, columns=[f"component_{i}" for i in range(X_t.shape[1])])
         return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)

--- a/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
@@ -4,10 +4,7 @@ from sklearn.preprocessing import OneHotEncoder as SKOneHotEncoder
 
 from evalml.pipelines.components import ComponentBaseMeta
 from evalml.pipelines.components.transformers.transformer import Transformer
-from evalml.utils import (
-    _retain_custom_types_and_initalize_woodwork,
-    infer_feature_types
-)
+from evalml.utils import infer_feature_types
 
 
 class OneHotEncoderMeta(ComponentBaseMeta):

--- a/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
@@ -74,7 +74,7 @@ class OneHotEncoder(Transformer, metaclass=OneHotEncoderMeta):
 
     @staticmethod
     def _get_cat_cols(X):
-        """Get names of categorical columns in the input Woodwork DataTable."""
+        """Get names of categorical columns in the input DataFrame."""
         return list(X.ww.select(include=['category']).columns)
 
     def fit(self, X, y=None):
@@ -127,11 +127,11 @@ class OneHotEncoder(Transformer, metaclass=OneHotEncoderMeta):
         """One-hot encode the input data.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features to one-hot encode.
-            y (ww.DataColumn, pd.Series): Ignored.
+            X (pd.DataFrame): Features to one-hot encode.
+            y (pd.Series): Ignored.
 
         Returns:
-            ww.DataTable: Transformed data, where each categorical feature has been encoded into numerical columns using one-hot encoding.
+            pd.DataFrame: Transformed data, where each categorical feature has been encoded into numerical columns using one-hot encoding.
         """
         X_ww = infer_feature_types(X)
         X_copy = self._handle_parameter_handle_missing(X_ww)

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -7,7 +7,6 @@ from evalml.pipelines.components.transformers.encoders.onehot_encoder import (
     OneHotEncoderMeta
 )
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     import_or_raise,
     infer_feature_types
@@ -64,13 +63,11 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
 
     def transform(self, X, y=None):
         X_ww = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         if y is not None:
             y = infer_feature_types(y)
-            y = _convert_woodwork_types_wrapper(y.to_series())
         X_t = self._component_obj.transform(X, y)
-        X_t_df = pd.DataFrame(X_t, columns=X.columns, index=X.index)
-        return _retain_custom_types_and_initalize_woodwork(X_ww, X_t_df, ltypes_to_ignore=[Categorical])
+        X_t_df = pd.DataFrame(X_t, columns=X_ww.columns, index=X_ww.index)
+        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, X_t_df, ltypes_to_ignore=[Categorical])
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -3,7 +3,6 @@ import pandas as pd
 from evalml.exceptions import MethodPropertyNotFoundError
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
@@ -32,19 +31,18 @@ class FeatureSelector(Transformer):
             ww.DataTable: Transformed X
         """
         X_ww = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
-        self.input_feature_names = list(X.columns.values)
+        self.input_feature_names = list(X_ww.columns.values)
 
         try:
             X_t = self._component_obj.transform(X)
         except AttributeError:
             raise MethodPropertyNotFoundError("Feature selector requires a transform method or a component_obj that implements transform")
 
-        X_dtypes = X.dtypes.to_dict()
+        X_dtypes = X_ww.dtypes.to_dict()
         selected_col_names = self.get_names()
         col_types = {key: X_dtypes[key] for key in selected_col_names}
-        features = pd.DataFrame(X_t, columns=selected_col_names, index=X.index).astype(col_types)
-        return _retain_custom_types_and_initalize_woodwork(X_ww, features)
+        features = pd.DataFrame(X_t, columns=selected_col_names, index=X_ww.index).astype(col_types)
+        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, features)
 
     def fit_transform(self, X, y=None):
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -24,11 +24,11 @@ class FeatureSelector(Transformer):
         """Transforms input data by selecting features. If the component_obj does not have a transform method, will raise an MethodPropertyNotFoundError exception.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform.
-            y (ww.DataColumn, pd.Series, optional): Target data. Ignored.
+            X (pd.DataFrame): Data to transform.
+            y (pd.Series, optional): Target data. Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         self.input_feature_names = list(X_ww.columns.values)

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -58,8 +58,8 @@ class Imputer(Transformer):
             treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, optional): The target training data of length [n_samples]
+            X (pd.DataFrame, np.ndarray): The input training data of shape [n_samples, n_features]
+            y (pd.Series, optional): The target training data of length [n_samples]
 
         Returns:
             self
@@ -87,11 +87,11 @@ class Imputer(Transformer):
             treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): Data to transform
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         X_null_dropped = X_ww.ww.drop(self._all_null_cols)

--- a/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
@@ -47,8 +47,8 @@ class PerColumnImputer(Transformer):
         """Fits imputers on input data
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features] to fit.
-            y (ww.DataColumn, pd.Series, optional): The target training data of length [n_samples]. Ignored.
+            X (pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features] to fit.
+            y (pd.Series, optional): The target training data of length [n_samples]. Ignored.
 
         Returns:
             self
@@ -70,14 +70,14 @@ class PerColumnImputer(Transformer):
         """Transforms input data by imputing missing values.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features] to transform.
-            y (ww.DataColumn, pd.Series, optional): The target training data of length [n_samples]. Ignored.
+            X (pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features] to transform.
+            y (pd.Series, optional): The target training data of length [n_samples]. Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
-        original_logical_types = {col: value for col, value in X_ww.ww.logical_types.items()}
+        original_logical_types = X_ww.ww.schema.logical_types
 
         cols_to_drop = []
         for column, imputer in self.imputers.items():

--- a/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
@@ -77,6 +77,8 @@ class PerColumnImputer(Transformer):
             ww.DataTable: Transformed X
         """
         X_ww = infer_feature_types(X)
+        original_logical_types = {col: value for col, value in X_ww.ww.logical_types.items()}
+
         cols_to_drop = []
         for column, imputer in self.imputers.items():
             transformed = imputer.transform(X_ww[[column]])
@@ -85,4 +87,4 @@ class PerColumnImputer(Transformer):
             else:
                 X_ww.ww[column] = transformed[column]
         X_t = X_ww.ww.drop(cols_to_drop)
-        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, X_t)
+        return _retain_custom_types_and_initalize_woodwork(original_logical_types, X_t)

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from sklearn.impute import SimpleImputer as SkImputer
+from woodwork.logical_types import NaturalLanguage
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
@@ -47,6 +48,9 @@ class SimpleImputer(Transformer):
         """
         X = infer_feature_types(X)
 
+        # Not using select because we just need column names, not a new dataframe
+        X.ww.set_types({col: "Categorical" for col, ltype in X.ww.logical_types.items() if ltype == NaturalLanguage})
+
         # Convert all bool dtypes to category for fitting
         if (X.dtypes == bool).all():
             X = X.astype('category')
@@ -66,20 +70,24 @@ class SimpleImputer(Transformer):
             ww.DataTable: Transformed X
         """
         X_ww = infer_feature_types(X)
+        original_logical_types = {col: value for col, value in X_ww.ww.logical_types.items()}
 
         # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
         if (X_ww.dtypes == bool).all():
             return X_ww
 
         X_null_dropped = X_ww.ww.drop(self._all_null_cols)
+
+        # Not using select because we just need column names, not a new dataframe
+        X_ww.ww.set_types({col: "Categorical" for col, ltype in X_ww.ww.logical_types.items() if ltype == NaturalLanguage})
+
         X_t = self._component_obj.transform(X_ww)
 
-        # Need this for test_simple_imputer_multitype_with_one_bool
         X_t = pd.DataFrame(X_t, columns=X_null_dropped.columns)
         if not X_null_dropped.empty:
             X_t.index = X_null_dropped.index
 
-        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, X_t)
+        return _retain_custom_types_and_initalize_woodwork(original_logical_types, X_t)
 
     def fit_transform(self, X, y=None):
         """Fits on X and transforms X

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -40,8 +40,8 @@ class SimpleImputer(Transformer):
             treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): the input training data of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, optional): the target training data of length [n_samples]
+            X (pd.DataFrame or np.ndarray): the input training data of shape [n_samples, n_features]
+            y (pd.Series, optional): the target training data of length [n_samples]
 
         Returns:
             self
@@ -49,7 +49,10 @@ class SimpleImputer(Transformer):
         X = infer_feature_types(X)
 
         # Not using select because we just need column names, not a new dataframe
-        X.ww.set_types({col: "Categorical" for col, ltype in X.ww.logical_types.items() if ltype == NaturalLanguage})
+        natural_language_columns = [col for col, ltype in X.ww.logical_types.items() if ltype == NaturalLanguage]
+        if natural_language_columns:
+            X = X.ww.copy()
+            X.ww.set_types({col: "Categorical" for col in natural_language_columns})
 
         # Convert all bool dtypes to category for fitting
         if (X.dtypes == bool).all():
@@ -63,14 +66,14 @@ class SimpleImputer(Transformer):
         """Transforms input by imputing missing values. 'None' and np.nan values are treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): Data to transform
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
-        original_logical_types = {col: value for col, value in X_ww.ww.logical_types.items()}
+        original_logical_types = X_ww.ww.schema.logical_types
 
         # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
         if (X_ww.dtypes == bool).all():
@@ -93,10 +96,10 @@ class SimpleImputer(Transformer):
         """Fits on X and transforms X
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to fit and transform
-            y (ww.DataColumn, pd.Series, optional): Target data.
+            X (pd.DataFrame): Data to fit and transform
+            y (pd.Series, optional): Target data.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -3,7 +3,6 @@ from sklearn.impute import SimpleImputer as SkImputer
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
@@ -47,7 +46,6 @@ class SimpleImputer(Transformer):
             self
         """
         X = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
 
         # Convert all bool dtypes to category for fitting
         if (X.dtypes == bool).all():
@@ -68,22 +66,20 @@ class SimpleImputer(Transformer):
             ww.DataTable: Transformed X
         """
         X_ww = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
 
         # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
-        if (X.dtypes == bool).all():
-            return infer_feature_types(X)
+        if (X_ww.dtypes == bool).all():
+            return X_ww
 
-        X_null_dropped = X.copy()
-        X_null_dropped.drop(self._all_null_cols, axis=1, errors='ignore', inplace=True)
-        X_t = self._component_obj.transform(X)
-        if X_null_dropped.empty:
-            X_t = pd.DataFrame(X_t, columns=X_null_dropped.columns)
-            return infer_feature_types(X_t)
+        X_null_dropped = X_ww.ww.drop(self._all_null_cols)
+        X_t = self._component_obj.transform(X_ww)
 
+        # Need this for test_simple_imputer_multitype_with_one_bool
         X_t = pd.DataFrame(X_t, columns=X_null_dropped.columns)
-        X_t.index = X_null_dropped.index
-        return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)
+        if not X_null_dropped.empty:
+            X_t.index = X_null_dropped.index
+
+        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, X_t)
 
     def fit_transform(self, X, y=None):
         """Fits on X and transforms X

--- a/evalml/pipelines/components/transformers/imputers/target_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/target_imputer.py
@@ -60,8 +60,8 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
             treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]. Ignored.
-            y (ww.DataColumn, pd.Series, optional): The target training data of length [n_samples].
+            X (pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]. Ignored.
+            y (pd.Series, optional): The target training data of length [n_samples].
 
         Returns:
             self
@@ -81,11 +81,11 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
         """Transforms input target data by imputing missing values. 'None' and np.nan values are treated as the same.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features. Ignored.
-            y (ww.DataColumn, pd.Series): Target data to impute.
+            X (pd.DataFrame): Features. Ignored.
+            y (pd.Series): Target data to impute.
 
         Returns:
-            (ww.DataTable, ww.DataColumn): The original X, transformed y
+            (pd.DataFrame, pd.Series): The original X, transformed y
         """
 
         if X is not None:
@@ -109,10 +109,10 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
         """Fits on and transforms the input target data.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features. Ignored.
-            y (ww.DataColumn, pd.Series): Target data to impute.
+            X (pd.DataFrame): Features. Ignored.
+            y (pd.Series): Target data to impute.
 
         Returns:
-            (ww.DataTable, ww.DataColumn): The original X, transformed y
+            (pd.DataFrame, pd.Series): The original X, transformed y
         """
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
@@ -94,7 +94,6 @@ class DateTimeFeaturizer(Transformer):
             for feature in features_to_extract:
                 name = f"{col_name}_{feature}"
                 features, categories = self._function_mappings[feature](X_ww[col_name], self.encode_as_categories)
-                features.name = None
                 X_ww.ww[name] = features
                 if categories:
                     self._categories[name] = categories

--- a/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
@@ -80,11 +80,11 @@ class DateTimeFeaturizer(Transformer):
         """Transforms data X by creating new features using existing DateTime columns, and then dropping those DateTime columns
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): Data to transform
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         features_to_extract = self.parameters["features_to_extract"]

--- a/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
@@ -4,9 +4,7 @@ from sklearn.preprocessing import LabelEncoder, OrdinalEncoder
 from woodwork import logical_types
 
 from evalml.pipelines.components.transformers.transformer import Transformer
-from evalml.utils import (
-    infer_feature_types
-)
+from evalml.utils import infer_feature_types
 
 
 class DelayedFeatureTransformer(Transformer):

--- a/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
@@ -1,10 +1,11 @@
+import copy
+
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder, OrdinalEncoder
 from woodwork import logical_types
 
 from evalml.pipelines.components.transformers.transformer import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
@@ -55,14 +56,13 @@ class DelayedFeatureTransformer(Transformer):
 
     @staticmethod
     def _encode_y_while_preserving_index(y):
-        original_y = _convert_woodwork_types_wrapper(y.to_series())
-        y_encoded = LabelEncoder().fit_transform(original_y)
-        y = pd.Series(y_encoded, index=original_y.index)
+        y_encoded = LabelEncoder().fit_transform(y)
+        y = pd.Series(y_encoded, index=y.index)
         return y
 
     @staticmethod
     def _get_categorical_columns(X):
-        return [name for name, column in X.columns.items() if column.logical_type == logical_types.Categorical]
+        return [name for name, column in X.ww.columns.items() if column.logical_type == logical_types.Categorical]
 
     @staticmethod
     def _encode_X_while_preserving_index(X_categorical):
@@ -90,26 +90,24 @@ class DelayedFeatureTransformer(Transformer):
             X = pd.DataFrame()
         # Normalize the data into pandas objects
         X_ww = infer_feature_types(X)
+        original_logical_types = copy.deepcopy(X_ww.ww.logical_types)
         categorical_columns = self._get_categorical_columns(X_ww)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         if self.delay_features and len(X) > 0:
-            X_categorical = self._encode_X_while_preserving_index(X[categorical_columns])
-            for col_name in X:
-                col = X[col_name]
+            X_categorical = self._encode_X_while_preserving_index(X_ww[categorical_columns])
+            for col_name in X_ww:
+                col = X_ww[col_name]
                 if col_name in categorical_columns:
                     col = X_categorical[col_name]
-                X = X.assign(**{f"{col_name}_delay_{t}": col.shift(t) for t in range(1, self.max_delay + 1)})
+                X_ww = X_ww.assign(**{f"{col_name}_delay_{t}": col.shift(t) for t in range(1, self.max_delay + 1)})
         # Handle cases where the target was passed in
         if self.delay_target and y is not None:
             y = infer_feature_types(y)
-            if y.logical_type == logical_types.Categorical:
+            if y.ww.logical_type == logical_types.Categorical:
                 y = self._encode_y_while_preserving_index(y)
-            else:
-                y = _convert_woodwork_types_wrapper(y.to_series())
-            X = X.assign(**{f"target_delay_{t}": y.shift(t)
-                            for t in range(self.start_delay_for_target, self.max_delay + 1)})
+            X_ww = X_ww.assign(**{f"target_delay_{t}": y.shift(t)
+                                  for t in range(self.start_delay_for_target, self.max_delay + 1)})
 
-        return _retain_custom_types_and_initalize_woodwork(X_ww, X)
+        return _retain_custom_types_and_initalize_woodwork(original_logical_types, X_ww)
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
@@ -1,4 +1,3 @@
-import copy
 
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder, OrdinalEncoder
@@ -6,7 +5,6 @@ from woodwork import logical_types
 
 from evalml.pipelines.components.transformers.transformer import Transformer
 from evalml.utils import (
-    _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
 
@@ -90,7 +88,6 @@ class DelayedFeatureTransformer(Transformer):
             X = pd.DataFrame()
         # Normalize the data into pandas objects
         X_ww = infer_feature_types(X)
-        original_logical_types = copy.deepcopy(X_ww.ww.logical_types)
         categorical_columns = self._get_categorical_columns(X_ww)
         if self.delay_features and len(X) > 0:
             X_categorical = self._encode_X_while_preserving_index(X_ww[categorical_columns])
@@ -98,16 +95,17 @@ class DelayedFeatureTransformer(Transformer):
                 col = X_ww[col_name]
                 if col_name in categorical_columns:
                     col = X_categorical[col_name]
-                X_ww = X_ww.assign(**{f"{col_name}_delay_{t}": col.shift(t) for t in range(1, self.max_delay + 1)})
+                for t in range(1, self.max_delay + 1):
+                    X_ww.ww[f"{col_name}_delay_{t}"] = col.shift(t)
         # Handle cases where the target was passed in
         if self.delay_target and y is not None:
             y = infer_feature_types(y)
             if y.ww.logical_type == logical_types.Categorical:
                 y = self._encode_y_while_preserving_index(y)
-            X_ww = X_ww.assign(**{f"target_delay_{t}": y.shift(t)
-                                  for t in range(self.start_delay_for_target, self.max_delay + 1)})
+            for t in range(self.start_delay_for_target, self.max_delay + 1):
+                X_ww.ww[f"target_delay_{t}"] = y.shift(t)
 
-        return _retain_custom_types_and_initalize_woodwork(original_logical_types, X_ww)
+        return X_ww
 
     def fit_transform(self, X, y):
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
@@ -42,8 +42,8 @@ class DelayedFeatureTransformer(Transformer):
         """Fits the DelayFeatureTransformer.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, optional): The target training data of length [n_samples]
+            X (pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
+            y (pd.Series, optional): The target training data of length [n_samples]
 
         Returns:
             self
@@ -76,11 +76,11 @@ class DelayedFeatureTransformer(Transformer):
         If y is not None, it will also compute the delayed values for the target variable.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or None): Data to transform. None is expected when only the target variable is being used.
-            y (ww.DataColumn, pd.Series, or None): Target.
+            X (pd.DataFrame or None): Data to transform. None is expected when only the target variable is being used.
+            y (pd.Series, or None): Target.
 
         Returns:
-            ww.DataTable: Transformed X.
+            pd.DataFrame: Transformed X.
         """
         if X is None:
             X = pd.DataFrame()

--- a/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
+++ b/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
@@ -41,11 +41,11 @@ class DropNullColumns(Transformer):
         """Transforms data X by dropping columns that exceed the threshold of null values.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): Data to transform
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_t = infer_feature_types(X)
         if len(self._cols_to_drop) == 0:

--- a/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
+++ b/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
@@ -1,5 +1,5 @@
 from evalml.pipelines.components.transformers import Transformer
-from evalml.utils import _convert_woodwork_types_wrapper, infer_feature_types
+from evalml.utils import infer_feature_types
 
 
 class DropNullColumns(Transformer):
@@ -29,7 +29,6 @@ class DropNullColumns(Transformer):
     def fit(self, X, y=None):
         pct_null_threshold = self.parameters["pct_null_threshold"]
         X_t = infer_feature_types(X)
-        X_t = _convert_woodwork_types_wrapper(X_t.to_dataframe())
         percent_null = X_t.isnull().mean()
         if pct_null_threshold == 0.0:
             null_cols = percent_null[percent_null > 0]
@@ -51,4 +50,4 @@ class DropNullColumns(Transformer):
         X_t = infer_feature_types(X)
         if len(self._cols_to_drop) == 0:
             return X_t
-        return X_t.drop(self._cols_to_drop)
+        return X_t.ww.drop(self._cols_to_drop)

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -2,7 +2,6 @@ from featuretools import EntitySet, calculate_feature_matrix, dfs
 
 from evalml.pipelines.components.transformers.transformer import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
@@ -51,7 +50,6 @@ class DFSTransformer(Transformer):
             self
         """
         X = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         X.columns = X.columns.astype(str)
         es = self._make_entity_set(X)
         self.features = dfs(entityset=es,
@@ -70,8 +68,7 @@ class DFSTransformer(Transformer):
             ww.DataTable: Feature matrix
         """
         X_ww = infer_feature_types(X)
-        X_t = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
-        X_t.columns = X_t.columns.astype(str)
-        es = self._make_entity_set(X_t)
+        X_ww = X_ww.ww.rename({col: str(col) for col in X_ww.columns})
+        es = self._make_entity_set(X_ww)
         feature_matrix = calculate_feature_matrix(features=self.features, entityset=es)
-        return _retain_custom_types_and_initalize_woodwork(X_ww, feature_matrix)
+        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, feature_matrix)

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -8,7 +8,7 @@ from evalml.utils import (
 
 
 class DFSTransformer(Transformer):
-    """Featuretools DFS component that generates features for ww.DataTables and pd.DataFrames"""
+    """Featuretools DFS component that generates features for pd.DataFrames"""
     name = "DFS Transformer"
     hyperparameter_ranges = {}
 
@@ -43,15 +43,15 @@ class DFSTransformer(Transformer):
         """Fits the DFSTransformer Transformer component.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, np.array): The input data to transform, of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, np.ndarray, optional): The target training data of length [n_samples]
+            X (pd.DataFrame, np.array): The input data to transform, of shape [n_samples, n_features]
+            y (pd.Series, np.ndarray, optional): The target training data of length [n_samples]
 
         Returns:
             self
         """
-        X = infer_feature_types(X)
-        X.columns = X.columns.astype(str)
-        es = self._make_entity_set(X)
+        X_ww = infer_feature_types(X)
+        X_ww = X_ww.ww.rename({col: str(col) for col in X_ww.columns})
+        es = self._make_entity_set(X_ww)
         self.features = dfs(entityset=es,
                             target_entity='X',
                             features_only=True)
@@ -61,11 +61,11 @@ class DFSTransformer(Transformer):
         """Computes the feature matrix for the input X using featuretools' dfs algorithm.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data to transform. Has shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame or np.ndarray): The input training data to transform. Has shape [n_samples, n_features]
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Feature matrix
+            pd.DataFrame: Feature matrix
         """
         X_ww = infer_feature_types(X)
         X_ww = X_ww.ww.rename({col: str(col) for col in X_ww.columns})

--- a/evalml/pipelines/components/transformers/preprocessing/lsa.py
+++ b/evalml/pipelines/components/transformers/preprocessing/lsa.py
@@ -41,11 +41,11 @@ class LSA(TextTransformer):
         """Transforms data X by applying the LSA pipeline.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): The data to transform.
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): The data to transform.
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X. The original column is removed and replaced with two columns of the
+            pd.DataFrame: Transformed X. The original column is removed and replaced with two columns of the
                           format `LSA(original_column_name)[feature_number]`, where `feature_number` is 0 or 1.
         """
         X_ww = infer_feature_types(X)

--- a/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
+++ b/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
@@ -42,8 +42,8 @@ class PolynomialDetrender(Transformer):
         """Fits the PolynomialDetrender.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, optional): Ignored.
-            y (ww.DataColumn, pd.Series): Target variable to detrend.
+            X (pd.DataFrame, optional): Ignored.
+            y (pd.Series): Target variable to detrend.
 
         Returns:
             self
@@ -58,29 +58,29 @@ class PolynomialDetrender(Transformer):
         """Removes fitted trend from target variable.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, optional): Ignored.
-            y (ww.DataColumn, pd.Series): Target variable to detrend.
+            X (pd.DataFrame, optional): Ignored.
+            y (pd.Series): Target variable to detrend.
 
         Returns:
-            tuple of ww.DataTable, ww.DataColumn: The input features are returned without modification. The target
+            tuple of pd.DataFrame, pd.Series: The input features are returned without modification. The target
                 variable y is detrended
         """
         if y is None:
             return X, y
-        y_dt = infer_feature_types(y)
-        y_t = self._component_obj.transform(y_dt)
-        y_t = infer_feature_types(pd.Series(y_t, index=y_dt.index))
+        y_ww = infer_feature_types(y)
+        y_t = self._component_obj.transform(y_ww)
+        y_t = infer_feature_types(pd.Series(y_t, index=y_ww.index))
         return X, y_t
 
     def fit_transform(self, X, y=None):
         """Removes fitted trend from target variable.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, optional): Ignored.
-            y (ww.DataColumn, pd.Series): Target variable to detrend.
+            X (pd.DataFrame, optional): Ignored.
+            y (pd.Series): Target variable to detrend.
 
         Returns:
-            tuple of ww.DataTable, ww.DataColumn: The first element are the input features returned without modification.
+            tuple of pd.DataFrame, pd.Series: The first element are the input features returned without modification.
                 The second element is the target variable y with the fitted trend removed.
         """
         return self.fit(X, y).transform(X, y)
@@ -89,11 +89,11 @@ class PolynomialDetrender(Transformer):
         """Adds back fitted trend to target variable.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame, optional): Ignored.
-            y (ww.DataColumn, pd.Series): Target variable.
+            X (pd.DataFrame, optional): Ignored.
+            y (pd.Series): Target variable.
 
         Returns:
-            tuple of ww.DataTable, ww.DataColumn: The first element are the input features returned without modification.
+            tuple of pd.DataFrame, pd.Series: The first element are the input features returned without modification.
                 The second element is the target variable y with the trend added back.
         """
         if y is None:

--- a/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
+++ b/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
@@ -1,13 +1,8 @@
 import pandas as pd
-import woodwork as ww
 from skopt.space import Integer
 
 from evalml.pipelines.components.transformers.transformer import Transformer
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    import_or_raise,
-    infer_feature_types
-)
+from evalml.utils import import_or_raise, infer_feature_types
 
 
 class PolynomialDetrender(Transformer):
@@ -56,8 +51,7 @@ class PolynomialDetrender(Transformer):
         if y is None:
             raise ValueError("y cannot be None for PolynomialDetrender!")
         y_dt = infer_feature_types(y)
-        y_series = _convert_woodwork_types_wrapper(y_dt.to_series())
-        self._component_obj.fit(y_series)
+        self._component_obj.fit(y_dt)
         return self
 
     def transform(self, X, y=None):
@@ -74,9 +68,8 @@ class PolynomialDetrender(Transformer):
         if y is None:
             return X, y
         y_dt = infer_feature_types(y)
-        y_series = _convert_woodwork_types_wrapper(y_dt.to_series())
-        y_t = self._component_obj.transform(y_series)
-        y_t = ww.DataColumn(pd.Series(y_t, index=y_series.index))
+        y_t = self._component_obj.transform(y_dt)
+        y_t = infer_feature_types(pd.Series(y_t, index=y_dt.index))
         return X, y_t
 
     def fit_transform(self, X, y=None):
@@ -106,7 +99,6 @@ class PolynomialDetrender(Transformer):
         if y is None:
             raise ValueError("y cannot be None for PolynomialDetrender!")
         y_dt = infer_feature_types(y)
-        y_series = _convert_woodwork_types_wrapper(y_dt.to_series())
-        y_t = self._component_obj.inverse_transform(y_series)
-        y_t = ww.DataColumn(pd.Series(y_t, index=y_series.index))
+        y_t = self._component_obj.inverse_transform(y_dt)
+        y_t = infer_feature_types(pd.Series(y_t, index=y_dt.index))
         return X, y_t

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -60,8 +60,8 @@ class TextFeaturizer(TextTransformer):
         """Fits component to data
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, np.ndarray, optional): The target training data of length [n_samples]
+            X (pd.DataFrame or np.ndarray): The input training data of shape [n_samples, n_features]
+            y (pd.Series, np.ndarray, optional): The target training data of length [n_samples]
 
         Returns:
             self
@@ -97,11 +97,11 @@ class TextFeaturizer(TextTransformer):
         """Transforms data X by creating new features using existing text columns
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): The data to transform.
-            y (ww.DataColumn, pd.Series, optional): Ignored.
+            X (pd.DataFrame): The data to transform.
+            y (pd.Series, optional): Ignored.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         if self._features is None or len(self._features) == 0:

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -2,17 +2,12 @@ import string
 
 import featuretools as ft
 import nlp_primitives
-import pandas as pd
 
 from evalml.pipelines.components.transformers.preprocessing import (
     LSA,
     TextTransformer
 )
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    _retain_custom_types_and_initalize_woodwork,
-    infer_feature_types
-)
+from evalml.utils import infer_feature_types
 
 
 class TextFeaturizer(TextTransformer):
@@ -78,7 +73,6 @@ class TextFeaturizer(TextTransformer):
 
         self._lsa.fit(X)
 
-        X = _convert_woodwork_types_wrapper(X.to_dataframe())
         es = self._make_entity_set(X, self._text_columns)
         self._features = ft.dfs(entityset=es,
                                 target_entity='X',
@@ -112,16 +106,19 @@ class TextFeaturizer(TextTransformer):
         X_ww = infer_feature_types(X)
         if self._features is None or len(self._features) == 0:
             return X_ww
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
-        es = self._make_entity_set(X, self._text_columns)
+        es = self._make_entity_set(X_ww, self._text_columns)
         X_nlp_primitives = ft.calculate_feature_matrix(features=self._features, entityset=es)
         if X_nlp_primitives.isnull().any().any():
             X_nlp_primitives.fillna(0, inplace=True)
 
-        X_lsa = self._lsa.transform(X[self._text_columns]).to_dataframe()
-        X_nlp_primitives.set_index(X.index, inplace=True)
-        X_t = pd.concat([X.drop(self._text_columns, axis=1), X_nlp_primitives, X_lsa], axis=1)
-        return _retain_custom_types_and_initalize_woodwork(X_ww, X_t)
+        X_lsa = self._lsa.transform(X_ww[self._text_columns])
+        X_nlp_primitives.set_index(X_ww.index, inplace=True)
+        X_ww = X_ww.ww.drop(self._text_columns)
+        for col in X_nlp_primitives:
+            X_ww.ww[col] = X_nlp_primitives[col]
+        for col in X_lsa:
+            X_ww.ww[col] = X_lsa[col]
+        return X_ww
 
     def _get_feature_provenance(self):
         if not self._text_columns:

--- a/evalml/pipelines/components/transformers/preprocessing/text_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_transformer.py
@@ -22,6 +22,4 @@ class TextTransformer(Transformer):
 
     def _get_text_columns(self, X):
         """Returns the ordered list of columns names in the input which have been designated as text columns."""
-        text_column_vals = X.select('natural_language')
-        text_columns = list(text_column_vals.to_dataframe().columns)
-        return text_columns
+        return list(X.ww.select('NaturalLanguage').columns)

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -3,9 +3,7 @@ import copy
 from evalml.pipelines.components.transformers import Transformer
 from evalml.pipelines.components.utils import make_balancing_dictionary
 from evalml.utils import import_or_raise
-from evalml.utils.woodwork_utils import (
-    infer_feature_types
-)
+from evalml.utils.woodwork_utils import infer_feature_types
 
 
 class BaseSampler(Transformer):

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -37,7 +37,7 @@ class BaseSampler(Transformer):
         if y is None:
             raise ValueError("y cannot be none")
         y = infer_feature_types(y)
-        return X, y, X, y
+        return X, y
 
     def transform(self, X, y=None):
         """No transformation needs to be done here.
@@ -103,7 +103,7 @@ class BaseOverSampler(BaseSampler):
             y (ww.DataColumn): Target features
             sampler_class (imblearn.BaseSampler): The sampler we want to initialize
         """
-        _, _, _, y_pd = self._prepare_data(X, y)
+        _, y_pd = self._prepare_data(X, y)
         sampler_params = {k: v for k, v in copy.copy(self.parameters).items() if k != 'sampling_ratio'}
         # create the sampling dictionary
         sampling_ratio = self.parameters['sampling_ratio']
@@ -123,6 +123,6 @@ class BaseOverSampler(BaseSampler):
             ww.DataTable, ww.DataColumn: Sampled X and y data
         """
         self.fit(X, y)
-        _, _, X_pd, y_pd = self._prepare_data(X, y)
+        X_pd, y_pd = self._prepare_data(X, y)
         X_new, y_new = self._component_obj.fit_resample(X_pd, y_pd)
         return infer_feature_types(X_new), infer_feature_types(y_new)

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -13,8 +13,8 @@ class BaseSampler(Transformer):
         """Resample the data using the sampler. Since our sampler doesn't need to be fit, we do nothing here.
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
 
         Returns:
             self
@@ -27,11 +27,11 @@ class BaseSampler(Transformer):
         """Transforms the input data to pandas data structure that our sampler can ingest.
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
 
          Returns:
-            ww.DataTable, ww.DataColumn, pd.DataFrame, pd.Series: Prepared X and y data, both woodwork and pandas
+            pd.DataFrame, pd.Series: Prepared X and y data, both woodwork and pandas
         """
         X = infer_feature_types(X)
         if y is None:
@@ -43,11 +43,11 @@ class BaseSampler(Transformer):
         """No transformation needs to be done here.
 
         Arguments:
-            X (ww.DataFrame): Training features. Ignored.
-            y (ww.DataColumn): Target features. Ignored.
+            X (pd.DataFrame): Training features. Ignored.
+            y (pd.Series): Target features. Ignored.
 
         Returns:
-            ww.DataTable, ww.DataColumn: X and y data that was passed in.
+            pd.DataFrame, pd.Series: X and y data that was passed in.
         """
         X = infer_feature_types(X)
         if y is not None:
@@ -85,8 +85,8 @@ class BaseOverSampler(BaseSampler):
         """Fits the Oversampler to the data.
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
 
         Returns:
             self
@@ -99,15 +99,15 @@ class BaseOverSampler(BaseSampler):
         Otherwise, we use will create the sampler_ratio_dict dictionary.
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
             sampler_class (imblearn.BaseSampler): The sampler we want to initialize
         """
-        _, y_pd = self._prepare_data(X, y)
+        _, y_ww = self._prepare_data(X, y)
         sampler_params = {k: v for k, v in copy.copy(self.parameters).items() if k != 'sampling_ratio'}
         # create the sampling dictionary
         sampling_ratio = self.parameters['sampling_ratio']
-        dic = make_balancing_dictionary(y_pd, sampling_ratio)
+        dic = make_balancing_dictionary(y_ww, sampling_ratio)
         sampler_params['sampling_strategy'] = dic
         sampler = sampler_class(**sampler_params, random_state=self.random_seed)
         self._component_obj = sampler
@@ -116,13 +116,13 @@ class BaseOverSampler(BaseSampler):
         """Fit and transform the data using the data sampler. Used during training of the pipeline
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
 
          Returns:
-            ww.DataTable, ww.DataColumn: Sampled X and y data
+            pd.DataFrame, pd.Series: Sampled X and y data
         """
         self.fit(X, y)
-        X_pd, y_pd = self._prepare_data(X, y)
-        X_new, y_new = self._component_obj.fit_resample(X_pd, y_pd)
+        X_ww, y_ww = self._prepare_data(X, y)
+        X_new, y_new = self._component_obj.fit_resample(X_ww, y_ww)
         return infer_feature_types(X_new), infer_feature_types(y_new)

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -4,7 +4,6 @@ from evalml.pipelines.components.transformers import Transformer
 from evalml.pipelines.components.utils import make_balancing_dictionary
 from evalml.utils import import_or_raise
 from evalml.utils.woodwork_utils import (
-    _convert_woodwork_types_wrapper,
     infer_feature_types
 )
 
@@ -40,9 +39,7 @@ class BaseSampler(Transformer):
         if y is None:
             raise ValueError("y cannot be none")
         y = infer_feature_types(y)
-        X_pd = _convert_woodwork_types_wrapper(X.to_dataframe())
-        y_pd = _convert_woodwork_types_wrapper(y.to_series())
-        return X, y, X_pd, y_pd
+        return X, y, X, y
 
     def transform(self, X, y=None):
         """No transformation needs to be done here.

--- a/evalml/pipelines/components/transformers/samplers/oversamplers.py
+++ b/evalml/pipelines/components/transformers/samplers/oversamplers.py
@@ -35,7 +35,7 @@ class SMOTENCSampler(BaseOverSampler):
 
     def _get_categorical(self, X):
         X = infer_feature_types(X)
-        self.categorical_features = [i for i, val in enumerate(X.types['Logical Type'].items()) if str(val[1]) == 'Categorical']
+        self.categorical_features = [i for i, val in enumerate(X.ww.types['Logical Type'].items()) if str(val[1]) == 'Categorical']
         self._parameters['categorical_features'] = self.categorical_features
 
     def fit(self, X, y):

--- a/evalml/pipelines/components/transformers/samplers/undersampler.py
+++ b/evalml/pipelines/components/transformers/samplers/undersampler.py
@@ -41,14 +41,14 @@ class Undersampler(BaseSampler):
         """Fit and transform the data using the undersampler. Used during training of the pipeline
 
         Arguments:
-            X (ww.DataFrame): Training features
-            y (ww.DataColumn): Target features
+            X (pd.DataFrame): Training features
+            y (pd.Series): Target features
 
          Returns:
-            ww.DataTable, ww.DataColumn: Undersampled X and y data
+            pd.DataFrame, pd.Series: Undersampled X and y data
         """
-        X_pd, y_pd = self._prepare_data(X, y)
-        index_df = pd.Series(y_pd.index)
-        indices = self._component_obj.fit_resample(X_pd, y_pd)
+        X_ww, y_ww = self._prepare_data(X, y)
+        index_df = pd.Series(y_ww.index)
+        indices = self._component_obj.fit_resample(X_ww, y_ww)
         train_indices = index_df[index_df.isin(indices)].index.values.tolist()
-        return X_pd.iloc[train_indices], y_pd.iloc[train_indices]
+        return X_ww.iloc[train_indices], y_ww.iloc[train_indices]

--- a/evalml/pipelines/components/transformers/samplers/undersampler.py
+++ b/evalml/pipelines/components/transformers/samplers/undersampler.py
@@ -47,8 +47,8 @@ class Undersampler(BaseSampler):
          Returns:
             ww.DataTable, ww.DataColumn: Undersampled X and y data
         """
-        X, y, X_pd, y_pd = self._prepare_data(X, y)
+        X_pd, y_pd = self._prepare_data(X, y)
         index_df = pd.Series(y_pd.index)
         indices = self._component_obj.fit_resample(X_pd, y_pd)
         train_indices = index_df[index_df.isin(indices)].index.values.tolist()
-        return X.iloc[train_indices], y.iloc[train_indices]
+        return X_pd.iloc[train_indices], y_pd.iloc[train_indices]

--- a/evalml/pipelines/components/transformers/scalers/standard_scaler.py
+++ b/evalml/pipelines/components/transformers/scalers/standard_scaler.py
@@ -1,10 +1,9 @@
 import pandas as pd
 from sklearn.preprocessing import StandardScaler as SkScaler
-from woodwork.logical_types import Categorical, Integer
+from woodwork.logical_types import Boolean, Integer, Categorical
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (
-    _convert_woodwork_types_wrapper,
     _retain_custom_types_and_initalize_woodwork,
     infer_feature_types
 )
@@ -26,10 +25,9 @@ class StandardScaler(Transformer):
 
     def transform(self, X, y=None):
         X_ww = infer_feature_types(X)
-        X = _convert_woodwork_types_wrapper(X_ww.to_dataframe())
         X_t = self._component_obj.transform(X)
-        X_t_df = pd.DataFrame(X_t, columns=X.columns, index=X.index)
-        return _retain_custom_types_and_initalize_woodwork(X_ww, X_t_df, ltypes_to_ignore=[Integer, Categorical])
+        X_t_df = pd.DataFrame(X_t, columns=X_ww.columns, index=X_ww.index)
+        return _retain_custom_types_and_initalize_woodwork(X_ww.ww.logical_types, X_t_df, ltypes_to_ignore=[Integer, Categorical, Boolean])
 
     def fit_transform(self, X, y=None):
         return self.fit(X, y).transform(X, y)

--- a/evalml/pipelines/components/transformers/scalers/standard_scaler.py
+++ b/evalml/pipelines/components/transformers/scalers/standard_scaler.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from sklearn.preprocessing import StandardScaler as SkScaler
-from woodwork.logical_types import Boolean, Integer, Categorical
+from woodwork.logical_types import Boolean, Categorical, Integer
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import (

--- a/evalml/pipelines/components/transformers/transformer.py
+++ b/evalml/pipelines/components/transformers/transformer.py
@@ -28,11 +28,11 @@ class Transformer(ComponentBase):
         """Transforms data X.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to transform.
-            y (ww.DataColumn, pd.Series, optional): Target data.
+            X (pd.DataFrame): Data to transform.
+            y (pd.Series, optional): Target data.
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         if y is not None:
@@ -48,11 +48,11 @@ class Transformer(ComponentBase):
         """Fits on X and transforms X
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Data to fit and transform
-            y (ww.DataColumn, pd.Series): Target data
+            X (pd.DataFrame): Data to fit and transform
+            y (pd.Series): Target data
 
         Returns:
-            ww.DataTable: Transformed X
+            pd.DataFrame: Transformed X
         """
         X_ww = infer_feature_types(X)
         if y is not None:

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -147,7 +147,7 @@ class WrappedSKClassifier(BaseEstimator, ClassifierMixin):
         """Make predictions using selected features.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features
+            X (pd.DataFrame): Features
 
         Returns:
             np.ndarray: Predicted values
@@ -160,7 +160,7 @@ class WrappedSKClassifier(BaseEstimator, ClassifierMixin):
         """Make probability estimates for labels.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features
+            X (pd.DataFrame): Features
 
         Returns:
             np.ndarray: Probability estimates
@@ -188,8 +188,8 @@ class WrappedSKRegressor(BaseEstimator, RegressorMixin):
         """Fits component to data
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame or np.ndarray): the input training data of shape [n_samples, n_features]
-            y (ww.DataColumn, pd.Series, optional): the target training data of length [n_samples]
+            X (pd.DataFrame or np.ndarray): the input training data of shape [n_samples, n_features]
+            y (pd.Series, optional): the target training data of length [n_samples]
 
         Returns:
             self
@@ -201,7 +201,7 @@ class WrappedSKRegressor(BaseEstimator, RegressorMixin):
         """Make predictions using selected features.
 
         Arguments:
-            X (ww.DataTable, pd.DataFrame): Features
+            X (pd.DataFrame): Features
 
         Returns:
             np.ndarray: Predicted values

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -10,11 +10,7 @@ from evalml.pipelines.components.component_base import ComponentBase
 from evalml.pipelines.components.estimators.estimator import Estimator
 from evalml.pipelines.components.transformers.transformer import Transformer
 from evalml.problem_types import ProblemTypes, handle_problem_types
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    get_importable_subclasses,
-    get_logger
-)
+from evalml.utils import get_importable_subclasses, get_logger
 
 logger = get_logger(__file__)
 
@@ -158,7 +154,7 @@ class WrappedSKClassifier(BaseEstimator, ClassifierMixin):
         """
         check_is_fitted(self, 'is_fitted_')
 
-        return _convert_woodwork_types_wrapper(self.pipeline.predict(X).to_series()).to_numpy()
+        return self.pipeline.predict(X).to_numpy()
 
     def predict_proba(self, X):
         """Make probability estimates for labels.
@@ -169,7 +165,7 @@ class WrappedSKClassifier(BaseEstimator, ClassifierMixin):
         Returns:
             np.ndarray: Probability estimates
         """
-        return _convert_woodwork_types_wrapper(self.pipeline.predict_proba(X).to_dataframe()).to_numpy()
+        return self.pipeline.predict_proba(X).to_numpy()
 
 
 class WrappedSKRegressor(BaseEstimator, RegressorMixin):
@@ -210,7 +206,7 @@ class WrappedSKRegressor(BaseEstimator, RegressorMixin):
         Returns:
             np.ndarray: Predicted values
         """
-        return self.pipeline.predict(X).to_series().to_numpy()
+        return self.pipeline.predict(X).to_numpy()
 
 
 def scikit_learn_wrapped_estimator(evalml_obj):

--- a/evalml/tests/component_tests/test_baseline_classifier.py
+++ b/evalml/tests/component_tests/test_baseline_classifier.py
@@ -37,14 +37,14 @@ def test_baseline_binary_mode(data_type, make_data_type):
     fitted = clf.fit(X, y)
     assert isinstance(fitted, BaselineClassifier)
     assert clf.classes_ == [10, 11]
-    expected_predictions = pd.Series(np.array([10] * X.shape[0]), dtype="Int64")
+    expected_predictions = pd.Series(np.array([10] * X.shape[0]), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (X.shape[0], 2)
     expected_predictions_proba = pd.DataFrame({10: [1., 1., 1., 1.], 11: [0., 0., 0., 0.]})
-    assert_frame_equal(expected_predictions_proba, predicted_proba.to_dataframe())
+    assert_frame_equal(expected_predictions_proba, predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
@@ -56,14 +56,14 @@ def test_baseline_binary_random(X_y_binary):
     clf.fit(X, y)
     assert clf.classes_ == [0, 1]
 
-    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X)), dtype="Int64")
+    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X)), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 2)
     expected_predictions_proba = pd.DataFrame(np.array([[0.5 for i in range(len(values))]] * len(X)))
-    assert_frame_equal(expected_predictions_proba, predicted_proba.to_dataframe())
+    assert_frame_equal(expected_predictions_proba, predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
@@ -78,14 +78,14 @@ def test_baseline_binary_random_weighted(X_y_binary):
     clf.fit(X, y)
 
     assert clf.classes_ == [0, 1]
-    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X), p=percent_freq), dtype="Int64")
+    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X), p=percent_freq), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 2)
     expected_predictions_proba = pd.DataFrame(np.array([[percent_freq[i] for i in range(len(values))]] * len(X)))
-    assert_frame_equal(expected_predictions_proba, predicted_proba.to_dataframe())
+    assert_frame_equal(expected_predictions_proba, predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
@@ -98,13 +98,13 @@ def test_baseline_multiclass_mode():
 
     assert clf.classes_ == [10, 11, 12]
     predictions = clf.predict(X)
-    expected_predictions = pd.Series([11] * len(X), dtype="Int64")
-    assert_series_equal(expected_predictions, predictions.to_series())
+    expected_predictions = pd.Series([11] * len(X), dtype="int64")
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 3)
     expected_predictions_proba = pd.DataFrame({10: [0., 0., 0., 0.], 11: [1., 1., 1., 1.], 12: [0., 0., 0., 0.]})
-    assert_frame_equal(expected_predictions_proba, predicted_proba.to_dataframe())
+    assert_frame_equal(expected_predictions_proba, predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
@@ -116,13 +116,13 @@ def test_baseline_multiclass_random(X_y_multi):
     clf.fit(X, y)
 
     assert clf.classes_ == [0, 1, 2]
-    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X)), dtype="Int64")
+    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X)), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 3)
-    assert_frame_equal(pd.DataFrame(np.array([[1. / 3 for i in range(len(values))]] * len(X))), predicted_proba.to_dataframe())
+    assert_frame_equal(pd.DataFrame(np.array([[1. / 3 for i in range(len(values))]] * len(X))), predicted_proba)
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
 
@@ -135,13 +135,13 @@ def test_baseline_multiclass_random_weighted(X_y_multi):
     clf.fit(X, y)
 
     assert clf.classes_ == [0, 1, 2]
-    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X), p=percent_freq), dtype="Int64")
+    expected_predictions = pd.Series(get_random_state(0).choice(np.unique(y), len(X), p=percent_freq), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 3)
-    assert_frame_equal(pd.DataFrame(np.array([[percent_freq[i] for i in range(len(values))]] * len(X))), predicted_proba.to_dataframe())
+    assert_frame_equal(pd.DataFrame(np.array([[percent_freq[i] for i in range(len(values))]] * len(X))), predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
@@ -153,12 +153,12 @@ def test_baseline_no_mode():
     clf.fit(X, y)
 
     assert clf.classes_ == [0, 1, 2]
-    expected_predictions = pd.Series([0] * len(X), dtype="Int64")
+    expected_predictions = pd.Series([0] * len(X), dtype="int64")
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
 
     predicted_proba = clf.predict_proba(X)
     assert predicted_proba.shape == (len(X), 3)
-    assert_frame_equal(pd.DataFrame(np.array([[1.0 if i == 0 else 0.0 for i in range(3)]] * len(X))), predicted_proba.to_dataframe())
+    assert_frame_equal(pd.DataFrame(np.array([[1.0 if i == 0 else 0.0 for i in range(3)]] * len(X))), predicted_proba)
 
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))

--- a/evalml/tests/component_tests/test_baseline_regressor.py
+++ b/evalml/tests/component_tests/test_baseline_regressor.py
@@ -34,7 +34,7 @@ def test_baseline_mean(X_y_regression):
 
     expected_predictions = pd.Series([mean] * len(X))
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
 
@@ -46,5 +46,5 @@ def test_baseline_median(X_y_regression):
 
     expected_predictions = pd.Series([median] * len(X))
     predictions = clf.predict(X)
-    assert_series_equal(expected_predictions, predictions.to_series())
+    assert_series_equal(expected_predictions, predictions)
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))

--- a/evalml/tests/component_tests/test_column_selector_transformers.py
+++ b/evalml/tests/component_tests/test_column_selector_transformers.py
@@ -25,63 +25,63 @@ def test_column_transformer_init(class_to_test):
 def test_column_transformer_empty_X(class_to_test):
     X = pd.DataFrame()
     transformer = class_to_test(columns=[])
-    assert_frame_equal(X, transformer.transform(X).to_dataframe())
+    assert_frame_equal(X, transformer.transform(X))
 
     transformer = class_to_test(columns=[])
-    assert_frame_equal(X, transformer.fit_transform(X).to_dataframe())
+    assert_frame_equal(X, transformer.fit_transform(X))
 
     transformer = class_to_test(columns=["not in data"])
     with pytest.raises(ValueError, match="'not in data' not found in input data"):
         transformer.fit(X)
 
     transformer = class_to_test(columns=list(X.columns))
-    assert transformer.transform(X).to_dataframe().empty
+    assert transformer.transform(X).empty
 
 
 @pytest.mark.parametrize("class_to_test,checking_functions",
-                         [(DropColumns, [lambda X, X_t: X_t.equals(X.astype("Int64")),
-                                         lambda X, X_t: X_t.equals(X.astype("Int64")),
-                                         lambda X, X_t: X_t.equals(X.drop(columns=["one"]).astype("Int64")),
+                         [(DropColumns, [lambda X, X_t: X_t.equals(X.astype("int64")),
+                                         lambda X, X_t: X_t.equals(X.astype("int64")),
+                                         lambda X, X_t: X_t.equals(X.drop(columns=["one"]).astype("int64")),
                                          lambda X, X_t: X_t.empty]),
                           (SelectColumns, [lambda X, X_t: X_t.empty,
                                            lambda X, X_t: X_t.empty,
-                                           lambda X, X_t: X_t.equals(X[["one"]].astype("Int64")),
-                                           lambda X, X_t: X_t.equals(X.astype("Int64"))])
+                                           lambda X, X_t: X_t.equals(X[["one"]].astype("int64")),
+                                           lambda X, X_t: X_t.equals(X.astype("int64"))])
                           ])
 def test_column_transformer_transform(class_to_test, checking_functions):
     X = pd.DataFrame({'one': [1, 2, 3, 4], 'two': [2, 3, 4, 5], 'three': [1, 2, 3, 4]})
     check1, check2, check3, check4 = checking_functions
 
     transformer = class_to_test(columns=None)
-    assert check1(X, transformer.transform(X).to_dataframe())
+    assert check1(X, transformer.transform(X))
 
     transformer = class_to_test(columns=[])
-    assert check2(X, transformer.transform(X).to_dataframe())
+    assert check2(X, transformer.transform(X))
 
     transformer = class_to_test(columns=["one"])
-    assert check3(X, transformer.transform(X).to_dataframe())
+    assert check3(X, transformer.transform(X))
 
     transformer = class_to_test(columns=list(X.columns))
-    assert check4(X, transformer.transform(X).to_dataframe())
+    assert check4(X, transformer.transform(X))
 
 
 @pytest.mark.parametrize("class_to_test,checking_functions",
-                         [(DropColumns, [lambda X, X_t: X_t.equals(X.astype("Int64")),
-                                         lambda X, X_t: X_t.equals(X.drop(columns=["one"]).astype("Int64")),
+                         [(DropColumns, [lambda X, X_t: X_t.equals(X.astype("int64")),
+                                         lambda X, X_t: X_t.equals(X.drop(columns=["one"]).astype("int64")),
                                          lambda X, X_t: X_t.empty]),
                           (SelectColumns, [lambda X, X_t: X_t.empty,
-                                           lambda X, X_t: X_t.equals(X[["one"]].astype("Int64")),
-                                           lambda X, X_t: X_t.equals(X.astype("Int64"))])
+                                           lambda X, X_t: X_t.equals(X[["one"]].astype("int64")),
+                                           lambda X, X_t: X_t.equals(X.astype("int64"))])
                           ])
 def test_column_transformer_fit_transform(class_to_test, checking_functions):
     X = pd.DataFrame({'one': [1, 2, 3, 4], 'two': [2, 3, 4, 5], 'three': [1, 2, 3, 4]})
     check1, check2, check3 = checking_functions
 
-    assert check1(X, class_to_test(columns=[]).fit_transform(X).to_dataframe())
+    assert check1(X, class_to_test(columns=[]).fit_transform(X))
 
-    assert check2(X, class_to_test(columns=["one"]).fit_transform(X).to_dataframe())
+    assert check2(X, class_to_test(columns=["one"]).fit_transform(X))
 
-    assert check3(X, class_to_test(columns=list(X.columns)).fit_transform(X).to_dataframe())
+    assert check3(X, class_to_test(columns=list(X.columns)).fit_transform(X))
 
 
 @pytest.mark.parametrize("class_to_test", [DropColumns, SelectColumns])
@@ -106,11 +106,11 @@ def test_drop_column_transformer_input_invalid_col_name(class_to_test):
 
 
 @pytest.mark.parametrize("class_to_test,answers",
-                         [(DropColumns, [pd.DataFrame([[0, 2, 3], [4, 6, 7], [8, 10, 11]], columns=[0, 2, 3], dtype="Int64"),
+                         [(DropColumns, [pd.DataFrame([[0, 2, 3], [4, 6, 7], [8, 10, 11]], columns=[0, 2, 3], dtype="int64"),
                                          pd.DataFrame([[], [], []], dtype="Int64"),
-                                         pd.DataFrame(np.arange(12).reshape(3, 4), dtype="Int64")]),
-                          (SelectColumns, [pd.DataFrame([[1], [5], [9]], columns=[1], dtype="Int64"),
-                                           pd.DataFrame(np.arange(12).reshape(3, 4), dtype="Int64"),
+                                         pd.DataFrame(np.arange(12).reshape(3, 4), dtype="int64")]),
+                          (SelectColumns, [pd.DataFrame([[1], [5], [9]], columns=[1], dtype="int64"),
+                                           pd.DataFrame(np.arange(12).reshape(3, 4), dtype="int64"),
                                            pd.DataFrame([[], [], []], dtype="Int64")])
                           ])
 def test_column_transformer_int_col_names_np_array(class_to_test, answers):
@@ -118,10 +118,10 @@ def test_column_transformer_int_col_names_np_array(class_to_test, answers):
     answer1, answer2, answer3 = answers
 
     transformer = class_to_test(columns=[1])
-    assert_frame_equal(answer1, transformer.transform(X).to_dataframe())
+    assert_frame_equal(answer1, transformer.transform(X))
 
     transformer = class_to_test(columns=[0, 1, 2, 3])
-    assert_frame_equal(answer2, transformer.transform(X).to_dataframe())
+    assert_frame_equal(answer2, transformer.transform(X))
 
     transformer = class_to_test(columns=[])
-    assert_frame_equal(answer3, transformer.transform(X).to_dataframe())
+    assert_frame_equal(answer3, transformer.transform(X))

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -440,11 +440,16 @@ def test_component_parameters_getter(test_classes):
 def test_component_parameters_init(logistic_regression_binary_pipeline_class,
                                    linear_regression_pipeline_class):
     for component_class in all_components():
+        if component_class in {StackedEnsembleClassifier, StackedEnsembleRegressor}:
+            continue
         print('Testing component {}'.format(component_class.name))
         try:
             component = component_class()
         except EnsembleMissingPipelinesError:
-            continue
+            if component_class == StackedEnsembleClassifier:
+                component = component_class(input_pipelines=[logistic_regression_binary_pipeline_class(parameters={})])
+            elif component_class == StackedEnsembleRegressor:
+                component = component_class(input_pipelines=[linear_regression_pipeline_class(parameters={})])
         parameters = component.parameters
 
         component2 = component_class(**parameters)
@@ -875,7 +880,7 @@ def test_estimators_accept_all_kwargs(estimator_class,
                                       logistic_regression_binary_pipeline_class,
                                       linear_regression_pipeline_class):
     if estimator_class in {StackedEnsembleClassifier, StackedEnsembleRegressor}:
-        pytest.skip("Skipping stacked ensemble tests because pipelines not updated yet.")
+        pytest.skip("Skipping stacked ensemble tests because pipelines  yet.")
     try:
         estimator = estimator_class()
     except EnsembleMissingPipelinesError:

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -880,7 +880,7 @@ def test_estimators_accept_all_kwargs(estimator_class,
                                       logistic_regression_binary_pipeline_class,
                                       linear_regression_pipeline_class):
     if estimator_class in {StackedEnsembleClassifier, StackedEnsembleRegressor}:
-        pytest.skip("Skipping stacked ensemble tests because pipelines  yet.")
+        pytest.skip("Skipping stacked ensemble tests because pipelines not updated yet.")
     try:
         estimator = estimator_class()
     except EnsembleMissingPipelinesError:

--- a/evalml/tests/component_tests/test_datetime_featurizer.py
+++ b/evalml/tests/component_tests/test_datetime_featurizer.py
@@ -162,7 +162,7 @@ def test_datetime_featurizer_woodwork_custom_overrides_returned_by_components(wi
         X_df['datetime col'] = pd.to_datetime(['20200101', '20200519', '20190607'], format='%Y%m%d')
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except (ww.exceptions.TypeConversionError, TypeError):
             continue

--- a/evalml/tests/component_tests/test_datetime_featurizer.py
+++ b/evalml/tests/component_tests/test_datetime_featurizer.py
@@ -3,13 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Categorical,
-    Datetime,
-    Double,
-    Integer,
-    NaturalLanguage
-)
+from woodwork.logical_types import Integer, Categorical, Datetime, Double, NaturalLanguage
 
 from evalml.pipelines.components import DateTimeFeaturizer
 
@@ -32,14 +26,14 @@ def test_datetime_featurizer_encodes_as_ints():
                                "2019-08-19 20:20:20", "2020-01-03 06:45:12"]})
     dt = DateTimeFeaturizer()
     X_transformed_df = dt.fit_transform(X)
-    expected = pd.DataFrame({"date_year": pd.Series([2016, 2017, 2018, 2019, 2020], dtype="Int64"),
-                             "date_month": pd.Series([3, 2, 6, 7, 0], dtype="Int64"),
-                             "date_day_of_week": pd.Series([0, 3, 2, 1, 5], dtype="Int64"),
-                             "date_hour": pd.Series([16, 13, 7, 20, 6], dtype="Int64")})
+    expected = pd.DataFrame({"date_year": pd.Series([2016, 2017, 2018, 2019, 2020]),
+                             "date_month": pd.Series([3, 2, 6, 7, 0]),
+                             "date_day_of_week": pd.Series([0, 3, 2, 1, 5]),
+                             "date_hour": pd.Series([16, 13, 7, 20, 6])})
     feature_names = {'date_month': {'April': 3, 'March': 2, 'July': 6, 'August': 7, 'January': 0},
                      'date_day_of_week': {'Sunday': 0, 'Wednesday': 3, 'Tuesday': 2, 'Monday': 1, 'Friday': 5}
                      }
-    assert_frame_equal(expected, X_transformed_df.to_dataframe())
+    assert_frame_equal(expected, X_transformed_df)
     assert dt.get_feature_names() == feature_names
 
     # Test that changing encode_as_categories to True only changes the dtypes but not the values
@@ -48,17 +42,17 @@ def test_datetime_featurizer_encodes_as_ints():
     expected["date_month"] = pd.Categorical([3, 2, 6, 7, 0])
     expected["date_day_of_week"] = pd.Categorical([0, 3, 2, 1, 5])
 
-    assert_frame_equal(expected, X_transformed_df.to_dataframe())
+    assert_frame_equal(expected, X_transformed_df)
     assert dt_with_cats.get_feature_names() == feature_names
 
     # Test that sequential calls to the same DateTimeFeaturizer work as expected by using the first dt we defined
     X = pd.DataFrame({"date": ["2020-04-10", "2017-03-15", "2019-08-19"]})
     X_transformed_df = dt.fit_transform(X)
-    expected = pd.DataFrame({"date_year": pd.Series([2020, 2017, 2019], dtype="Int64"),
-                             "date_month": pd.Series([3, 2, 7], dtype="Int64"),
-                             "date_day_of_week": pd.Series([5, 3, 1], dtype="Int64"),
-                             "date_hour": pd.Series([0, 0, 0], dtype="Int64")})
-    assert_frame_equal(expected, X_transformed_df.to_dataframe())
+    expected = pd.DataFrame({"date_year": pd.Series([2020, 2017, 2019]),
+                             "date_month": pd.Series([3, 2, 7]),
+                             "date_day_of_week": pd.Series([5, 3, 1]),
+                             "date_hour": pd.Series([0, 0, 0])})
+    assert_frame_equal(expected, X_transformed_df)
     assert dt.get_feature_names() == {'date_month': {'April': 3, 'March': 2, 'August': 7},
                                       'date_day_of_week': {'Friday': 5, 'Wednesday': 3, 'Monday': 1}}
 
@@ -78,10 +72,10 @@ def test_datetime_featurizer_transform():
                            'Date Col 2': pd.date_range('2020-02-03', periods=20, freq='W'),
                            'Numerical 2': [0] * 20})
     datetime_transformer.fit(X)
-    transformed_df = datetime_transformer.transform(X_test).to_dataframe()
+    transformed_df = datetime_transformer.transform(X_test)
     assert list(transformed_df.columns) == ['Numerical 1', 'Numerical 2', 'Date Col 1_year', 'Date Col 2_year']
-    assert transformed_df["Date Col 1_year"].equals(pd.Series([2020] * 20, dtype="Int64"))
-    assert transformed_df["Date Col 2_year"].equals(pd.Series([2020] * 20, dtype="Int64"))
+    assert transformed_df["Date Col 1_year"].equals(pd.Series([2020] * 20))
+    assert transformed_df["Date Col 2_year"].equals(pd.Series([2020] * 20))
     assert datetime_transformer.get_feature_names() == {}
 
 
@@ -91,10 +85,10 @@ def test_datetime_featurizer_fit_transform():
                       'Date Col 1': pd.date_range('2020-05-19', periods=20, freq='D'),
                       'Date Col 2': pd.date_range('2020-02-03', periods=20, freq='W'),
                       'Numerical 2': [0] * 20})
-    transformed_df = datetime_transformer.fit_transform(X).to_dataframe()
+    transformed_df = datetime_transformer.fit_transform(X)
     assert list(transformed_df.columns) == ['Numerical 1', 'Numerical 2', 'Date Col 1_year', 'Date Col 2_year']
-    assert transformed_df["Date Col 1_year"].equals(pd.Series([2020] * 20, dtype="Int64"))
-    assert transformed_df["Date Col 2_year"].equals(pd.Series([2020] * 20, dtype="Int64"))
+    assert transformed_df["Date Col 1_year"].equals(pd.Series([2020] * 20))
+    assert transformed_df["Date Col 2_year"].equals(pd.Series([2020] * 20))
     assert datetime_transformer.get_feature_names() == {}
 
 
@@ -114,9 +108,9 @@ def test_datetime_featurizer_no_features_to_extract():
     rng = pd.date_range('2020-02-24', periods=20, freq='D')
     X = pd.DataFrame({"date col": rng, "numerical": [0] * len(rng)})
     expected = X.copy()
-    expected["numerical"] = expected["numerical"].astype("Int64")
+    expected.ww.init()
     datetime_transformer.fit(X)
-    transformed = datetime_transformer.transform(X).to_dataframe()
+    transformed = datetime_transformer.transform(X)
     assert_frame_equal(expected, transformed)
     assert datetime_transformer.get_feature_names() == {}
 
@@ -133,9 +127,9 @@ def test_datetime_featurizer_custom_features_to_extract():
 def test_datetime_featurizer_no_datetime_cols():
     datetime_transformer = DateTimeFeaturizer(features_to_extract=["year", "month"])
     X = pd.DataFrame([[1, 3, 4], [2, 5, 2]])
-    expected = X.astype("Int64")
+    expected = X.copy()
     datetime_transformer.fit(X)
-    transformed = datetime_transformer.transform(X).to_dataframe()
+    transformed = datetime_transformer.transform(X)
     assert_frame_equal(expected, transformed)
     assert datetime_transformer.get_feature_names() == {}
 
@@ -150,7 +144,7 @@ def test_datetime_featurizer_numpy_array_input():
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.to_datetime(['20190902', '20200519', '20190607'], format='%Y%m%d')),
-                                  pd.DataFrame(pd.Series([1, 2, 3], dtype="Int64")),
+                                  pd.DataFrame(pd.Series([1, 2, 3])),
                                   pd.DataFrame(pd.Series([1., 2., 3.], dtype="float")),
                                   pd.DataFrame(pd.Series(['a', 'b', 'a'], dtype="category")),
                                   pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))])
@@ -162,26 +156,27 @@ def test_datetime_featurizer_woodwork_custom_overrides_returned_by_components(wi
         X_df['datetime col'] = pd.to_datetime(['20200101', '20200519', '20190607'], format='%Y%m%d')
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df.copy(), logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except (ww.exceptions.TypeConversionError, TypeError):
             continue
         datetime_transformer = DateTimeFeaturizer(encode_as_categories=encode_as_categories)
         datetime_transformer.fit(X)
         transformed = datetime_transformer.transform(X)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
 
         if with_datetime_col:
             if encode_as_categories:
                 datetime_col_transformed = {'datetime col_year': Integer, 'datetime col_month': Categorical, 'datetime col_day_of_week': Categorical, 'datetime col_hour': Integer}
             else:
                 datetime_col_transformed = {'datetime col_year': Integer, 'datetime col_month': Integer, 'datetime col_day_of_week': Integer, 'datetime col_hour': Integer}
-            assert all(item in transformed.logical_types.items() for item in datetime_col_transformed.items())
+            assert all(item in transformed.ww.logical_types.items() for item in datetime_col_transformed.items())
 
         if logical_type == Datetime:
             if encode_as_categories:
                 col_transformed = {'0_year': Integer, '0_month': Categorical, '0_day_of_week': Categorical, '0_hour': Integer}
             else:
                 col_transformed = {'0_year': Integer, '0_month': Integer, '0_day_of_week': Integer, '0_hour': Integer}
-            assert all(item in transformed.logical_types.items() for item in col_transformed.items())
+            assert all(item in transformed.ww.logical_types.items() for item in col_transformed.items())
         else:
-            assert transformed.logical_types[0] == logical_type
+            assert transformed.ww.logical_types[0] == logical_type

--- a/evalml/tests/component_tests/test_datetime_featurizer.py
+++ b/evalml/tests/component_tests/test_datetime_featurizer.py
@@ -3,7 +3,13 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Integer, Categorical, Datetime, Double, NaturalLanguage
+from woodwork.logical_types import (
+    Categorical,
+    Datetime,
+    Double,
+    Integer,
+    NaturalLanguage
+)
 
 from evalml.pipelines.components import DateTimeFeaturizer
 

--- a/evalml/tests/component_tests/test_decision_tree_classifier.py
+++ b/evalml/tests/component_tests/test_decision_tree_classifier.py
@@ -29,8 +29,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -48,8 +48,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_feature_importance(X_y_binary):

--- a/evalml/tests/component_tests/test_decision_tree_regressor.py
+++ b/evalml/tests/component_tests/test_decision_tree_regressor.py
@@ -27,7 +27,7 @@ def test_fit_predict(X_y_regression):
     assert isinstance(fitted, DecisionTreeRegressor)
 
     y_pred = clf.predict(X)
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
 
 
 def test_feature_importance(X_y_regression):

--- a/evalml/tests/component_tests/test_delayed_features_transformer.py
+++ b/evalml/tests/component_tests/test_delayed_features_transformer.py
@@ -2,13 +2,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Datetime,
-    Double,
-    Integer
-)
+from woodwork.logical_types import Boolean, Integer, Categorical, Datetime, Double
 
 from evalml.pipelines import DelayedFeatureTransformer
 
@@ -60,21 +54,21 @@ def test_delayed_feature_extractor_maxdelay3_gap1(encode_X_as_str, encode_y_as_s
                            "feature_delay_1": X_answer.feature.shift(1),
                            "feature_delay_2": X_answer.feature.shift(2),
                            "feature_delay_3": X_answer.feature.shift(3),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            "target_delay_2": y_answer.shift(2),
                            "target_delay_3": y_answer.shift(3)})
     if not encode_X_as_str:
-        answer["feature"] = X.feature.astype("Int64")
+        answer["feature"] = X.feature.astype("int64")
     if not encode_y_as_str:
-        answer["target_delay_0"] = y_answer.astype("Int64")
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=1).fit_transform(X=X, y=y).to_dataframe())
+        answer["target_delay_0"] = y_answer.astype("int64")
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=1).fit_transform(X=X, y=y))
 
-    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                   "target_delay_1": y_answer.shift(1),
                                   "target_delay_2": y_answer.shift(2),
                                   "target_delay_3": y_answer.shift(3)})
-    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=1).fit_transform(X=None, y=y).to_dataframe())
+    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=1).fit_transform(X=None, y=y))
 
 
 @pytest.mark.parametrize('encode_X_as_str', [True, False])
@@ -88,23 +82,23 @@ def test_delayed_feature_extractor_maxdelay5_gap1(encode_X_as_str, encode_y_as_s
                            "feature_delay_3": X_answer.feature.shift(3),
                            "feature_delay_4": X_answer.feature.shift(4),
                            "feature_delay_5": X_answer.feature.shift(5),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            "target_delay_2": y_answer.shift(2),
                            "target_delay_3": y_answer.shift(3),
                            "target_delay_4": y_answer.shift(4),
                            "target_delay_5": y_answer.shift(5)})
     if not encode_X_as_str:
-        answer["feature"] = X.feature.astype("Int64")
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=5, gap=1).fit_transform(X, y).to_dataframe())
+        answer["feature"] = X.feature.astype("int64")
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=5, gap=1).fit_transform(X, y))
 
-    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                   "target_delay_1": y_answer.shift(1),
                                   "target_delay_2": y_answer.shift(2),
                                   "target_delay_3": y_answer.shift(3),
                                   "target_delay_4": y_answer.shift(4),
                                   "target_delay_5": y_answer.shift(5)})
-    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=5, gap=1).fit_transform(X=None, y=y).to_dataframe())
+    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=5, gap=1).fit_transform(X=None, y=y))
 
 
 @pytest.mark.parametrize('encode_X_as_str', [True, False])
@@ -116,19 +110,19 @@ def test_delayed_feature_extractor_maxdelay3_gap7(encode_X_as_str, encode_y_as_s
                            "feature_delay_1": X_answer.feature.shift(1),
                            "feature_delay_2": X_answer.feature.shift(2),
                            "feature_delay_3": X_answer.feature.shift(3),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            "target_delay_2": y_answer.shift(2),
                            "target_delay_3": y_answer.shift(3)})
     if not encode_X_as_str:
-        answer["feature"] = X.feature.astype("Int64")
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X, y).to_dataframe())
+        answer["feature"] = X.feature.astype("int64")
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X, y))
 
-    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                   "target_delay_1": y_answer.shift(1),
                                   "target_delay_2": y_answer.shift(2),
                                   "target_delay_3": y_answer.shift(3)})
-    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y).to_dataframe())
+    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y))
 
 
 @pytest.mark.parametrize('encode_X_as_str', [True, False])
@@ -142,19 +136,19 @@ def test_delayed_feature_extractor_numpy(encode_X_as_str, encode_y_as_str, delay
                            "0_delay_1": X_answer.feature.shift(1),
                            "0_delay_2": X_answer.feature.shift(2),
                            "0_delay_3": X_answer.feature.shift(3),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            "target_delay_2": y_answer.shift(2),
                            "target_delay_3": y_answer.shift(3)})
     if not encode_X_as_str:
-        answer[0] = X.feature.astype("Int64")
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X_np, y_np).to_dataframe())
+        answer[0] = X.feature.astype("int64")
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X_np, y_np))
 
-    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                   "target_delay_1": y_answer.shift(1),
                                   "target_delay_2": y_answer.shift(2),
                                   "target_delay_3": y_answer.shift(3)})
-    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y_np).to_dataframe())
+    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y_np))
 
 
 @pytest.mark.parametrize("delay_features,delay_target", [(False, True), (True, False), (False, False)])
@@ -169,12 +163,12 @@ def test_lagged_feature_extractor_delay_features_delay_target(encode_y_as_str, e
                                "feature_delay_1": X_answer.feature.shift(1),
                                "feature_delay_2": X_answer.feature.shift(2),
                                "feature_delay_3": X_answer.feature.shift(3),
-                               "target_delay_0": y_answer.astype("Int64"),
+                               "target_delay_0": y_answer.astype("int64"),
                                "target_delay_1": y_answer.shift(1),
                                "target_delay_2": y_answer.shift(2),
                                "target_delay_3": y_answer.shift(3)})
     if not encode_X_as_str:
-        all_delays["feature"] = X.feature.astype("Int64")
+        all_delays["feature"] = X.feature.astype("int64")
     if not delay_features:
         all_delays = all_delays.drop(columns=[c for c in all_delays.columns if "feature_" in c])
     if not delay_target:
@@ -182,7 +176,7 @@ def test_lagged_feature_extractor_delay_features_delay_target(encode_y_as_str, e
 
     transformer = DelayedFeatureTransformer(max_delay=3, gap=1,
                                             delay_features=delay_features, delay_target=delay_target)
-    assert_frame_equal(all_delays, transformer.fit_transform(X, y).to_dataframe())
+    assert_frame_equal(all_delays, transformer.fit_transform(X, y))
 
 
 @pytest.mark.parametrize("delay_features,delay_target", [(False, True), (True, False), (False, False)])
@@ -194,35 +188,35 @@ def test_lagged_feature_extractor_delay_target(encode_y_as_str, encode_X_as_str,
     X, X_answer, y, y_answer = encode_X_y_as_strings(X, y, encode_X_as_str, encode_y_as_str)
     answer = pd.DataFrame()
     if delay_target:
-        answer = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+        answer = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                "target_delay_1": y_answer.shift(1),
                                "target_delay_2": y_answer.shift(2),
                                "target_delay_3": y_answer.shift(3)})
 
     transformer = DelayedFeatureTransformer(max_delay=3, gap=1,
                                             delay_features=delay_features, delay_target=delay_target)
-    assert_frame_equal(answer, transformer.fit_transform(None, y).to_dataframe())
+    assert_frame_equal(answer, transformer.fit_transform(None, y))
 
 
 @pytest.mark.parametrize("gap", [0, 1, 7])
 def test_target_delay_when_gap_is_0(gap, delayed_features_data):
     X, y = delayed_features_data
-    expected = pd.DataFrame({"feature": X.feature.astype("Int64"),
+    expected = pd.DataFrame({"feature": X.feature.astype("int64"),
                              "feature_delay_1": X.feature.shift(1),
-                             "target_delay_0": y.astype("Int64"),
+                             "target_delay_0": y.astype("int64"),
                              "target_delay_1": y.shift(1)})
 
     if gap == 0:
         expected = expected.drop(columns=["target_delay_0"])
 
     transformer = DelayedFeatureTransformer(max_delay=1, gap=gap)
-    assert_frame_equal(expected, transformer.fit_transform(X, y).to_dataframe())
-    expected = pd.DataFrame({"target_delay_0": y.astype("Int64"),
+    assert_frame_equal(expected, transformer.fit_transform(X, y))
+    expected = pd.DataFrame({"target_delay_0": y.astype("int64"),
                              "target_delay_1": y.shift(1)})
 
     if gap == 0:
         expected = expected.drop(columns=["target_delay_0"])
-    assert_frame_equal(expected, transformer.fit_transform(None, y).to_dataframe())
+    assert_frame_equal(expected, transformer.fit_transform(None, y))
 
 
 @pytest.mark.parametrize('encode_X_as_str', [True, False])
@@ -240,23 +234,23 @@ def test_delay_feature_transformer_supports_custom_index(encode_X_as_str, encode
                            "feature_delay_1": X_answer.feature.shift(1),
                            "feature_delay_2": X_answer.feature.shift(2),
                            "feature_delay_3": X_answer.feature.shift(3),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            "target_delay_2": y_answer.shift(2),
                            "target_delay_3": y_answer.shift(3)}, index=pd.RangeIndex(50, 81))
     if not encode_X_as_str:
-        answer["feature"] = X.feature.astype("Int64")
+        answer["feature"] = X.feature.astype("int64")
 
     X = make_data_type(data_type, X)
     y = make_data_type(data_type, y)
 
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X, y).to_dataframe())
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X, y))
 
-    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("Int64"),
+    answer_only_y = pd.DataFrame({"target_delay_0": y_answer.astype("int64"),
                                   "target_delay_1": y_answer.shift(1),
                                   "target_delay_2": y_answer.shift(2),
                                   "target_delay_3": y_answer.shift(3)}, index=pd.RangeIndex(50, 81))
-    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y).to_dataframe())
+    assert_frame_equal(answer_only_y, DelayedFeatureTransformer(max_delay=3, gap=7).fit_transform(X=None, y=y))
 
 
 def test_delay_feature_transformer_multiple_categorical_columns(delayed_features_data):
@@ -268,22 +262,22 @@ def test_delay_feature_transformer_multiple_categorical_columns(delayed_features
                            'feature_2': X.feature_2,
                            "feature_delay_1": X_answer.feature.shift(1),
                            "feature_2_delay_1": X_answer.feature_2.shift(1),
-                           "target_delay_0": y_answer.astype("Int64"),
+                           "target_delay_0": y_answer.astype("int64"),
                            "target_delay_1": y_answer.shift(1),
                            })
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=1, gap=11).fit_transform(X, y).to_dataframe())
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=1, gap=11).fit_transform(X, y))
 
 
 def test_delay_feature_transformer_y_is_none(delayed_features_data):
     X, _ = delayed_features_data
-    answer = pd.DataFrame({"feature": X.feature.astype("Int64"),
+    answer = pd.DataFrame({"feature": X.feature.astype("int64"),
                            "feature_delay_1": X.feature.shift(1),
                            })
-    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=1, gap=11).fit_transform(X, y=None).to_dataframe())
+    assert_frame_equal(answer, DelayedFeatureTransformer(max_delay=1, gap=11).fit_transform(X, y=None))
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.to_datetime(['20190902', '20200519', '20190607'], format='%Y%m%d')),
-                                  pd.DataFrame(pd.Series([1, 2, 3], dtype="Int64")),
+                                  pd.DataFrame(pd.Series([1, 2, 3], dtype="int64")),
                                   pd.DataFrame(pd.Series([1., 2., 3.], dtype="float")),
                                   pd.DataFrame(pd.Series(['a', 'b', 'a'], dtype="category")),
                                   pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))])
@@ -293,8 +287,9 @@ def test_delay_feature_transformer_woodwork_custom_overrides_returned_by_compone
     override_types = [Integer, Double, Categorical, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
         dft = DelayedFeatureTransformer(max_delay=1, gap=11)
         if fit_transform:
@@ -302,14 +297,19 @@ def test_delay_feature_transformer_woodwork_custom_overrides_returned_by_compone
         else:
             dft.fit(X, y)
             transformed = dft.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
         if logical_type in [Integer, Double, Categorical]:
-            assert transformed.logical_types == {0: logical_type,
-                                                 '0_delay_1': Double,
-                                                 'target_delay_0': Integer,
-                                                 'target_delay_1': Double}
+            assert transformed.ww.logical_types == {0: logical_type,
+                                                    '0_delay_1': Double,
+                                                    'target_delay_0': Integer,
+                                                    'target_delay_1': Double}
+        elif logical_type == Boolean:
+            assert transformed.ww.logical_types == {0: logical_type,
+                                                    '0_delay_1': Categorical,
+                                                    'target_delay_0': Integer,
+                                                    'target_delay_1': Double}
         else:
-            assert transformed.logical_types == {0: logical_type,
-                                                 '0_delay_1': logical_type,
-                                                 'target_delay_0': Integer,
-                                                 'target_delay_1': Double}
+            assert transformed.ww.logical_types == {0: logical_type,
+                                                    '0_delay_1': logical_type,
+                                                    'target_delay_0': Integer,
+                                                    'target_delay_1': Double}

--- a/evalml/tests/component_tests/test_delayed_features_transformer.py
+++ b/evalml/tests/component_tests/test_delayed_features_transformer.py
@@ -2,7 +2,13 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Integer, Categorical, Datetime, Double
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer
+)
 
 from evalml.pipelines import DelayedFeatureTransformer
 

--- a/evalml/tests/component_tests/test_delayed_features_transformer.py
+++ b/evalml/tests/component_tests/test_delayed_features_transformer.py
@@ -293,7 +293,7 @@ def test_delay_feature_transformer_woodwork_custom_overrides_returned_by_compone
     override_types = [Integer, Double, Categorical, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_drop_null_columns_transformer.py
+++ b/evalml/tests/component_tests/test_drop_null_columns_transformer.py
@@ -38,10 +38,10 @@ def test_drop_null_transformer_transform_default_pct_null_threshold():
     drop_null_transformer = DropNullColumns()
     X = pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                       'no_null': [1, 2, 3, 4, 5]})
-    X_expected = X.astype({'lots_of_null': 'float64', 'no_null': 'Int64'})
+    X_expected = X.astype({'lots_of_null': 'float64', 'no_null': 'int64'})
     drop_null_transformer.fit(X)
     X_t = drop_null_transformer.transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
 
 def test_drop_null_transformer_transform_custom_pct_null_threshold():
@@ -51,10 +51,10 @@ def test_drop_null_transformer_transform_custom_pct_null_threshold():
 
     drop_null_transformer = DropNullColumns(pct_null_threshold=0.5)
     X_expected = X.drop(["lots_of_null", "all_null"], axis=1)
-    X_expected = X_expected.astype({"no_null": "Int64"})
+    X_expected = X_expected.astype({"no_null": "int64"})
     drop_null_transformer.fit(X)
     X_t = drop_null_transformer.transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
     # check that X is untouched
     assert X.equals(pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                                   'all_null': [None, None, None, None, None],
@@ -68,12 +68,12 @@ def test_drop_null_transformer_transform_boundary_pct_null_threshold():
                       'some_null': [None, 0, 3, 4, 5]})
     drop_null_transformer.fit(X)
     X_t = drop_null_transformer.transform(X)
-    assert X_t.to_dataframe().empty
+    assert X_t.empty
 
     drop_null_transformer = DropNullColumns(pct_null_threshold=1.0)
     drop_null_transformer.fit(X)
     X_t = drop_null_transformer.transform(X)
-    assert_frame_equal(X_t.to_dataframe(), X.drop(["all_null"], axis=1))
+    assert_frame_equal(X_t, X.drop(["all_null"], axis=1))
     # check that X is untouched
     assert X.equals(pd.DataFrame({'all_null': [None, None, None, None, None],
                                   'lots_of_null': [None, None, None, None, 5],
@@ -84,18 +84,18 @@ def test_drop_null_transformer_fit_transform():
     drop_null_transformer = DropNullColumns()
     X = pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                       'no_null': [1, 2, 3, 4, 5]})
-    X_expected = X.astype({'lots_of_null': 'float64', 'no_null': 'Int64'})
+    X_expected = X.astype({'lots_of_null': 'float64', 'no_null': 'int64'})
     X_t = drop_null_transformer.fit_transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     X = pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                       'all_null': [None, None, None, None, None],
                       'no_null': [1, 2, 3, 4, 5]})
     drop_null_transformer = DropNullColumns(pct_null_threshold=0.5)
     X_expected = X.drop(["lots_of_null", "all_null"], axis=1)
-    X_expected = X_expected.astype({'no_null': 'Int64'})
+    X_expected = X_expected.astype({'no_null': 'int64'})
     X_t = drop_null_transformer.fit_transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
     # check that X is untouched
     assert X.equals(pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                                   'all_null': [None, None, None, None, None],
@@ -105,14 +105,14 @@ def test_drop_null_transformer_fit_transform():
     X = pd.DataFrame({'lots_of_null': [None, None, None, None, 5],
                       'some_null': [None, 0, 3, 4, 5]})
     X_t = drop_null_transformer.fit_transform(X)
-    assert X_t.to_dataframe().empty
+    assert X_t.empty
 
     X = pd.DataFrame({'all_null': [None, None, None, None, None],
                       'lots_of_null': [None, None, None, None, 5],
                       'some_null': [None, 0, 3, 4, 5]})
     drop_null_transformer = DropNullColumns(pct_null_threshold=1.0)
     X_t = drop_null_transformer.fit_transform(X)
-    assert_frame_equal(X.drop(["all_null"], axis=1), X_t.to_dataframe())
+    assert_frame_equal(X.drop(["all_null"], axis=1), X_t)
 
 
 def test_drop_null_transformer_np_array():
@@ -122,7 +122,7 @@ def test_drop_null_transformer_np_array():
                   [np.nan, 2, np.nan, 0],
                   [np.nan, 1, 1, 0]])
     X_t = drop_null_transformer.fit_transform(X)
-    assert_frame_equal(X_t.to_dataframe(), pd.DataFrame(np.delete(X, [0, 2], axis=1), columns=[1, 3]))
+    assert_frame_equal(X_t, pd.DataFrame(np.delete(X, [0, 2], axis=1), columns=[1, 3]))
 
     # check that X is untouched
     np.testing.assert_allclose(X, np.array([[np.nan, 0, 2, 0],
@@ -144,12 +144,13 @@ def test_drop_null_transformer_woodwork_custom_overrides_returned_by_components(
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         drop_null_transformer = DropNullColumns()
         drop_null_transformer.fit(X)
         transformed = drop_null_transformer.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {0: logical_type}
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {0: logical_type}

--- a/evalml/tests/component_tests/test_drop_null_columns_transformer.py
+++ b/evalml/tests/component_tests/test_drop_null_columns_transformer.py
@@ -144,7 +144,7 @@ def test_drop_null_transformer_woodwork_custom_overrides_returned_by_components(
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_en_classifier.py
+++ b/evalml/tests/component_tests/test_en_classifier.py
@@ -37,8 +37,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -61,8 +61,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_feature_importance(X_y_binary):

--- a/evalml/tests/component_tests/test_en_regressor.py
+++ b/evalml/tests/component_tests/test_en_regressor.py
@@ -44,7 +44,7 @@ def test_fit_predict(X_y_regression):
     assert isinstance(fitted, ElasticNetRegressor)
 
     y_pred = clf.predict(X)
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
 
 
 def test_feature_importance(X_y_regression):

--- a/evalml/tests/component_tests/test_estimators.py
+++ b/evalml/tests/component_tests/test_estimators.py
@@ -41,7 +41,7 @@ def test_estimators_feature_name_with_random_ascii(X_y_binary, X_y_multi, X_y_re
             clf.fit(X, y)
             assert len(clf.feature_importance) == len(X.columns)
             assert not np.isnan(clf.feature_importance).all().all()
-            predictions = clf.predict(X).to_series()
+            predictions = clf.predict(X)
             assert len(predictions) == len(y)
             assert not np.isnan(predictions).all()
             assert (clf.input_feature_names == col_names)
@@ -56,7 +56,7 @@ def test_binary_classification_estimators_predict_proba_col_order(helper_functio
         if ProblemTypes.BINARY in supported_problem_types:
             estimator = helper_functions.safe_init_component_with_njobs_1(estimator_class)
             estimator.fit(X, y)
-            predicted_proba = estimator.predict_proba(X).to_dataframe()
+            predicted_proba = estimator.predict_proba(X)
             expected = np.concatenate([(1 - data).reshape(-1, 1), data.reshape(-1, 1)], axis=1)
             np.testing.assert_allclose(expected, np.round(predicted_proba).values)
 
@@ -122,7 +122,7 @@ def test_estimator_predict_output_type(X_y_binary, helper_functions):
             component = helper_functions.safe_init_component_with_njobs_1(component_class)
             component.fit(X, y=y)
             predict_output = component.predict(X)
-            assert isinstance(predict_output, ww.DataColumn)
+            assert isinstance(predict_output, pd.Series)
             assert len(predict_output) == len(y)
             assert predict_output.name is None
 
@@ -134,7 +134,7 @@ def test_estimator_predict_output_type(X_y_binary, helper_functions):
                           X.columns if isinstance(X, pd.DataFrame) else None, type(y),
                           y.name if isinstance(y, pd.Series) else None))
             predict_proba_output = component.predict_proba(X)
-            assert isinstance(predict_proba_output, ww.DataTable)
+            assert isinstance(predict_proba_output, pd.DataFrame)
             assert predict_proba_output.shape == (len(y), len(np.unique(y)))
             assert (list(predict_proba_output.columns) == y_cols_expected).all()
 
@@ -188,10 +188,10 @@ def test_estimator_check_for_fit_with_overrides(X_y_binary):
 
 def test_estimator_manage_woodwork(X_y_binary):
     X_df = pd.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6], "baz": [7, 8, 9]})
-    X_ww = ww.DataTable(X_df)
+    X_df.ww.init()
 
     y_series = pd.Series([1, 2, 3])
-    y_ww = ww.DataColumn(y_series)
+    y_series = ww.init_series(y_series)
 
     class MockEstimator(Estimator):
         name = "Mock Estimator Subclass"
@@ -200,11 +200,11 @@ def test_estimator_manage_woodwork(X_y_binary):
 
     # Test y is None case
     est = MockEstimator()
-    X, y = est._manage_woodwork(X_ww, y=None)
+    X, y = est._manage_woodwork(X_df, y=None)
     assert isinstance(X, pd.DataFrame)
     assert y is None
 
     # Test y is not None case
-    X, y = est._manage_woodwork(X_ww, y_ww)
+    X, y = est._manage_woodwork(X_df, y_series)
     assert isinstance(X, pd.DataFrame)
     assert isinstance(y, pd.Series)

--- a/evalml/tests/component_tests/test_et_classifier.py
+++ b/evalml/tests/component_tests/test_et_classifier.py
@@ -29,8 +29,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -48,8 +48,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_feature_importance(X_y_binary):

--- a/evalml/tests/component_tests/test_et_regressor.py
+++ b/evalml/tests/component_tests/test_et_regressor.py
@@ -27,7 +27,7 @@ def test_fit_predict(X_y_regression):
     assert isinstance(fitted, ExtraTreesRegressor)
 
     y_pred = clf.predict(X)
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
 
 
 def test_feature_importance(X_y_regression):

--- a/evalml/tests/component_tests/test_feature_selectors.py
+++ b/evalml/tests/component_tests/test_feature_selectors.py
@@ -93,7 +93,7 @@ def test_feature_selectors_woodwork_custom_overrides_returned_by_components(X_df
     override_types = [Integer, Double, Boolean]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_feature_selectors.py
+++ b/evalml/tests/component_tests/test_feature_selectors.py
@@ -93,16 +93,17 @@ def test_feature_selectors_woodwork_custom_overrides_returned_by_components(X_df
     override_types = [Integer, Double, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         rf_classifier.fit(X, y)
         transformed = rf_classifier.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {0: logical_type, 'another column': Double}
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {0: logical_type, 'another column': Double}
 
         rf_regressor.fit(X, y)
         transformed = rf_regressor.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {0: logical_type, 'another column': Double}
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {0: logical_type, 'another column': Double}

--- a/evalml/tests/component_tests/test_featuretools.py
+++ b/evalml/tests/component_tests/test_featuretools.py
@@ -116,7 +116,7 @@ def test_ft_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_featuretools.py
+++ b/evalml/tests/component_tests/test_featuretools.py
@@ -5,7 +5,13 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer
+)
 
 from evalml.pipelines.components import DFSTransformer
 

--- a/evalml/tests/component_tests/test_featuretools.py
+++ b/evalml/tests/component_tests/test_featuretools.py
@@ -5,13 +5,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Datetime,
-    Double,
-    Integer
-)
+from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer
 
 from evalml.pipelines.components import DFSTransformer
 
@@ -76,15 +70,15 @@ def test_transform(X_y_binary, X_y_multi, X_y_regression):
         feature.fit(X)
         X_t = feature.transform(X)
 
-        assert_frame_equal(feature_matrix, X_t.to_dataframe())
+        assert_frame_equal(feature_matrix, X_t)
         assert features == feature.features
 
         feature.fit(X, y)
         feature.transform(X)
 
-        X_ww = ww.DataTable(X_pd)
-        feature.fit(X_ww)
-        feature.transform(X_ww)
+        X_pd.ww.init()
+        feature.fit(X_pd)
+        feature.transform(X_pd)
 
 
 def test_transform_subset(X_y_binary, X_y_multi, X_y_regression):
@@ -104,7 +98,7 @@ def test_transform_subset(X_y_binary, X_y_multi, X_y_regression):
         feature.fit(X_fit)
         X_t = feature.transform(X_transform)
 
-        assert_frame_equal(feature_matrix, X_t.to_dataframe())
+        assert_frame_equal(feature_matrix, X_t)
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.to_datetime(['20190902', '20200519', '20190607'], format='%Y%m%d')),
@@ -116,15 +110,16 @@ def test_ft_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df.copy(), logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         dft = DFSTransformer()
         dft.fit(X, y)
         transformed = dft.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
         if logical_type == Datetime:
-            assert transformed.logical_types == {'DAY(0)': Integer, 'MONTH(0)': Integer, 'WEEKDAY(0)': Integer, 'YEAR(0)': Integer}
+            assert transformed.ww.logical_types == {'DAY(0)': Integer, 'MONTH(0)': Integer, 'WEEKDAY(0)': Integer, 'YEAR(0)': Integer}
         else:
-            assert transformed.logical_types == {'0': logical_type}
+            assert transformed.ww.logical_types == {'0': logical_type}

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -26,7 +26,7 @@ def imputer_test_data():
         "int with nan": [np.nan, 1, 0, 0, 1],
         "float with nan": [0.0, 1.0, np.nan, -1.0, 0.],
         "object with nan": ["b", "b", np.nan, "c", np.nan],
-        "bool col with nan": pd.Series([True, np.nan, False, np.nan, True]),
+        "bool col with nan": pd.Series([True, np.nan, False, np.nan, True], dtype='category'),
         "all nan": [np.nan, np.nan, np.nan, np.nan, np.nan],
         "all nan cat": pd.Series([np.nan, np.nan, np.nan, np.nan, np.nan], dtype='category')
     })

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -3,13 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Double,
-    Integer,
-    NaturalLanguage
-)
+from woodwork.logical_types import Boolean, Integer, Categorical, Double, NaturalLanguage
 
 from evalml.pipelines.components import Imputer
 
@@ -26,7 +20,7 @@ def imputer_test_data():
         "int with nan": [np.nan, 1, 0, 0, 1],
         "float with nan": [0.0, 1.0, np.nan, -1.0, 0.],
         "object with nan": ["b", "b", np.nan, "c", np.nan],
-        "bool col with nan": pd.Series([True, np.nan, False, np.nan, True], dtype='boolean'),
+        "bool col with nan": pd.Series([True, np.nan, False, np.nan, True]),
         "all nan": [np.nan, np.nan, np.nan, np.nan, np.nan],
         "all nan cat": pd.Series([np.nan, np.nan, np.nan, np.nan, np.nan], dtype='category')
     })
@@ -86,11 +80,11 @@ def test_numeric_only_input(imputer_test_data):
         "int with nan": [0.5, 1.0, 0.0, 0.0, 1.0],
         "float with nan": [0.0, 1.0, 0, -1.0, 0.]
     })
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_categorical_only_input(imputer_test_data):
@@ -107,12 +101,12 @@ def test_categorical_only_input(imputer_test_data):
         "bool col": [True, False, False, True, True],
         "categorical with nan": pd.Series(["0", "1", "0", "0", "3"], dtype='category'),
         "object with nan": pd.Series(["b", "b", "b", "c", "b"], dtype='category'),
-        "bool col with nan": [True, True, False, True, True]
+        "bool col with nan": pd.Series([True, True, False, True, True], dtype='category')
     })
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_categorical_and_numeric_input(imputer_test_data):
@@ -131,27 +125,28 @@ def test_categorical_and_numeric_input(imputer_test_data):
         "int with nan": [0.5, 1.0, 0.0, 0.0, 1.0],
         "float with nan": [0.0, 1.0, 0, -1.0, 0.],
         "object with nan": pd.Series(["b", "b", "b", "c", "b"], dtype='category'),
-        "bool col with nan": [True, True, False, True, True]
+        "bool col with nan": pd.Series([True, True, False, True, True], dtype="category")
     })
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_drop_all_columns(imputer_test_data):
     X = imputer_test_data[["all nan cat", "all nan"]]
     y = pd.Series([0, 0, 1, 0, 1])
+    X.ww.init()
     imputer = Imputer()
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
     expected = X.drop(["all nan cat", "all nan"], axis=1)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_typed_imputer_numpy_input():
@@ -165,11 +160,11 @@ def test_typed_imputer_numpy_input():
     expected = pd.DataFrame(np.array([[1, 2, 2, 0],
                                       [1, 0, 0, 0],
                                       [1, 1, 1, 0]]))
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_imputer_datetime_input():
@@ -182,11 +177,11 @@ def test_imputer_datetime_input():
     imputer = Imputer()
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), X, check_dtype=False)
+    assert_frame_equal(transformed, X, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), X, check_dtype=False)
+    assert_frame_equal(transformed, X, check_dtype=False)
 
 
 @pytest.mark.parametrize("data_type", ['np', 'pd', 'ww'])
@@ -199,11 +194,11 @@ def test_imputer_empty_data(data_type, make_data_type):
     imputer = Imputer()
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_imputer_does_not_reset_index():
@@ -219,7 +214,7 @@ def test_imputer_does_not_reset_index():
     imputer = Imputer()
     imputer.fit(X, y=y)
     transformed = imputer.transform(X)
-    pd.testing.assert_frame_equal(transformed.to_dataframe(),
+    pd.testing.assert_frame_equal(transformed,
                                   pd.DataFrame({'input_val': [1.0, 2, 3, 4, 5, 6, 7, 8, 9],
                                                 'input_cat': pd.Categorical(['a'] * 6 + ['b'] * 3)},
                                                index=list(range(1, 10))))
@@ -240,12 +235,12 @@ def test_imputer_fill_value(imputer_test_data):
         "object with nan": pd.Series(["b", "b", "fill", "c", "fill"], dtype='category'),
         "bool col with nan": pd.Series([True, "fill", False, "fill", True], dtype='category')
     })
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
     imputer = Imputer(categorical_impute_strategy="constant", numeric_impute_strategy="constant",
                       categorical_fill_value="fill", numeric_fill_value=-1)
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
 
 def test_imputer_no_nans(imputer_test_data):
@@ -260,19 +255,19 @@ def test_imputer_no_nans(imputer_test_data):
         "object col": pd.Series(["b", "b", "a", "c", "d"], dtype='category'),
         "bool col": [True, False, False, True, True],
     })
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
     imputer = Imputer(categorical_impute_strategy="constant", numeric_impute_strategy="constant",
                       categorical_fill_value="fill", numeric_fill_value=-1)
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(transformed.to_dataframe(), expected, check_dtype=False)
+    assert_frame_equal(transformed, expected, check_dtype=False)
 
 
 def test_imputer_with_none():
     X = pd.DataFrame({"int with None": [1, 0, 5, None],
                       "float with None": [0.1, 0.0, 0.5, None],
                       "category with None": pd.Series(["b", "a", "a", None], dtype='category'),
-                      "boolean with None": pd.Series([True, None, False, True], dtype='boolean'),
+                      "boolean with None": pd.Series([True, None, False, True]),
                       "object with None": ["b", "a", "a", None],
                       "all None": [None, None, None, None]})
     y = pd.Series([0, 0, 1, 0, 1])
@@ -282,50 +277,50 @@ def test_imputer_with_none():
     expected = pd.DataFrame({"int with None": [1, 0, 5, 2],
                              "float with None": [0.1, 0.0, 0.5, 0.2],
                              "category with None": pd.Series(["b", "a", "a", "a"], dtype='category'),
-                             "boolean with None": pd.Series([True, True, False, True], dtype='boolean'),
+                             "boolean with None": pd.Series([True, True, False, True], dtype='category'),
                              "object with None": pd.Series(["b", "a", "a", "a"], dtype='category')})
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
     imputer = Imputer()
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_all_bool_return_original(data_type, make_data_type):
     X = make_data_type(data_type, pd.DataFrame([True, True, False, True, True], dtype=bool))
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='boolean')
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     y = make_data_type(data_type, pd.Series([1, 0, 0, 1, 0]))
 
     imputer = Imputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe())
+    assert_frame_equal(X_expected_arr, X_t)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_bool_dtype_object(data_type, make_data_type):
-    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype='boolean')
+    X = pd.DataFrame([True, np.nan, False, np.nan, True])
     y = pd.Series([1, 0, 0, 1, 0])
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='boolean')
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
     X = make_data_type(data_type, X)
     y = make_data_type(data_type, y)
     imputer = Imputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe())
+    assert_frame_equal(X_expected_arr, X_t)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_imputer_multitype_with_one_bool(data_type, make_data_type):
     X_multi = pd.DataFrame({
-        "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype='boolean'),
+        "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
     y = pd.Series([1, 0, 0, 1, 0])
     X_multi_expected_arr = pd.DataFrame({
-        "bool with nan": pd.Series([True, False, False, False, False], dtype='boolean'),
-        "bool no nan": pd.Series([False, False, False, False, True], dtype='boolean'),
+        "bool with nan": pd.Series([True, False, False, False, False], dtype='category'),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
 
     X_multi = make_data_type(data_type, X_multi)
@@ -334,13 +329,47 @@ def test_imputer_multitype_with_one_bool(data_type, make_data_type):
     imputer = Imputer()
     imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)
-    assert_frame_equal(X_multi_expected_arr, X_multi_t.to_dataframe())
+    assert_frame_equal(X_multi_expected_arr, X_multi_t)
+
+
+def test_imputer_int_preserved():
+    X = pd.DataFrame(pd.Series([1, 2, 11, np.nan]))
+    imputer = Imputer(numeric_impute_strategy="mean")
+    transformed = imputer.fit_transform(X)
+    pd.testing.assert_frame_equal(transformed, pd.DataFrame(pd.Series([1, 2, 11, 14 / 3])))
+    assert transformed.ww.logical_types == {0: Double}
+
+    X = pd.DataFrame(pd.Series([1, 2, 3, np.nan]))
+    imputer = Imputer(numeric_impute_strategy="mean")
+    transformed = imputer.fit_transform(X)
+    pd.testing.assert_frame_equal(transformed, pd.DataFrame(pd.Series([1, 2, 3, 2])), check_dtype=False)
+    assert transformed.ww.logical_types == {0: Double}
+
+    X = pd.DataFrame(pd.Series([1, 2, 3, 4], dtype='int'))
+    imputer = Imputer(numeric_impute_strategy="mean")
+    transformed = imputer.fit_transform(X)
+    pd.testing.assert_frame_equal(transformed, pd.DataFrame(pd.Series([1, 2, 3, 4])), check_dtype=False)
+    assert transformed.ww.logical_types == {0: Integer}
+
+
+def test_imputer_bool_preserved():
+    X = pd.DataFrame(pd.Series([True, False, True, np.nan]))
+    imputer = Imputer(categorical_impute_strategy="most_frequent")
+    transformed = imputer.fit_transform(X)
+    pd.testing.assert_frame_equal(transformed, pd.DataFrame(pd.Series([True, False, True, True], dtype="category")))
+    assert transformed.ww.logical_types == {0: Categorical}
+
+    X = pd.DataFrame(pd.Series([True, False, True, False]))
+    imputer = Imputer(categorical_impute_strategy="most_frequent")
+    transformed = imputer.fit_transform(X)
+    pd.testing.assert_frame_equal(transformed, pd.DataFrame(pd.Series([True, False, True, False])), check_dtype=False)
+    assert transformed.ww.logical_types == {0: Boolean}
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.Series([1, 2, 3], dtype="Int64")),
                                   pd.DataFrame(pd.Series([1., 2., 4.], dtype="float")),
                                   pd.DataFrame(pd.Series(['a', 'b', 'a'], dtype="category")),
-                                  pd.DataFrame(pd.Series([True, False, True], dtype="boolean")),
+                                  pd.DataFrame(pd.Series([True, False, True], dtype=bool)),
                                   pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))])
 @pytest.mark.parametrize("has_nan", [True, False])
 @pytest.mark.parametrize("numeric_impute_strategy", ["mean", "median", "most_frequent"])
@@ -351,17 +380,18 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan,
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         imputer = Imputer(numeric_impute_strategy=numeric_impute_strategy)
         imputer.fit(X, y)
         transformed = imputer.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
         if numeric_impute_strategy == "most_frequent":
-            assert transformed.logical_types == {0: logical_type}
-        elif logical_type in [Categorical, NaturalLanguage] or not has_nan:
-            assert transformed.logical_types == {0: logical_type}
+            assert transformed.ww.logical_types == {0: logical_type}
+        elif logical_type in [Categorical, NaturalLanguage, Boolean] or not has_nan:
+            assert transformed.ww.logical_types == {0: logical_type}
         else:
-            assert transformed.logical_types == {0: Double}
+            assert transformed.ww.logical_types == {0: Double}

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -3,7 +3,13 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Integer, Categorical, Double, NaturalLanguage
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Double,
+    Integer,
+    NaturalLanguage
+)
 
 from evalml.pipelines.components import Imputer
 

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -385,6 +385,9 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan,
         X_df.iloc[len(X_df) - 1, 0] = np.nan
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
+        # Converting a column with NaNs to Boolean will impute NaNs.
+        if has_nan and logical_type == Boolean:
+            continue
         try:
             X = X_df
             X.ww.init(logical_types={0: logical_type})
@@ -397,7 +400,7 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan,
         assert isinstance(transformed, pd.DataFrame)
         if numeric_impute_strategy == "most_frequent":
             assert transformed.ww.logical_types == {0: logical_type}
-        elif logical_type in [Categorical, NaturalLanguage, Boolean] or not has_nan:
+        elif logical_type in [Categorical, NaturalLanguage] or not has_nan:
             assert transformed.ww.logical_types == {0: logical_type}
         else:
             assert transformed.ww.logical_types == {0: Double}

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -381,15 +381,15 @@ def test_imputer_bool_preserved():
 @pytest.mark.parametrize("numeric_impute_strategy", ["mean", "median", "most_frequent"])
 def test_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan, numeric_impute_strategy):
     y = pd.Series([1, 2, 1])
-    if has_nan:
-        X_df.iloc[len(X_df) - 1, 0] = np.nan
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
-        # Converting a column with NaNs to Boolean will impute NaNs.
+        # Column with Nans to boolean used to fail. Now it doesn't
         if has_nan and logical_type == Boolean:
             continue
         try:
-            X = X_df
+            X = X_df.copy()
+            if has_nan:
+                X.iloc[len(X_df) - 1, 0] = np.nan
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -383,7 +383,7 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan,
     y = pd.Series([1, 2, 1])
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
-        # Column with Nans to boolean used to fail. Now it doesn't
+        # Column with Nans to boolean used to fail. Now it doesn't but it should.
         if has_nan and logical_type == Boolean:
             continue
         try:

--- a/evalml/tests/component_tests/test_knn_classifier.py
+++ b/evalml/tests/component_tests/test_knn_classifier.py
@@ -31,8 +31,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series(), decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe(), decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -48,8 +48,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series(), decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe(), decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba, decimal=5)
 
 
 def test_feature_importance(X_y_binary):

--- a/evalml/tests/component_tests/test_lda.py
+++ b/evalml/tests/component_tests/test_lda.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Integer, Double
+from woodwork.logical_types import Double, Integer
 
 from evalml.pipelines.components import LinearDiscriminantAnalysis
 

--- a/evalml/tests/component_tests/test_lda.py
+++ b/evalml/tests/component_tests/test_lda.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Double, Integer
+from woodwork.logical_types import Integer, Double
 
 from evalml.pipelines.components import LinearDiscriminantAnalysis
 
@@ -31,7 +31,7 @@ def test_lda_numeric(data_type, make_data_type):
                                  [3.659653362085993]],
                                 columns=["component_0"])
     X_t = lda.fit_transform(X, y)
-    assert_frame_equal(expected_X_t, X_t.to_dataframe())
+    assert_frame_equal(expected_X_t, X_t)
 
 
 def test_lda_array():
@@ -50,7 +50,7 @@ def test_lda_array():
                                 columns=[f"component_{i}" for i in range(2)])
     lda.fit(X, y)
     X_t = lda.transform(X)
-    assert_frame_equal(expected_X_t, X_t.to_dataframe())
+    assert_frame_equal(expected_X_t, X_t)
 
 
 def test_lda_invalid():
@@ -130,7 +130,6 @@ def test_invalid_n_components():
 
 
 def test_lda_woodwork_custom_overrides_returned_by_components():
-    y = pd.Series([1, 2, 1])
     X_df = pd.DataFrame([[3, 0, 1, 6],
                          [1, 2, 1, 6],
                          [10, 2, 1, 6],
@@ -139,9 +138,9 @@ def test_lda_woodwork_custom_overrides_returned_by_components():
     y = pd.Series([0, 1, 0, 1, 1])
     override_types = [Integer, Double]
     for logical_type in override_types:
-        X = ww.DataTable(X_df, logical_types={0: logical_type, 1: logical_type, 2: logical_type, 3: logical_type})
+        X_df.ww.init(logical_types={0: logical_type, 1: logical_type, 2: logical_type, 3: logical_type})
         lda = LinearDiscriminantAnalysis(n_components=1)
-        lda.fit(X, y)
-        transformed = lda.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {'component_0': ww.logical_types.Double}
+        lda.fit(X_df, y)
+        transformed = lda.transform(X_df, y)
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {'component_0': ww.logical_types.Double}

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -50,8 +50,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -67,8 +67,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 def test_feature_importance(X_y_binary):
@@ -104,8 +104,8 @@ def test_fit_string_features(X_y_binary):
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.to_dataframe().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba_sk, y_pred_proba.values, decimal=5)
 
 
 @patch('evalml.pipelines.components.estimators.estimator.Estimator.predict_proba')
@@ -274,5 +274,5 @@ def test_lightgbm_multiindex(data_type, X_y_binary, make_data_type):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
-    assert not y_pred.to_series().isnull().values.any()
-    assert not y_pred_proba.to_dataframe().isnull().values.any().any()
+    assert not y_pred.isnull().values.any()
+    assert not y_pred_proba.isnull().values.any().any()

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -46,7 +46,7 @@ def test_fit_predict_regression(X_y_regression):
     clf.fit(X, y)
     y_pred = clf.predict(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
 
 
 def test_feature_importance(X_y_regression):
@@ -80,7 +80,7 @@ def test_fit_string_features(X_y_regression):
     clf.fit(X, y)
     y_pred = clf.predict(X)
 
-    np.testing.assert_almost_equal(y_pred_sk, y_pred.to_series().values, decimal=5)
+    np.testing.assert_almost_equal(y_pred_sk, y_pred.values, decimal=5)
 
 
 @patch('evalml.pipelines.components.estimators.estimator.Estimator.predict')
@@ -188,4 +188,4 @@ def test_lightgbm_multiindex(data_type, X_y_regression, make_data_type):
     clf = LightGBMRegressor()
     clf.fit(X, y)
     y_pred = clf.predict(X)
-    assert not y_pred.to_series().isnull().values.any()
+    assert not y_pred.isnull().values.any()

--- a/evalml/tests/component_tests/test_lsa.py
+++ b/evalml/tests/component_tests/test_lsa.py
@@ -3,7 +3,13 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Integer, NaturalLanguage, Categorical, Double
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Double,
+    Integer,
+    NaturalLanguage
+)
 
 from evalml.pipelines.components import LSA
 from evalml.utils import infer_feature_types

--- a/evalml/tests/component_tests/test_one_hot_encoder.py
+++ b/evalml/tests/component_tests/test_one_hot_encoder.py
@@ -535,7 +535,7 @@ def test_ohe_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, NaturalLanguage, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_one_hot_encoder.py
+++ b/evalml/tests/component_tests/test_one_hot_encoder.py
@@ -3,7 +3,14 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 from woodwork.exceptions import TypeConversionError
-from woodwork.logical_types import Boolean, Integer, NaturalLanguage, Categorical, Datetime, Double
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer,
+    NaturalLanguage
+)
 
 from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import OneHotEncoder
@@ -541,11 +548,10 @@ def test_ohe_woodwork_custom_overrides_returned_by_components(X_df):
             assert transformed.ww.logical_types == {0: logical_type}
 
 
-
 def test_ohe_output_bools():
     X = pd.DataFrame({"bool": [bool(i % 2) for i in range(100)],
-                                   "categorical": ["dog"] * 20 + ["cat"] * 40 + ["fish"] * 40,
-                                   "integers": [i for i in range(100)]})
+                      "categorical": ["dog"] * 20 + ["cat"] * 40 + ["fish"] * 40,
+                      "integers": [i for i in range(100)]})
     X.ww.init()
     y = pd.Series([i % 2 for i in range(100)])
     y.ww.init()

--- a/evalml/tests/component_tests/test_one_hot_encoder.py
+++ b/evalml/tests/component_tests/test_one_hot_encoder.py
@@ -1,24 +1,13 @@
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Datetime,
-    Double,
-    Integer,
-    NaturalLanguage
-)
+from woodwork.exceptions import TypeConversionError
+from woodwork.logical_types import Boolean, Integer, NaturalLanguage, Categorical, Datetime, Double
 
 from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import OneHotEncoder
-from evalml.utils import (
-    _convert_woodwork_types_wrapper,
-    get_random_seed,
-    infer_feature_types
-)
+from evalml.utils import get_random_seed, infer_feature_types
 
 
 def test_init():
@@ -183,7 +172,7 @@ def test_handle_unknown():
 
     encoder = OneHotEncoder(handle_unknown='error')
     encoder.fit(X)
-    assert isinstance(encoder.transform(X), ww.DataTable)
+    assert isinstance(encoder.transform(X), pd.DataFrame)
 
     X = pd.DataFrame({"col_1": ["x", "b", "c", "d", "e", "f", "g"],
                       "col_2": ["a", "c", "d", "b", "e", "e", "f"],
@@ -283,7 +272,6 @@ def test_more_top_n_unique_values():
 
     # Conversion changes the resulting dataframe dtype, resulting in a different random state, so we need make the conversion here too
     X = infer_feature_types(X)
-    X = _convert_woodwork_types_wrapper(X.to_dataframe())
     col_1_counts = X["col_1"].value_counts(dropna=False).to_frame()
     col_1_counts = col_1_counts.sample(frac=1, random_state=random_seed)
     col_1_counts = col_1_counts.sort_values(["col_1"], ascending=False, kind='mergesort')
@@ -318,7 +306,6 @@ def test_more_top_n_unique_values_large():
 
     # Conversion changes the resulting dataframe dtype, resulting in a different random state, so we need make the conversion here too
     X = infer_feature_types(X)
-    X = _convert_woodwork_types_wrapper(X.to_dataframe())
     col_1_counts = X["col_1"].value_counts(dropna=False).to_frame()
     col_1_counts = col_1_counts.sample(frac=1, random_state=random_seed)
     col_1_counts = col_1_counts.sort_values(["col_1"], ascending=False, kind='mergesort')
@@ -341,7 +328,7 @@ def test_categorical_dtype():
 
     encoder = OneHotEncoder(top_n=5)
     encoder.fit(X)
-    X_t = encoder.transform(X).to_dataframe()
+    X_t = encoder.transform(X)
 
     expected_col_names = set(["col_1_f", "col_1_b", "col_1_c", "col_1_d", "col_1_e",
                               "col_2_d", "col_2_e", "col_2_a", "col_3_a",
@@ -357,11 +344,11 @@ def test_all_numerical_dtype():
                       "col_2": [3, 2, 5, 1, 3],
                       "col_3": [0, 0, 1, 3, 2],
                       "col_4": [2, 4, 1, 4, 0]})
-    X_expected = X.astype("Int64")
+    X_expected = X.copy()
     encoder = OneHotEncoder(top_n=5)
     encoder.fit(X)
     X_t = encoder.transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
 
 def test_numpy_input():
@@ -369,7 +356,7 @@ def test_numpy_input():
     encoder = OneHotEncoder()
     encoder.fit(X)
     X_t = encoder.transform(X)
-    assert_frame_equal(pd.DataFrame(X), X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(pd.DataFrame(X), X_t, check_dtype=False)
 
 
 def test_large_number_of_categories():
@@ -399,10 +386,11 @@ def test_data_types(data_type):
     elif data_type == 'pd_index':
         X = pd.DataFrame(["a", "b", "c"], columns=['0'])
     elif data_type == 'ww':
-        X = ww.DataTable(pd.DataFrame(["a", "b", "c"]))
+        X = pd.DataFrame(["a", "b", "c"])
+        X.ww.init()
     encoder = OneHotEncoder()
     encoder.fit(X)
-    X_t = encoder.transform(X).to_dataframe()
+    X_t = encoder.transform(X)
     assert list(X_t.columns) == ['0_a', '0_b', '0_c']
     np.testing.assert_array_equal(X_t.to_numpy(), np.identity(3))
 
@@ -416,7 +404,7 @@ def test_ohe_preserves_custom_index(index):
     df = pd.DataFrame({"categories": [f"cat_{i}" for i in range(5)], "numbers": np.arange(5)},
                       index=index)
     ohe = OneHotEncoder()
-    new_df = ohe.fit_transform(df).to_dataframe()
+    new_df = ohe.fit_transform(df)
     pd.testing.assert_index_equal(new_df.index, df.index)
     assert not new_df.isna().any(axis=None)
 
@@ -459,7 +447,7 @@ def test_ohe_features_to_encode():
 
     encoder = OneHotEncoder(top_n=5, features_to_encode=['col_1'])
     encoder.fit(X)
-    X_t = encoder.transform(X).to_dataframe()
+    X_t = encoder.transform(X)
     expected_col_names = set(['col_1_0', 'col_1_1', 'col_1_2', 'col_2'])
     col_names = set(X_t.columns)
     assert (col_names == expected_col_names)
@@ -467,7 +455,7 @@ def test_ohe_features_to_encode():
 
     encoder = OneHotEncoder(top_n=5, features_to_encode=['col_1', 'col_2'])
     encoder.fit(X)
-    X_t = encoder.transform(X).to_dataframe()
+    X_t = encoder.transform(X)
     expected_col_names = set(['col_1_0', 'col_1_1', 'col_1_2',
                               'col_2_a', 'col_2_b', 'col_2_c', 'col_2_d'])
     col_names = set(X_t.columns)
@@ -489,7 +477,7 @@ def test_ohe_features_to_encode_no_col_names():
     X = pd.DataFrame([["b", 0], ["a", 1], ["b", 1]])
     encoder = OneHotEncoder(top_n=5, features_to_encode=[0])
     encoder.fit(X)
-    X_t = encoder.transform(X).to_dataframe()
+    X_t = encoder.transform(X)
     expected_col_names = set([1, "0_a"])
     col_names = set(X_t.columns)
     assert (col_names == expected_col_names)
@@ -502,8 +490,8 @@ def test_ohe_top_n_categories_always_the_same():
 
     def check_df_equality(random_seed):
         ohe = OneHotEncoder(top_n=4, random_seed=random_seed)
-        df1 = ohe.fit_transform(df).to_dataframe()
-        df2 = ohe.fit_transform(df).to_dataframe()
+        df1 = ohe.fit_transform(df)
+        df2 = ohe.fit_transform(df)
         assert_frame_equal(df1, df2)
 
     check_df_equality(5)
@@ -540,26 +528,30 @@ def test_ohe_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, NaturalLanguage, Datetime, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except TypeConversionError:
             continue
 
         ohe = OneHotEncoder()
         ohe.fit(X, y)
         transformed = ohe.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
         if logical_type != Categorical:
-            assert transformed.logical_types == {0: logical_type}
+            assert transformed.ww.logical_types == {0: logical_type}
+
 
 
 def test_ohe_output_bools():
-    X = ww.DataTable(pd.DataFrame({"bool": [bool(i % 2) for i in range(100)],
+    X = pd.DataFrame({"bool": [bool(i % 2) for i in range(100)],
                                    "categorical": ["dog"] * 20 + ["cat"] * 40 + ["fish"] * 40,
-                                   "integers": [i for i in range(100)]}))
-    y = ww.DataColumn(pd.Series([i % 2 for i in range(100)]))
+                                   "integers": [i for i in range(100)]})
+    X.ww.init()
+    y = pd.Series([i % 2 for i in range(100)])
+    y.ww.init()
     ohe = OneHotEncoder()
     output = ohe.fit_transform(X, y)
-    for name, types in output.types["Logical Type"].items():
+    for name, types in output.ww.types["Logical Type"].items():
         if name == 'integers':
             assert str(types) == "Integer"
         else:

--- a/evalml/tests/component_tests/test_oversamplers.py
+++ b/evalml/tests/component_tests/test_oversamplers.py
@@ -58,12 +58,6 @@ def test_no_oversample(data_type, sampler, make_data_type, X_y_binary):
     else:
         new_X, new_y = oversampler.fit_transform(X, y)
 
-    if data_type == "ww":
-        X = X.values
-        y = y.values
-    elif data_type == "pd":
-        X = X.values
-        y = y.values
 
     np.testing.assert_equal(X, new_X.values)
     np.testing.assert_equal(y, new_y.values)
@@ -99,13 +93,6 @@ def test_oversample_imbalanced_binary(data_type, sampler, make_data_type):
 
     transform_X, transform_y = oversampler.transform(X, y)
 
-    if data_type == "ww":
-        X = X.values
-        y = y.values
-    elif data_type == "pd":
-        X = X.values
-        y = y.values
-
     np.testing.assert_equal(X, transform_X.values)
     np.testing.assert_equal(y, transform_y.values)
 
@@ -139,13 +126,6 @@ def test_oversample_imbalanced_multiclass(data_type, sampler, sampling_ratio, ma
     np.testing.assert_equal(value_counts.values, np.array(num_samples))
 
     transform_X, transform_y = oversampler.transform(X2, y)
-
-    if data_type == "ww":
-        X = X.values
-        y = y.values
-    elif data_type == "pd":
-        X = X.values
-        y = y.values
 
     np.testing.assert_equal(X, transform_X.values)
     np.testing.assert_equal(y, transform_y.values)

--- a/evalml/tests/component_tests/test_oversamplers.py
+++ b/evalml/tests/component_tests/test_oversamplers.py
@@ -53,20 +53,20 @@ def test_no_oversample(data_type, sampler, make_data_type, X_y_binary):
     if oversampler.name == "SMOTENC Oversampler":
         X2 = infer_feature_types(X, feature_types={1: "Categorical"})
         if data_type == "ww":
-            X2 = X2.set_types({0: "Categorical"})
+            X2.ww.set_types({0: "Categorical"})
         new_X, new_y = oversampler.fit_transform(X2, y)
     else:
         new_X, new_y = oversampler.fit_transform(X, y)
 
     if data_type == "ww":
-        X = X.to_dataframe().values
-        y = y.to_series().values
+        X = X.values
+        y = y.values
     elif data_type == "pd":
         X = X.values
         y = y.values
 
-    np.testing.assert_equal(X, new_X.to_dataframe().values)
-    np.testing.assert_equal(y, new_y.to_series().values)
+    np.testing.assert_equal(X, new_X.values)
+    np.testing.assert_equal(y, new_y.values)
 
 
 @pytest.mark.parametrize("sampler", [SMOTESampler(sampling_ratio=1),
@@ -85,7 +85,7 @@ def test_oversample_imbalanced_binary(data_type, sampler, make_data_type):
     if oversampler.name == "SMOTENC Oversampler":
         X2 = infer_feature_types(X, feature_types={1: "Categorical"})
         if data_type == "ww":
-            X2 = X2.set_types({0: "Categorical"})
+            X2.ww.set_types({0: "Categorical"})
         new_X, new_y = oversampler.fit_transform(X2, y)
     else:
         new_X, new_y = oversampler.fit_transform(X, y)
@@ -93,21 +93,21 @@ def test_oversample_imbalanced_binary(data_type, sampler, make_data_type):
     new_length = 1700
     assert len(new_X) == new_length
     assert len(new_y) == new_length
-    value_counts = new_y.to_series().value_counts()
+    value_counts = new_y.value_counts()
     assert value_counts.values[0] == value_counts.values[1]
     pd.testing.assert_series_equal(value_counts, pd.Series([850, 850]), check_dtype=False)
 
     transform_X, transform_y = oversampler.transform(X, y)
 
     if data_type == "ww":
-        X = X.to_dataframe().values
-        y = y.to_series().values
+        X = X.values
+        y = y.values
     elif data_type == "pd":
         X = X.values
         y = y.values
 
-    np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(X, transform_X.values)
+    np.testing.assert_equal(y, transform_y.values)
 
 
 @pytest.mark.parametrize("sampling_ratio", [0.2, 0.5])
@@ -125,7 +125,7 @@ def test_oversample_imbalanced_multiclass(data_type, sampler, sampling_ratio, ma
     if sampler.name == 'SMOTENC Oversampler':
         X2 = infer_feature_types(X, feature_types={0: "Categorical"})
         if data_type == "ww":
-            X2 = X2.set_types({0: "Categorical"})
+            X2.ww.set_types({0: "Categorical"})
         oversampler = sampler(sampling_ratio=sampling_ratio)
 
     new_X, new_y = oversampler.fit_transform(X2, y)
@@ -134,21 +134,21 @@ def test_oversample_imbalanced_multiclass(data_type, sampler, sampling_ratio, ma
     # check the lengths and sampled values are as we expect
     assert len(new_X) == sum(num_samples)
     assert len(new_y) == sum(num_samples)
-    value_counts = new_y.to_series().value_counts()
+    value_counts = new_y.value_counts()
     assert value_counts.values[1] == value_counts.values[2]
     np.testing.assert_equal(value_counts.values, np.array(num_samples))
 
     transform_X, transform_y = oversampler.transform(X2, y)
 
     if data_type == "ww":
-        X = X.to_dataframe().values
-        y = y.to_series().values
+        X = X.values
+        y = y.values
     elif data_type == "pd":
         X = X.values
         y = y.values
 
-    np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(X, transform_X.values)
+    np.testing.assert_equal(y, transform_y.values)
 
 
 @pytest.mark.parametrize("sampler", [SMOTESampler, SMOTENCSampler, SMOTENSampler])
@@ -175,10 +175,10 @@ def test_oversample_seed_same_outputs(sampler, X_y_binary):
         if s2 == 2 and sampler != SMOTENSampler:
             # group 3, SMOTENSampler performance doesn't change with different random states
             with pytest.raises(AssertionError):
-                pd.testing.assert_frame_equal(X1.to_dataframe(), X2.to_dataframe())
+                pd.testing.assert_frame_equal(X1, X2)
         else:
-            pd.testing.assert_frame_equal(X1.to_dataframe(), X2.to_dataframe())
-        pd.testing.assert_series_equal(y1.to_series(), y2.to_series())
+            pd.testing.assert_frame_equal(X1, X2)
+        pd.testing.assert_series_equal(y1, y2)
 
 
 @pytest.mark.parametrize("component_sampler,imblearn_sampler",
@@ -212,8 +212,8 @@ def test_samplers_perform_equally(problem_type, component_sampler, imblearn_samp
     X_com, y_com = component.fit_transform(X2, y)
     X_im, y_im = imb_sampler.fit_resample(X, y)
 
-    np.testing.assert_equal(X_com.to_dataframe().values, X_im)
-    np.testing.assert_equal(y_com.to_series().values, y_im)
+    np.testing.assert_equal(X_com.values, X_im)
+    np.testing.assert_equal(y_com.values, y_im)
     np.testing.assert_equal(sorted(y_im), expected_y)
 
 

--- a/evalml/tests/component_tests/test_oversamplers.py
+++ b/evalml/tests/component_tests/test_oversamplers.py
@@ -58,7 +58,6 @@ def test_no_oversample(data_type, sampler, make_data_type, X_y_binary):
     else:
         new_X, new_y = oversampler.fit_transform(X, y)
 
-
     np.testing.assert_equal(X, new_X.values)
     np.testing.assert_equal(y, new_y.values)
 

--- a/evalml/tests/component_tests/test_pca.py
+++ b/evalml/tests/component_tests/test_pca.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Double, Integer
+from woodwork.logical_types import Integer, Double
 
 from evalml.pipelines.components import PCA
 
@@ -24,7 +24,7 @@ def test_pca_numeric(data_type, make_data_type):
                                  [-0.112877, -0.755922]],
                                 columns=[f"component_{i}" for i in range(2)])
     X_t = pca.fit_transform(X)
-    assert_frame_equal(expected_X_t, X_t.to_dataframe())
+    assert_frame_equal(expected_X_t, X_t)
 
 
 def test_pca_array():
@@ -42,7 +42,7 @@ def test_pca_array():
                                 columns=[f"component_{i}" for i in range(2)])
     pca.fit(X)
     X_t = pca.transform(X)
-    assert_frame_equal(expected_X_t, X_t.to_dataframe())
+    assert_frame_equal(expected_X_t, X_t)
 
 
 def test_pca_invalid():
@@ -89,7 +89,7 @@ def test_variance():
                                  [6.828241, -3.867796, 2.597358, -1.740404]],
                                 columns=[f"component_{i}" for i in range(4)])
     X_t_90 = pca.fit_transform(X)
-    assert_frame_equal(expected_X_t, X_t_90.to_dataframe())
+    assert_frame_equal(expected_X_t, X_t_90)
 
     pca = PCA(variance=0.75)
     X_t_75 = pca.fit_transform(X)
@@ -126,9 +126,9 @@ def test_pca_woodwork_custom_overrides_returned_by_components(X_df):
     y = pd.Series([1, 2, 1])
     override_types = [Integer, Double]
     for logical_type in override_types:
-        X = ww.DataTable(X_df, logical_types={0: logical_type})
+        X_df.ww.init(logical_types={0: logical_type})
         pca = PCA(n_components=1)
-        pca.fit(X)
-        transformed = pca.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {'component_0': ww.logical_types.Double}
+        pca.fit(X_df)
+        transformed = pca.transform(X_df, y)
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {'component_0': ww.logical_types.Double}

--- a/evalml/tests/component_tests/test_pca.py
+++ b/evalml/tests/component_tests/test_pca.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Integer, Double
+from woodwork.logical_types import Double, Integer
 
 from evalml.pipelines.components import PCA
 

--- a/evalml/tests/component_tests/test_per_column_imputer.py
+++ b/evalml/tests/component_tests/test_per_column_imputer.py
@@ -3,7 +3,14 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Integer, Categorical, Double
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Double,
+    Integer,
+    NaturalLanguage
+)
+from woodwork.table_accessor import _get_invalid_schema_message
 
 from evalml.pipelines.components import PerColumnImputer
 
@@ -183,19 +190,17 @@ def test_transform_drop_all_nan_columns_empty():
                                   pd.DataFrame(pd.Series([1., 2., 3.], dtype="float")),
                                   pd.DataFrame(pd.Series(['a', 'b', 'a'], dtype="category")),
                                   pd.DataFrame(pd.Series([True, False, True], dtype="boolean")),
-                                  pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))
-                         ])
+                                  pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))])
 @pytest.mark.parametrize("has_nan", [True, False])
 def test_per_column_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan):
     y = pd.Series([1, 2, 1])
     if has_nan:
         X_df.iloc[len(X_df) - 1, 0] = np.nan
-    override_types = [Integer, Double, Categorical, Boolean]
+    override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
         try:
             X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
-            from woodwork.table_accessor import _get_invalid_schema_message
             if _get_invalid_schema_message(X, X.ww.schema):
                 continue
         except ww.exceptions.TypeConversionError:
@@ -203,10 +208,6 @@ def test_per_column_imputer_woodwork_custom_overrides_returned_by_components(X_d
 
         imputer = PerColumnImputer()
         imputer.fit(X, y)
-        try:
-            transformed = imputer.transform(X, y)
-        except Exception as e:
-            breakpoint()
-            raise e
+        transformed = imputer.transform(X, y)
         assert isinstance(transformed, pd.DataFrame)
         assert transformed.ww.logical_types == {0: logical_type}

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -66,17 +66,18 @@ def test_polynomial_detrender_fit_transform(degree, use_int_index, input_type, t
         X = X_input.values
         y = y_input.values
     elif input_type == 'ww':
-        X = ww.DataTable(X_input)
-        y = ww.DataColumn(y_input)
+        X = X_input.copy()
+        X.ww.init()
+        y = ww.init_series(y_input.copy())
 
     output_X, output_y = PolynomialDetrender(degree=degree).fit_transform(X, y)
-    pd.testing.assert_series_equal(expected_answer, output_y.to_series())
+    pd.testing.assert_series_equal(expected_answer, output_y)
 
     # Verify the X is not changed
     if input_type == "np":
         np.testing.assert_equal(X, output_X)
     elif input_type == "ww":
-        pd.testing.assert_frame_equal(X.to_dataframe(), output_X.to_dataframe())
+        pd.testing.assert_frame_equal(X, output_X)
     else:
         pd.testing.assert_frame_equal(X, output_X)
 
@@ -92,7 +93,7 @@ def test_polynomial_detrender_inverse_transform(degree, use_int_index, ts_data):
     detrender = PolynomialDetrender(degree=degree)
     output_X, output_y = detrender.fit_transform(X, y)
     output_inverse_X, output_inverse_y = detrender.inverse_transform(output_X, output_y)
-    pd.testing.assert_series_equal(y, output_inverse_y.to_series(), check_dtype=False)
+    pd.testing.assert_series_equal(y, output_inverse_y, check_dtype=False)
     pd.testing.assert_frame_equal(X, output_inverse_X)
 
 

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -76,8 +76,6 @@ def test_polynomial_detrender_fit_transform(degree, use_int_index, input_type, t
     # Verify the X is not changed
     if input_type == "np":
         np.testing.assert_equal(X, output_X)
-    elif input_type == "ww":
-        pd.testing.assert_frame_equal(X, output_X)
     else:
         pd.testing.assert_frame_equal(X, output_X)
 

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -285,7 +285,7 @@ def test_simple_imputer_with_none():
     assert_frame_equal(expected, transformed, check_dtype=False)
 
 
-def test_simple_imputer_supports_natural_language():
+def test_simple_imputer_supports_natural_language_constant():
     X = pd.DataFrame({"cat with None": ["a", "b", "a", None],
                       "natural language col": ["free-form text", "will", "be imputed", None]})
     y = pd.Series([0, 0, 1, 0, 1])

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -10,7 +10,6 @@ from woodwork.logical_types import (
     Integer,
     NaturalLanguage
 )
-from woodwork.table_accessor import _get_invalid_schema_message
 
 from evalml.pipelines.components import SimpleImputer
 
@@ -308,18 +307,16 @@ def test_simple_imputer_supports_natural_language():
 @pytest.mark.parametrize("impute_strategy", ["mean", "median"])
 def test_simple_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan, impute_strategy):
     y = pd.Series([1, 2, 1])
-    if has_nan:
-        X_df.iloc[len(X_df) - 1, 0] = np.nan
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
-        # Converting a column with NaNs to Boolean will impute NaNs.
+        # Column with Nans to boolean used to fail. Now it doesn't
         if has_nan and logical_type == Boolean:
             continue
         try:
             X = X_df.copy()
+            if has_nan:
+                X.iloc[len(X_df) - 1, 0] = np.nan
             X.ww.init(logical_types={0: logical_type})
-            if _get_invalid_schema_message(X, X.ww.schema):
-                continue
         except ww.exceptions.TypeConversionError:
             continue
 

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -3,13 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Double,
-    Integer,
-    NaturalLanguage
-)
+from woodwork.logical_types import Boolean, Integer, Categorical, Double
 
 from evalml.pipelines.components import SimpleImputer
 
@@ -27,7 +21,7 @@ def test_simple_imputer_median():
                                    [10, 2, 5, 2],
                                    [6, 2, 7, 0]])
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
 def test_simple_imputer_mean():
@@ -40,7 +34,7 @@ def test_simple_imputer_mean():
                                    [1, 2, 3, 2],
                                    [1, 2, 3, 0]])
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
 def test_simple_imputer_constant():
@@ -55,7 +49,7 @@ def test_simple_imputer_constant():
                                    ["b", 2, 3, 0]])
     X_expected_arr = X_expected_arr.astype({0: 'category'})
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
 def test_simple_imputer_most_frequent():
@@ -69,7 +63,7 @@ def test_simple_imputer_most_frequent():
                                    ["b", 2, 1, 0]])
     X_expected_arr = X_expected_arr.astype({0: 'category'})
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
 def test_simple_imputer_col_with_non_numeric():
@@ -98,7 +92,7 @@ def test_simple_imputer_col_with_non_numeric():
                                    ["a", 2, 3, 0]])
     X_expected_arr = X_expected_arr.astype({0: 'category'})
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
     transformer = SimpleImputer(impute_strategy='constant', fill_value=2)
     X_expected_arr = pd.DataFrame([["a", 0, 1, 2],
@@ -107,7 +101,7 @@ def test_simple_imputer_col_with_non_numeric():
                                    [2, 2, 3, 0]])
     X_expected_arr = X_expected_arr.astype({0: 'category'})
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
@@ -116,42 +110,42 @@ def test_simple_imputer_all_bool_return_original(data_type, make_data_type):
     y = pd.Series([1, 0, 0, 1, 0])
     X = make_data_type(data_type, X)
     y = make_data_type(data_type, y)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='boolean')
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
     imputer = SimpleImputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe())
+    assert_frame_equal(X_expected_arr, X_t)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_simple_imputer_boolean_dtype(data_type, make_data_type):
-    X = pd.DataFrame([True, np.nan, False, np.nan, True], dtype='boolean')
+    X = pd.DataFrame([True, np.nan, False, np.nan, True])
     y = pd.Series([1, 0, 0, 1, 0])
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='boolean')
+    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype='category')
     X = make_data_type(data_type, X)
     imputer = SimpleImputer()
     imputer.fit(X, y)
     X_t = imputer.transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe())
+    assert_frame_equal(X_expected_arr, X_t)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_simple_imputer_multitype_with_one_bool(data_type, make_data_type):
     X_multi = pd.DataFrame({
-        "bool with nan": pd.Series([True, np.nan, False, np.nan, False], dtype='boolean'),
+        "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
         "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
     y = pd.Series([1, 0, 0, 1, 0])
     X_multi_expected_arr = pd.DataFrame({
-        "bool with nan": pd.Series([True, False, False, False, False], dtype='boolean'),
-        "bool no nan": pd.Series([False, False, False, False, True], dtype='boolean'),
+        "bool with nan": pd.Series([True, False, False, False, False], dtype='category'),
+        "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
     })
     X_multi = make_data_type(data_type, X_multi)
 
     imputer = SimpleImputer()
     imputer.fit(X_multi, y)
     X_multi_t = imputer.transform(X_multi)
-    assert_frame_equal(X_multi_expected_arr, X_multi_t.to_dataframe())
+    assert_frame_equal(X_multi_expected_arr, X_multi_t)
 
 
 def test_simple_imputer_fit_transform_drop_all_nan_columns():
@@ -162,7 +156,7 @@ def test_simple_imputer_fit_transform_drop_all_nan_columns():
     transformer = SimpleImputer(impute_strategy='most_frequent')
     X_expected_arr = pd.DataFrame({"some_nan": [0, 1, 0], "another_col": [0, 1, 2]})
     X_t = transformer.fit_transform(X)
-    assert_frame_equal(X_expected_arr, X_t.to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, X_t, check_dtype=False)
     assert_frame_equal(X, pd.DataFrame({"all_nan": [np.nan, np.nan, np.nan],
                                         "some_nan": [np.nan, 1, 0],
                                         "another_col": [0, 1, 2]}))
@@ -175,7 +169,7 @@ def test_simple_imputer_transform_drop_all_nan_columns():
     transformer = SimpleImputer(impute_strategy='most_frequent')
     transformer.fit(X)
     X_expected_arr = pd.DataFrame({"some_nan": [0, 1, 0], "another_col": [0, 1, 2]})
-    assert_frame_equal(X_expected_arr, transformer.transform(X).to_dataframe(), check_dtype=False)
+    assert_frame_equal(X_expected_arr, transformer.transform(X), check_dtype=False)
     assert_frame_equal(X, pd.DataFrame({"all_nan": [np.nan, np.nan, np.nan],
                                         "some_nan": [np.nan, 1, 0],
                                         "another_col": [0, 1, 2]}))
@@ -184,12 +178,12 @@ def test_simple_imputer_transform_drop_all_nan_columns():
 def test_simple_imputer_transform_drop_all_nan_columns_empty():
     X = pd.DataFrame([[np.nan, np.nan, np.nan]])
     transformer = SimpleImputer(impute_strategy='most_frequent')
-    assert transformer.fit_transform(X).to_dataframe().empty
+    assert transformer.fit_transform(X).empty
     assert_frame_equal(X, pd.DataFrame([[np.nan, np.nan, np.nan]]))
 
     transformer = SimpleImputer(impute_strategy='most_frequent')
     transformer.fit(X)
-    assert transformer.transform(X).to_dataframe().empty
+    assert transformer.transform(X).empty
     assert_frame_equal(X, pd.DataFrame([[np.nan, np.nan, np.nan]]))
 
 
@@ -201,7 +195,7 @@ def test_simple_imputer_numpy_input():
     X_expected_arr = np.array([[0, 1, 1],
                                [2, 3, 2],
                                [2, 3, 0]])
-    assert np.allclose(X_expected_arr, transformer.fit_transform(X).to_dataframe())
+    assert np.allclose(X_expected_arr, transformer.fit_transform(X))
     np.testing.assert_almost_equal(X, np.array([[np.nan, 0, 1, np.nan],
                                                 [np.nan, 2, 3, 2],
                                                 [np.nan, 2, 3, 0]]))
@@ -233,11 +227,11 @@ def test_simple_imputer_fill_value(data_type):
     imputer = SimpleImputer(impute_strategy="constant", fill_value=fill_value)
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
     imputer = SimpleImputer(impute_strategy="constant", fill_value=fill_value)
     transformed = imputer.fit_transform(X, y)
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
 
 def test_simple_imputer_does_not_reset_index():
@@ -256,7 +250,7 @@ def test_simple_imputer_does_not_reset_index():
     pd.testing.assert_frame_equal(pd.DataFrame({'input_val': [1, 2, 3, 4, 5, 6, 7, 8, 9]},
                                                dtype=float,
                                                index=list(range(1, 10))),
-                                  transformed.to_dataframe())
+                                  transformed)
 
 
 def test_simple_imputer_with_none():
@@ -269,10 +263,10 @@ def test_simple_imputer_with_none():
     transformed = imputer.transform(X, y)
     expected = pd.DataFrame({"int with None": [1, 0, 5, 2],
                              "float with None": [0.1, 0.0, 0.5, 0.2]})
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
     X = pd.DataFrame({"category with None": pd.Series(["b", "a", "a", None], dtype='category'),
-                      "boolean with None": pd.Series([True, None, False, True], dtype='boolean'),
+                      "boolean with None": pd.Series([True, None, False, True]),
                       "object with None": ["b", "a", "a", None],
                       "all None": [None, None, None, None]})
     y = pd.Series([0, 0, 1, 0, 1])
@@ -280,38 +274,43 @@ def test_simple_imputer_with_none():
     imputer.fit(X, y)
     transformed = imputer.transform(X, y)
     expected = pd.DataFrame({"category with None": pd.Series(["b", "a", "a", "a"], dtype='category'),
-                             "boolean with None": pd.Series([True, True, False, True], dtype='boolean'),
+                             "boolean with None": pd.Series([True, True, False, True], dtype='category'),
                              "object with None": pd.Series(["b", "a", "a", "a"], dtype='category')})
-    assert_frame_equal(expected, transformed.to_dataframe(), check_dtype=False)
+    assert_frame_equal(expected, transformed, check_dtype=False)
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.Series([1, 2, 3], dtype="Int64")),
                                   pd.DataFrame(pd.Series([1., 2., 3.], dtype="float")),
                                   pd.DataFrame(pd.Series(['a', 'b', 'a'], dtype="category")),
-                                  pd.DataFrame(pd.Series([True, False, True], dtype="boolean")),
+                                  pd.DataFrame(pd.Series([True, False, True], dtype=bool)),
                                   pd.DataFrame(pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string"))])
 @pytest.mark.parametrize("has_nan", [True, False])
-@pytest.mark.parametrize("impute_strategy", ["mean", "median", "most_frequent"])
+@pytest.mark.parametrize("impute_strategy", ["mean", "median"])
 def test_simple_imputer_woodwork_custom_overrides_returned_by_components(X_df, has_nan, impute_strategy):
     y = pd.Series([1, 2, 1])
     if has_nan:
         X_df.iloc[len(X_df) - 1, 0] = np.nan
-    override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
+    override_types = [Integer, Double, Categorical, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df.copy()
+            X.ww.init(logical_types={0: logical_type})
+            from woodwork.table_accessor import _get_invalid_schema_message
+            if _get_invalid_schema_message(X, X.ww.schema):
+                continue
+        except ww.exceptions.TypeConversionError:
             continue
 
         impute_strategy_to_use = impute_strategy
-        if logical_type in [NaturalLanguage, Categorical]:
+        if logical_type == Categorical:
             impute_strategy_to_use = "most_frequent"
 
         imputer = SimpleImputer(impute_strategy=impute_strategy_to_use)
         imputer.fit(X, y)
         transformed = imputer.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        if impute_strategy_to_use == "most_frequent" or not has_nan:
-            assert transformed.logical_types == {0: logical_type}
+        assert isinstance(transformed, pd.DataFrame)
+        # Issue is that converting a nullable type to bool imputes all the categories
+        if impute_strategy_to_use == "most_frequent" or not has_nan or logical_type == Boolean:
+            assert transformed.ww.logical_types == {0: logical_type}
         else:
-            assert transformed.logical_types == {0: Double}
+            assert transformed.ww.logical_types == {0: Double}

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -312,6 +312,9 @@ def test_simple_imputer_woodwork_custom_overrides_returned_by_components(X_df, h
         X_df.iloc[len(X_df) - 1, 0] = np.nan
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean]
     for logical_type in override_types:
+        # Converting a column with NaNs to Boolean will impute NaNs.
+        if has_nan and logical_type == Boolean:
+            continue
         try:
             X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
@@ -328,8 +331,7 @@ def test_simple_imputer_woodwork_custom_overrides_returned_by_components(X_df, h
         imputer.fit(X, y)
         transformed = imputer.transform(X, y)
         assert isinstance(transformed, pd.DataFrame)
-        # Issue is that converting a nullable type to bool imputes all the categories
-        if impute_strategy_to_use == "most_frequent" or not has_nan or logical_type == Boolean:
+        if impute_strategy_to_use == "most_frequent" or not has_nan:
             assert transformed.ww.logical_types == {0: logical_type}
         else:
             assert transformed.ww.logical_types == {0: Double}

--- a/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
+++ b/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 
 from evalml.exceptions import EnsembleMissingPipelinesError
 from evalml.model_family import ModelFamily
@@ -65,7 +64,7 @@ def test_stacked_ensemble_init_with_multiple_same_estimators(X_y_binary, logisti
 
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 def test_stacked_ensemble_n_jobs_negative_one(X_y_binary, logistic_regression_binary_pipeline_class):
@@ -82,7 +81,7 @@ def test_stacked_ensemble_n_jobs_negative_one(X_y_binary, logistic_regression_bi
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 @patch('evalml.pipelines.components.ensemble.StackedEnsembleClassifier._stacking_estimator_class')
@@ -108,7 +107,7 @@ def test_stacked_ensemble_multilevel(logistic_regression_binary_pipeline_class):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 def test_stacked_problem_types():
@@ -134,25 +133,25 @@ def test_stacked_fit_predict_classification(X_y_binary, X_y_multi, stackable_cla
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert isinstance(y_pred, ww.DataColumn)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert isinstance(y_pred, pd.Series)
+    assert not np.isnan(y_pred).all()
 
     y_pred_proba = clf.predict_proba(X)
-    assert isinstance(y_pred_proba, ww.DataTable)
+    assert isinstance(y_pred_proba, pd.DataFrame)
     assert y_pred_proba.shape == (len(y), num_classes)
-    assert not np.isnan(y_pred_proba.to_dataframe()).all().all()
+    assert not np.isnan(y_pred_proba).all().all()
 
     clf = StackedEnsembleClassifier(input_pipelines=input_pipelines, final_estimator=RandomForestClassifier(), n_jobs=1)
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert isinstance(y_pred, ww.DataColumn)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert isinstance(y_pred, pd.Series)
+    assert not np.isnan(y_pred).all()
 
     y_pred_proba = clf.predict_proba(X)
     assert y_pred_proba.shape == (len(y), num_classes)
-    assert isinstance(y_pred_proba, ww.DataTable)
-    assert not np.isnan(y_pred_proba.to_dataframe()).all().all()
+    assert isinstance(y_pred_proba, pd.DataFrame)
+    assert not np.isnan(y_pred_proba).all().all()
 
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])

--- a/evalml/tests/component_tests/test_stacked_ensemble_regressor.py
+++ b/evalml/tests/component_tests/test_stacked_ensemble_regressor.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 
 from evalml.exceptions import EnsembleMissingPipelinesError
 from evalml.model_family import ModelFamily
@@ -66,7 +65,7 @@ def test_stacked_ensemble_init_with_multiple_same_estimators(X_y_regression, lin
 
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 def test_stacked_ensemble_n_jobs_negative_one(X_y_regression, linear_regression_pipeline_class):
@@ -83,7 +82,7 @@ def test_stacked_ensemble_n_jobs_negative_one(X_y_regression, linear_regression_
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 @patch('evalml.pipelines.components.ensemble.StackedEnsembleRegressor._stacking_estimator_class')
@@ -109,7 +108,7 @@ def test_stacked_ensemble_multilevel(linear_regression_pipeline_class):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert not np.isnan(y_pred).all()
 
 
 def test_stacked_problem_types():
@@ -125,15 +124,15 @@ def test_stacked_fit_predict_regression(X_y_regression, stackable_regressors):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert isinstance(y_pred, ww.DataColumn)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert isinstance(y_pred, pd.Series)
+    assert not np.isnan(y_pred).all()
 
     clf = StackedEnsembleRegressor(input_pipelines=input_pipelines, final_estimator=RandomForestRegressor(), n_jobs=1)
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert len(y_pred) == len(y)
-    assert isinstance(y_pred, ww.DataColumn)
-    assert not np.isnan(y_pred.to_series()).all()
+    assert isinstance(y_pred, pd.Series)
+    assert not np.isnan(y_pred).all()
 
 
 @patch('evalml.pipelines.components.ensemble.StackedEnsembleRegressor.fit')

--- a/evalml/tests/component_tests/test_standard_scaler.py
+++ b/evalml/tests/component_tests/test_standard_scaler.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 import woodwork as ww
-from woodwork.logical_types import Boolean, Categorical, Double, Integer
+from woodwork.logical_types import Boolean, Integer, Categorical, Double
 
 from evalml.pipelines.components import StandardScaler
 
@@ -14,12 +14,12 @@ def test_standard_scaler_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, Boolean]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X_df.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         std_scaler = StandardScaler()
-        std_scaler.fit(X, y)
-        transformed = std_scaler.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {0: Double}
+        std_scaler.fit(X_df, y)
+        transformed = std_scaler.transform(X_df, y)
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {0: Double}

--- a/evalml/tests/component_tests/test_standard_scaler.py
+++ b/evalml/tests/component_tests/test_standard_scaler.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 import woodwork as ww
-from woodwork.logical_types import Boolean, Integer, Categorical, Double
+from woodwork.logical_types import Boolean, Categorical, Double, Integer
 
 from evalml.pipelines.components import StandardScaler
 

--- a/evalml/tests/component_tests/test_svm_classifier.py
+++ b/evalml/tests/component_tests/test_svm_classifier.py
@@ -31,8 +31,8 @@ def test_fit_predict_binary(X_y_binary):
     y_pred = svc.predict(X)
     y_pred_proba = svc.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred.to_series().values, y_pred_sk, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba.to_dataframe().values, y_pred_proba_sk, decimal=5)
+    np.testing.assert_almost_equal(y_pred.values, y_pred_sk, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba.values, y_pred_proba_sk, decimal=5)
 
 
 def test_fit_predict_multi(X_y_multi):
@@ -49,8 +49,8 @@ def test_fit_predict_multi(X_y_multi):
     y_pred = svc.predict(X)
     y_pred_proba = svc.predict_proba(X)
 
-    np.testing.assert_almost_equal(y_pred.to_series().values, y_pred_sk, decimal=5)
-    np.testing.assert_almost_equal(y_pred_proba.to_dataframe().values, y_pred_proba_sk, decimal=5)
+    np.testing.assert_almost_equal(y_pred.values, y_pred_sk, decimal=5)
+    np.testing.assert_almost_equal(y_pred_proba.values, y_pred_proba_sk, decimal=5)
 
 
 @pytest.mark.parametrize('kernel', ['linear', 'rbf', 'sigmoid'])

--- a/evalml/tests/component_tests/test_svm_regressor.py
+++ b/evalml/tests/component_tests/test_svm_regressor.py
@@ -26,7 +26,7 @@ def test_fit_predict_regression(X_y_regression):
     svr.fit(X, y)
     y_pred = svr.predict(X)
 
-    np.testing.assert_almost_equal(y_pred.to_series().values, y_pred_sk, decimal=5)
+    np.testing.assert_almost_equal(y_pred.values, y_pred_sk, decimal=5)
 
 
 @pytest.mark.parametrize('kernel', ['linear', 'rbf', 'sigmoid'])

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -6,14 +6,7 @@ import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
 from pytest import importorskip
-from woodwork.logical_types import (
-    Boolean,
-    Categorical,
-    Datetime,
-    Double,
-    Integer,
-    NaturalLanguage
-)
+from woodwork.logical_types import Boolean, Integer, NaturalLanguage, Categorical, Datetime, Double
 
 from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import TargetEncoder
@@ -66,7 +59,7 @@ def test_null_values_in_dataframe():
                                'col_2': [0.526894, 0.526894, 0.526894, 0.6, 0.526894],
                                'col_3': [0.6, 0.6, 0.6, 0.6, 0.6, ]})
 
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     encoder = TargetEncoder(handle_missing='return_nan')
     encoder.fit(X, y)
@@ -74,7 +67,7 @@ def test_null_values_in_dataframe():
     X_expected = pd.DataFrame({'col_1': [0.6, 0.6, 0.6, 0.6, np.nan],
                                'col_2': [0.526894, 0.526894, 0.526894, 0.6, 0.526894],
                                'col_3': [0.6, 0.6, 0.6, 0.6, 0.6, ]})
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     encoder = TargetEncoder(handle_missing='error')
     with pytest.raises(ValueError, match='Columns to be encoded can not contain null'):
@@ -85,20 +78,20 @@ def test_cols():
     X = pd.DataFrame({'col_1': [1, 2, 1, 1, 2],
                       'col_2': ['2', '1', '1', '1', '1'],
                       'col_3': ["a", "a", "a", "a", "a"]})
-    X_expected = X.astype({'col_1': 'Int64', 'col_2': 'category', 'col_3': 'category'})
+    X_expected = X.astype({'col_1': 'int64', 'col_2': 'category', 'col_3': 'category'})
     y = pd.Series([0, 1, 1, 1, 0])
     encoder = TargetEncoder(cols=[])
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     encoder = TargetEncoder(cols=['col_2'])
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="Int64"),
+    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="int64"),
                                'col_2': [0.60000, 0.742886, 0.742886, 0.742886, 0.742886],
                                'col_3': pd.Series(["a", "a", "a", "a", "a"], dtype="category")})
-    assert_frame_equal(X_expected, X_t.to_dataframe(), check_less_precise=True)
+    assert_frame_equal(X_expected, X_t, check_less_precise=True)
 
     encoder = TargetEncoder(cols=['col_2', 'col_3'])
     encoder.fit(X, y)
@@ -106,7 +99,7 @@ def test_cols():
     encoder2 = TargetEncoder()
     encoder2.fit(X, y)
     X_t2 = encoder2.transform(X)
-    assert_frame_equal(X_t.to_dataframe(), X_t2.to_dataframe())
+    assert_frame_equal(X_t, X_t2)
 
 
 def test_transform():
@@ -117,10 +110,10 @@ def test_transform():
     encoder = TargetEncoder()
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="Int64"),
+    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="int64"),
                                'col_2': [0.6, 0.65872, 0.6, 0.65872, 0.65872],
                                'col_3': [0.504743, 0.504743, 0.504743, 0.6, 0.504743]})
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
 
 def test_smoothing():
@@ -132,26 +125,26 @@ def test_smoothing():
     encoder = TargetEncoder(smoothing=1)
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="Int64"),
-                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="Int64"),
+    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="int64"),
+                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="int64"),
                                'col_3': [0.742886, 0.742886, 0.742886, 0.742886, 0.6]})
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     encoder = TargetEncoder(smoothing=10)
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="Int64"),
-                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="Int64"),
+    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="int64"),
+                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="int64"),
                                'col_3': [0.686166, 0.686166, 0.686166, 0.686166, 0.6]})
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
     encoder = TargetEncoder(smoothing=100)
     encoder.fit(X, y)
     X_t = encoder.transform(X)
-    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="Int64"),
-                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="Int64"),
+    X_expected = pd.DataFrame({'col_1': pd.Series([1, 2, 1, 1, 2], dtype="int64"),
+                               'col_2': pd.Series([2, 1, 1, 1, 1], dtype="int64"),
                                'col_3': [0.676125, 0.676125, 0.676125, 0.676125, 0.6]})
-    assert_frame_equal(X_expected, X_t.to_dataframe())
+    assert_frame_equal(X_expected, X_t)
 
 
 def test_get_feature_names():
@@ -191,16 +184,17 @@ def test_target_encoder_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean, Datetime]
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         encoder = TargetEncoder()
         encoder.fit(X, y)
         transformed = encoder.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
+        assert isinstance(transformed, pd.DataFrame)
 
         if logical_type == Categorical:
-            assert transformed.logical_types == {0: Double}
+            assert transformed.ww.logical_types == {0: Double}
         else:
-            assert transformed.logical_types == {0: logical_type}
+            assert transformed.ww.logical_types == {0: logical_type}

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -6,7 +6,14 @@ import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal
 from pytest import importorskip
-from woodwork.logical_types import Boolean, Integer, NaturalLanguage, Categorical, Datetime, Double
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer,
+    NaturalLanguage
+)
 
 from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import TargetEncoder

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -191,7 +191,7 @@ def test_target_encoder_woodwork_custom_overrides_returned_by_components(X_df):
     override_types = [Integer, Double, Categorical, NaturalLanguage, Boolean, Datetime]
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_target_imputer.py
+++ b/evalml/tests/component_tests/test_target_imputer.py
@@ -176,13 +176,16 @@ def test_target_imputer_woodwork_custom_overrides_returned_by_components(y_pd, h
         y_to_use[len(y_pd) - 1] = np.nan
     override_types = [Integer, Double, Categorical, Boolean]
     for logical_type in override_types:
+        # Converting a column with NaNs to Boolean will impute NaNs.
+        if has_nan and logical_type == Boolean:
+            continue
         try:
             y = ww.init_series(y_to_use.copy(), logical_type=logical_type)
         except (ww.exceptions.TypeConversionError, ValueError):
             continue
 
         impute_strategy_to_use = impute_strategy
-        if logical_type in [Categorical, NaturalLanguage, Boolean]:
+        if logical_type in [Categorical, NaturalLanguage]:
             impute_strategy_to_use = "most_frequent"
 
         imputer = TargetImputer(impute_strategy=impute_strategy_to_use)

--- a/evalml/tests/component_tests/test_target_imputer.py
+++ b/evalml/tests/component_tests/test_target_imputer.py
@@ -31,8 +31,8 @@ def test_target_imputer_with_X():
     y_expected = pd.Series([2, 1, 3])
     X_expected = pd.DataFrame({"some col": [1, 3, np.nan]})
     X_t, y_t = imputer.fit_transform(X, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
-    assert_frame_equal(X_expected, X_t.to_dataframe(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
+    assert_frame_equal(X_expected, X_t, check_dtype=False)
 
 
 def test_target_imputer_median():
@@ -40,7 +40,7 @@ def test_target_imputer_median():
     imputer = TargetImputer(impute_strategy='median')
     y_expected = pd.Series([8, 1, 10, 10, 6])
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 def test_target_imputer_mean():
@@ -48,7 +48,7 @@ def test_target_imputer_mean():
     imputer = TargetImputer(impute_strategy='mean')
     y_expected = pd.Series([1, 2, 0])
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 @pytest.mark.parametrize("fill_value, y, y_expected", [(None, pd.Series([np.nan, 0, 5]), pd.Series([0, 0, 5])),
@@ -58,7 +58,7 @@ def test_target_imputer_mean():
 def test_target_imputer_constant(fill_value, y, y_expected):
     imputer = TargetImputer(impute_strategy='constant', fill_value=fill_value)
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 def test_target_imputer_most_frequent():
@@ -66,13 +66,13 @@ def test_target_imputer_most_frequent():
     imputer = TargetImputer(impute_strategy='most_frequent')
     y_expected = pd.Series(["a", "a", "b"]).astype("category")
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
     y = pd.Series([np.nan, 1, 1, 2])
     imputer = TargetImputer(impute_strategy='most_frequent')
     y_expected = pd.Series([1, 1, 1, 2])
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 def test_target_imputer_col_with_non_numeric_with_numeric_strategy():
@@ -93,22 +93,22 @@ def test_target_imputer_col_with_non_numeric_with_numeric_strategy():
 def test_target_imputer_all_bool_return_original(data_type, make_data_type):
     y = pd.Series([True, True, False, True, True], dtype=bool)
     y = make_data_type(data_type, y)
-    y_expected = pd.Series([True, True, False, True, True], dtype='boolean')
+    y_expected = pd.Series([True, True, False, True, True], dtype=bool)
     imputer = TargetImputer()
     imputer.fit(None, y)
     _, y_t = imputer.transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series())
+    assert_series_equal(y_expected, y_t)
 
 
 @pytest.mark.parametrize("data_type", ['pd', 'ww'])
 def test_target_imputer_boolean_dtype(data_type, make_data_type):
-    y = pd.Series([True, np.nan, False, np.nan, True], dtype='boolean')
-    y_expected = pd.Series([True, True, False, True, True], dtype='boolean')
+    y = pd.Series([True, np.nan, False, np.nan, True], dtype='category')
+    y_expected = pd.Series([True, True, False, True, True], dtype='category')
     y = make_data_type(data_type, y)
     imputer = TargetImputer()
     imputer.fit(None, y)
     _, y_t = imputer.transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series())
+    assert_series_equal(y_expected, y_t)
 
 
 def test_target_imputer_fit_transform_all_nan_empty():
@@ -129,7 +129,7 @@ def test_target_imputer_numpy_input():
     imputer = TargetImputer(impute_strategy='mean')
     y_expected = np.array([1, 0, 2])
     _, y_t = imputer.fit_transform(None, y)
-    assert np.allclose(y_expected, y_t.to_series())
+    assert np.allclose(y_expected, y_t)
     np.testing.assert_almost_equal(y, np.array([np.nan, 0, 2]))
 
 
@@ -144,7 +144,7 @@ def test_target_imputer_does_not_reset_index():
     imputer = TargetImputer(impute_strategy="mean")
     imputer.fit(None, y=y)
     _, y_t = imputer.transform(None, y)
-    pd.testing.assert_series_equal(pd.Series([1.0, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float, index=list(range(1, 10))), y_t.to_series())
+    pd.testing.assert_series_equal(pd.Series([1.0, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float, index=list(range(1, 10))), y_t)
 
 
 @pytest.mark.parametrize("y, y_expected", [(pd.Series([1, 0, 5, None]), pd.Series([1, 0, 5, 2])),
@@ -152,23 +152,22 @@ def test_target_imputer_does_not_reset_index():
 def test_target_imputer_with_none(y, y_expected):
     imputer = TargetImputer(impute_strategy="mean")
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 @pytest.mark.parametrize("y, y_expected", [(pd.Series(["b", "a", "a", None], dtype='category'), pd.Series(["b", "a", "a", "a"], dtype='category')),
-                                           (pd.Series([True, None, False, True], dtype='boolean'), pd.Series([True, True, False, True], dtype='boolean')),
+                                           (pd.Series([True, None, False, True], dtype='category'), pd.Series([True, True, False, True], dtype='category')),
                                            (pd.Series(["b", "a", "a", None]), pd.Series(["b", "a", "a", "a"], dtype='category'))])
 def test_target_imputer_with_none_non_numeric(y, y_expected):
     imputer = TargetImputer()
     _, y_t = imputer.fit_transform(None, y)
-    assert_series_equal(y_expected, y_t.to_series(), check_dtype=False)
+    assert_series_equal(y_expected, y_t, check_dtype=False)
 
 
 @pytest.mark.parametrize("y_pd", [pd.Series([1, 2, 3], dtype="int64"),
                                   pd.Series([1., 2., 3.], dtype="float"),
                                   pd.Series(['a', 'b', 'a'], dtype="category"),
-                                  pd.Series([True, False, True], dtype="boolean"),
-                                  pd.Series(['this will be a natural language column because length', 'yay', 'hay'], dtype="string")])
+                                  pd.Series([True, False, True], dtype=bool)])
 @pytest.mark.parametrize("has_nan", [True, False])
 @pytest.mark.parametrize("impute_strategy", ["mean", "median", "most_frequent"])
 def test_target_imputer_woodwork_custom_overrides_returned_by_components(y_pd, has_nan, impute_strategy):
@@ -178,20 +177,19 @@ def test_target_imputer_woodwork_custom_overrides_returned_by_components(y_pd, h
     override_types = [Integer, Double, Categorical, Boolean]
     for logical_type in override_types:
         try:
-            y = ww.DataColumn(y_to_use.copy(), logical_type=logical_type)
-        except TypeError:
+            y = ww.init_series(y_to_use.copy(), logical_type=logical_type)
+        except (ww.exceptions.TypeConversionError, ValueError):
             continue
 
         impute_strategy_to_use = impute_strategy
-        if logical_type in [Categorical, NaturalLanguage]:
+        if logical_type in [Categorical, NaturalLanguage, Boolean]:
             impute_strategy_to_use = "most_frequent"
 
         imputer = TargetImputer(impute_strategy=impute_strategy_to_use)
         imputer.fit(None, y)
         _, y_t = imputer.transform(None, y)
-        assert isinstance(y_t, ww.DataColumn)
 
         if impute_strategy_to_use == "most_frequent" or not has_nan:
-            assert y_t.logical_type == logical_type
+            assert y_t.ww.logical_type == logical_type
         else:
-            assert y_t.logical_type == Double
+            assert y_t.ww.logical_type == Double

--- a/evalml/tests/component_tests/test_text_featurizer.py
+++ b/evalml/tests/component_tests/test_text_featurizer.py
@@ -267,7 +267,7 @@ def test_text_featurizer_woodwork_custom_overrides_returned_by_components(X_df):
 
     for logical_type in override_types:
         try:
-            X = X_df
+            X = X_df.copy()
             X.ww.init(logical_types={0: logical_type})
         except ww.exceptions.TypeConversionError:
             continue

--- a/evalml/tests/component_tests/test_text_featurizer.py
+++ b/evalml/tests/component_tests/test_text_featurizer.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal, assert_series_equal
-from woodwork.logical_types import Boolean, Categorical, Double, Integer
+from woodwork.logical_types import Boolean, Integer, Categorical, Double
 
 from evalml.pipelines.components import TextFeaturizer
 from evalml.utils import infer_feature_types
@@ -27,7 +27,7 @@ def test_featurizer_only_text(text_df):
     X_t = tf.transform(X)
     assert set(X_t.columns) == expected_col_names
     assert len(X_t.columns) == 10
-    assert set(X_t.logical_types.values()) == {ww.logical_types.Double}
+    assert set(X_t.ww.logical_types.values()) == {ww.logical_types.Double}
 
 
 def test_featurizer_with_nontext(text_df):
@@ -50,7 +50,7 @@ def test_featurizer_with_nontext(text_df):
     X_t = tf.transform(X)
     assert set(X_t.columns) == expected_col_names
     assert len(X_t.columns) == 11
-    assert set(X_t.logical_types.values()) == {ww.logical_types.Double}
+    assert set(X_t.ww.logical_types.values()) == {ww.logical_types.Double}
 
 
 def test_featurizer_no_text():
@@ -78,7 +78,7 @@ def test_some_missing_col_names(text_df, caplog):
     X_t = tf.transform(X)
     assert set(X_t.columns) == expected_col_names
     assert len(X_t.columns) == 10
-    assert set(X_t.logical_types.values()) == {ww.logical_types.Double}
+    assert set(X_t.ww.logical_types.values()) == {ww.logical_types.Double}
 
 
 def test_empty_text_column():
@@ -117,7 +117,7 @@ def test_no_null_output():
     tf = TextFeaturizer()
     tf.fit(X)
     X_t = tf.transform(X)
-    assert not X_t.to_dataframe().isnull().any().any()
+    assert not X_t.isnull().any().any()
 
 
 def test_index_col_names():
@@ -140,7 +140,7 @@ def test_index_col_names():
     X_t = tf.transform(X)
     assert set(X_t.columns) == expected_col_names
     assert len(X_t.columns) == 10
-    assert set(X_t.logical_types.values()) == {ww.logical_types.Double}
+    assert set(X_t.ww.logical_types.values()) == {ww.logical_types.Double}
 
 
 def test_float_col_names():
@@ -167,7 +167,7 @@ def test_float_col_names():
     X_t = tf.transform(X)
     assert set(X_t.columns) == expected_col_names
     assert len(X_t.columns) == 10
-    assert set(X_t.logical_types.values()) == {ww.logical_types.Double}
+    assert set(X_t.ww.logical_types.values()) == {ww.logical_types.Double}
 
 
 def test_output_null():
@@ -182,7 +182,7 @@ def test_output_null():
     tf = TextFeaturizer()
     tf.fit(X)
     X_t = tf.transform(X)
-    assert not X_t.to_dataframe().isnull().any().any()
+    assert not X_t.isnull().any().any()
 
 
 def test_diversity_primitive_output():
@@ -195,7 +195,7 @@ def test_diversity_primitive_output():
 
     expected_features = pd.Series([1.0, 0.5, 0.75], name='DIVERSITY_SCORE(diverse)')
     X_t = tf.transform(X)
-    features = X_t['DIVERSITY_SCORE(diverse)'].to_series()
+    features = X_t['DIVERSITY_SCORE(diverse)']
     assert_series_equal(expected_features, features)
 
 
@@ -213,7 +213,7 @@ def test_lsa_primitive_output():
     X_t = tf.transform(X)
     cols = [col for col in X_t.columns if 'LSA' in col]
     features = X_t[cols]
-    assert_frame_equal(expected_features, features.to_dataframe(), atol=1e-3)
+    assert_frame_equal(expected_features, features, atol=1e-3)
 
 
 def test_mean_characters_primitive_output():
@@ -227,7 +227,7 @@ def test_mean_characters_primitive_output():
     expected_features = pd.Series([4.11764705882352, 3.45, 3.72727272727], name='MEAN_CHARACTERS_PER_WORD(mean_characters)')
     X_t = tf.transform(X)
     features = X_t['MEAN_CHARACTERS_PER_WORD(mean_characters)']
-    assert_series_equal(expected_features, features.to_series())
+    assert_series_equal(expected_features, features)
 
 
 def test_polarity_primitive_output():
@@ -241,7 +241,7 @@ def test_polarity_primitive_output():
     expected_features = pd.Series([0.0, -0.214, 0.602], name='POLARITY_SCORE(polarity)')
     X_t = tf.transform(X)
     features = X_t['POLARITY_SCORE(polarity)']
-    assert_series_equal(expected_features, features.to_series())
+    assert_series_equal(expected_features, features)
 
 
 def test_featurizer_with_custom_indices(text_df):
@@ -250,7 +250,7 @@ def test_featurizer_with_custom_indices(text_df):
     tf = TextFeaturizer(text_columns=['col_1', 'col_2'])
     tf.fit(X)
     X_t = tf.transform(X)
-    assert not X_t.to_dataframe().isnull().any().any()
+    assert not X_t.isnull().any().any()
 
 
 @pytest.mark.parametrize("X_df", [pd.DataFrame(pd.Series([1, 2, 10], dtype="Int64")),
@@ -267,15 +267,16 @@ def test_text_featurizer_woodwork_custom_overrides_returned_by_components(X_df):
 
     for logical_type in override_types:
         try:
-            X = ww.DataTable(X_df, logical_types={0: logical_type})
-        except TypeError:
+            X = X_df
+            X.ww.init(logical_types={0: logical_type})
+        except ww.exceptions.TypeConversionError:
             continue
 
         tf.fit(X)
         transformed = tf.transform(X, y)
-        assert isinstance(transformed, ww.DataTable)
-        assert transformed.logical_types == {0: logical_type, 'LSA(text col)[0]': Double,
-                                             'LSA(text col)[1]': Double,
-                                             'DIVERSITY_SCORE(text col)': Double,
-                                             'MEAN_CHARACTERS_PER_WORD(text col)': Double,
-                                             'POLARITY_SCORE(text col)': Double}
+        assert isinstance(transformed, pd.DataFrame)
+        assert transformed.ww.logical_types == {0: logical_type, 'LSA(text col)[0]': Double,
+                                                'LSA(text col)[1]': Double,
+                                                'DIVERSITY_SCORE(text col)': Double,
+                                                'MEAN_CHARACTERS_PER_WORD(text col)': Double,
+                                                'POLARITY_SCORE(text col)': Double}

--- a/evalml/tests/component_tests/test_text_featurizer.py
+++ b/evalml/tests/component_tests/test_text_featurizer.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import woodwork as ww
 from pandas.testing import assert_frame_equal, assert_series_equal
-from woodwork.logical_types import Boolean, Integer, Categorical, Double
+from woodwork.logical_types import Boolean, Categorical, Double, Integer
 
 from evalml.pipelines.components import TextFeaturizer
 from evalml.utils import infer_feature_types

--- a/evalml/tests/component_tests/test_time_series_baseline_estimators.py
+++ b/evalml/tests/component_tests/test_time_series_baseline_estimators.py
@@ -32,7 +32,7 @@ def test_time_series_baseline(ts_data):
     clf = TimeSeriesBaselineEstimator(gap=1)
     clf.fit(X, y)
 
-    assert_series_equal(y.astype("Int64"), clf.predict(X, y).to_series())
+    assert_series_equal(y.astype("int64"), clf.predict(X, y))
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
 
@@ -44,7 +44,7 @@ def test_time_series_baseline_gap_0(ts_data):
     clf = TimeSeriesBaselineEstimator(gap=0)
     clf.fit(X, y)
 
-    assert_series_equal(y_true, clf.predict(X, y).to_series())
+    assert_series_equal(y_true, clf.predict(X, y))
     np.testing.assert_allclose(clf.feature_importance, np.array([0.0] * X.shape[1]))
 
 
@@ -54,5 +54,5 @@ def test_time_series_baseline_no_X(ts_data):
     clf = TimeSeriesBaselineEstimator()
     clf.fit(X=None, y=y)
 
-    assert_series_equal(y.astype("Int64"), clf.predict(X=None, y=y).to_series())
+    assert_series_equal(y.astype("int64"), clf.predict(X=None, y=y))
     np.testing.assert_allclose(clf.feature_importance, np.array([]))

--- a/evalml/tests/component_tests/test_undersampler.py
+++ b/evalml/tests/component_tests/test_undersampler.py
@@ -35,15 +35,8 @@ def test_no_undersample(data_type, make_data_type, X_y_binary):
     undersampler = Undersampler()
     new_X, new_y = undersampler.fit_transform(X, y)
 
-    if data_type == "ww":
-        X = X.to_dataframe().values
-        y = y.to_series().values
-    elif data_type == "pd":
-        X = X.values
-        y = y.values
-
-    np.testing.assert_equal(X, new_X.to_dataframe().values)
-    np.testing.assert_equal(y, new_y.to_series().values)
+    np.testing.assert_equal(X, new_X.values)
+    np.testing.assert_equal(y, new_y.values)
 
 
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
@@ -59,18 +52,11 @@ def test_undersample_imbalanced(data_type, make_data_type):
 
     assert len(new_X) == 750
     assert len(new_y) == 750
-    value_counts = new_y.to_series().value_counts()
+    value_counts = new_y.value_counts()
     assert value_counts.values[1] / value_counts.values[0] == sampling_ratio
     pd.testing.assert_series_equal(value_counts, pd.Series([600, 150], index=[1, 0]), check_dtype=False)
 
     transform_X, transform_y = undersampler.transform(X, y)
 
-    if data_type == "ww":
-        X = X.to_dataframe().values
-        y = y.to_series().values
-    elif data_type == "pd":
-        X = X.values
-        y = y.values
-
-    np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(X, transform_X.values)
+    np.testing.assert_equal(y, transform_y.values)

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -43,11 +43,11 @@ def test_xgboost_feature_name_with_random_ascii(problem_type, X_y_binary, X_y_mu
     clf.fit(X, y)
     predictions = clf.predict(X)
     assert len(predictions) == len(y)
-    assert not np.isnan(predictions.to_series()).all()
+    assert not np.isnan(predictions).all()
 
     predictions = clf.predict_proba(X)
     assert predictions.shape == (len(y), expected_cols)
-    assert not np.isnan(predictions.to_dataframe()).all().all()
+    assert not np.isnan(predictions).all().all()
 
     assert len(clf.feature_importance) == len(X.columns)
     assert not np.isnan(clf.feature_importance).all().all()
@@ -66,5 +66,5 @@ def test_xgboost_multiindex(data_type, X_y_binary, make_data_type):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     y_pred_proba = clf.predict_proba(X)
-    assert not y_pred.to_series().isnull().values.any()
-    assert not y_pred_proba.to_dataframe().isnull().values.any().any()
+    assert not y_pred.isnull().values.any()
+    assert not y_pred_proba.isnull().values.any().any()

--- a/evalml/tests/component_tests/test_xgboost_regressor.py
+++ b/evalml/tests/component_tests/test_xgboost_regressor.py
@@ -33,7 +33,7 @@ def test_xgboost_feature_name_with_random_ascii(X_y_regression):
     clf.fit(X, y)
     predictions = clf.predict(X)
     assert len(predictions) == len(y)
-    assert not np.isnan(predictions.to_series()).all()
+    assert not np.isnan(predictions).all()
 
     assert len(clf.feature_importance) == len(X.columns)
     assert not np.isnan(clf.feature_importance).all().all()
@@ -51,4 +51,4 @@ def test_xgboost_multiindex(data_type, X_y_regression, make_data_type):
     clf = XGBoostRegressor()
     clf.fit(X, y)
     y_pred = clf.predict(X)
-    assert not y_pred.to_series().isnull().values.any()
+    assert not y_pred.isnull().values.any()

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -210,13 +210,14 @@ def _rename_column_names_to_numeric(X, flatten_tuples=True):
     if isinstance(X, (np.ndarray, list)):
         return pd.DataFrame(X)
 
+    X_renamed = X.copy()
     if flatten_tuples and (len(X.columns) > 0 and isinstance(X.columns, pd.MultiIndex)):
-        flat_col_names = list(map(str, X.columns))
-        X.columns = flat_col_names
+        flat_col_names = list(map(str, X_renamed.columns))
+        X_renamed.columns = flat_col_names
         rename_cols_dict = dict((str(col), col_num) for col_num, col in enumerate(list(X.columns)))
     else:
         rename_cols_dict = dict((col, col_num) for col_num, col in enumerate(list(X.columns)))
-    X_renamed = X.rename(columns=rename_cols_dict)
+    X_renamed.rename(columns=rename_cols_dict, inplace=True)
     return X_renamed
 
 

--- a/evalml/utils/woodwork_utils.py
+++ b/evalml/utils/woodwork_utils.py
@@ -54,22 +54,16 @@ def infer_feature_types(data, feature_types=None):
 
     _raise_value_error_if_nullable_types_detected(data)
 
-    ww_data = data.copy()
+    if data.ww.schema is not None:
+        data.ww.init(schema=data.ww.schema)
+        return data
 
     if isinstance(data, pd.Series):
-        if data.ww.schema is not None:
-            ww_data = ww.init_series(ww_data, logical_type=data.ww.logical_type,
-                                     semantic_tags=data.ww.semantic_tags,
-                                     description=data.ww.description)
-        else:
-            ww_data = ww.init_series(ww_data, logical_type=feature_types)
+        return ww.init_series(data, logical_type=feature_types)
     else:
-        if data.ww.schema is not None:
-            ww_data.ww.init(schema=data.ww.schema)
-        else:
-            ww_data.ww.init(logical_types=feature_types)
-
-    return ww_data
+        ww_data = data.copy()
+        ww_data.ww.init(logical_types=feature_types)
+        return ww_data
 
 
 def _convert_woodwork_types_wrapper():


### PR DESCRIPTION
### Pull Request Description
Updating components for the woodwork 0.2.0 update.

I've tried to eliminate the use `_retain_custom_types` as much as possible but there are some places where we need to keep it for the time being, e.g. standard scaler, imputers, dfs component.


See the roadmap [here](https://github.com/alteryx/evalml/pull/2181#issue-621551559)


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
