### PR TITLE
Sort first batch of automl

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Update precision-recall curve with positive label index argument, and fix for 2d predicted probabilities :pr:`2090`
         * Add pct_null_rows to ``HighlyNullDataCheck`` :pr:`2211`
         * Added a standalone AutoML `search` method for convenience, which runs data checks and then runs automl :pr:`2152`
+        * Make the first batch of AutoML have a predefined order, with linear models first and complex models last :pr:`2223`
     * Fixes
         * Fixed partial dependence not respecting grid resolution parameter for numerical features :pr:`2180`
     * Changes

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -9,6 +9,16 @@ from .automl_algorithm import AutoMLAlgorithm, AutoMLAlgorithmException
 from evalml.model_family import ModelFamily
 from evalml.pipelines.utils import _make_stacked_ensemble_pipeline
 
+_ESTIMATOR_FAMILY_ORDER = [
+    ModelFamily.LINEAR_MODEL,
+    ModelFamily.DECISION_TREE,
+    ModelFamily.EXTRA_TREES,
+    ModelFamily.RANDOM_FOREST,
+    ModelFamily.XGBOOST,
+    ModelFamily.LIGHTGBM,
+    ModelFamily.CATBOOST
+]
+
 
 class IterativeAlgorithm(AutoMLAlgorithm):
     """An automl algorithm which first fits a base round of pipelines with default parameters, then does a round of parameter tuning on each pipeline in order of performance."""
@@ -23,7 +33,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                  number_features=None,  # TODO remove
                  ensembling=False,
                  pipeline_params=None,
-                 _frozen_pipeline_parameters=None):
+                 _frozen_pipeline_parameters=None,
+                 _estimator_family_order=None):
         """An automl algorithm which first fits a base round of pipelines with default parameters, then does a round of parameter tuning on each pipeline in order of performance.
 
         Arguments:
@@ -37,7 +48,21 @@ class IterativeAlgorithm(AutoMLAlgorithm):
             ensembling (boolean): If True, runs ensembling in a separate batch after every allowed pipeline class has been iterated over. Defaults to False.
             pipeline_params (dict or None): Pipeline-level parameters that should be passed to the proposed pipelines.
             _frozen_pipeline_parameters (dict or None): Pipeline-level parameters are frozen and used in the proposed pipelines.
+            _estimator_family_order (list(ModelFamily) or None): specify the sort order for the first batch. Defaults to _ESTIMATOR_FAMILY_ORDER.
         """
+        self._estimator_family_order = _estimator_family_order or _ESTIMATOR_FAMILY_ORDER
+        indices = []
+        pipelines_to_sort = []
+        pipelines_end = []
+        for pipeline in allowed_pipelines:
+            if pipeline.model_family in self._estimator_family_order:
+                indices.append(self._estimator_family_order.index(pipeline.model_family))
+                pipelines_to_sort.append(pipeline)
+            else:
+                pipelines_end.append(pipeline)
+        pipelines_start = [pipeline for _, pipeline in sorted(zip(indices, pipelines_to_sort), key=lambda pair: pair[0])]
+        allowed_pipelines = pipelines_start + pipelines_end
+
         super().__init__(allowed_pipelines=allowed_pipelines,
                          max_iterations=max_iterations,
                          tuner_class=tuner_class,

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -54,13 +54,14 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         indices = []
         pipelines_to_sort = []
         pipelines_end = []
-        for pipeline in allowed_pipelines:
+        for pipeline in allowed_pipelines or []:
             if pipeline.model_family in self._estimator_family_order:
                 indices.append(self._estimator_family_order.index(pipeline.model_family))
                 pipelines_to_sort.append(pipeline)
             else:
                 pipelines_end.append(pipeline)
-        pipelines_start = [pipeline for _, pipeline in sorted(zip(indices, pipelines_to_sort), key=lambda pair: pair[0])]
+        pipelines_start = [pipeline for _, pipeline in (sorted(zip(indices, pipelines_to_sort),
+                                                               key=lambda pair: pair[0]) or [])]
         allowed_pipelines = pipelines_start + pipelines_end
 
         super().__init__(allowed_pipelines=allowed_pipelines,

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -394,11 +394,16 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary, has_min
     next_batch = algo.next_batch()
     estimators_in_first_batch = [p.estimator.name for p in next_batch]
 
-    final_estimators = []
-    if has_minimal_dependencies:
+    if problem_type == ProblemTypes.REGRESSION:
         final_estimators = ['XGBoost Regressor',
                             'LightGBM Regressor',
                             'CatBoost Regressor']
+    else:
+        final_estimators = ['XGBoost Classifier',
+                            'LightGBM Classifier',
+                            'CatBoost Classifier']
+    if has_minimal_dependencies:
+        final_estimators = []
     if problem_type == ProblemTypes.REGRESSION:
         assert estimators_in_first_batch == ['Linear Regressor',
                                              'Elastic Net Regressor',

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -384,7 +384,7 @@ def test_iterative_algorithm_results_best_pipeline_info_id(dummy_binary_pipeline
 
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.REGRESSION, ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
-def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
+def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary, has_minimal_dependencies):
     X, y = X_y_binary
     estimators = get_estimators(problem_type, None)
     pipelines = [make_pipeline(X, y, e, problem_type) for e in estimators]
@@ -393,32 +393,29 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
     # initial batch contains one of each pipeline, with default parameters
     next_batch = algo.next_batch()
     estimators_in_first_batch = [p.estimator.name for p in next_batch]
+
+    final_estimators = []
+    if has_minimal_dependencies:
+        final_estimators = ['XGBoost Regressor',
+                            'LightGBM Regressor',
+                            'CatBoost Regressor']
     if problem_type == ProblemTypes.REGRESSION:
         assert estimators_in_first_batch == ['Linear Regressor',
                                              'Elastic Net Regressor',
                                              'Decision Tree Regressor',
                                              'Extra Trees Regressor',
-                                             'Random Forest Regressor',
-                                             'XGBoost Regressor',
-                                             'LightGBM Regressor',
-                                             'CatBoost Regressor']
+                                             'Random Forest Regressor'] + final_estimators
     elif problem_type == ProblemTypes.BINARY:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
                                              'Extra Trees Classifier',
-                                             'Random Forest Classifier',
-                                             'XGBoost Classifier',
-                                             'LightGBM Classifier',
-                                             'CatBoost Classifier']
+                                             'Random Forest Classifier'] + final_estimators
     elif problem_type == ProblemTypes.MULTICLASS:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
                                              'Extra Trees Classifier',
-                                             'Random Forest Classifier',
-                                             'XGBoost Classifier',
-                                             'LightGBM Classifier',
-                                             'CatBoost Classifier']
+                                             'Random Forest Classifier'] + final_estimators
     else:
         assert False, "Invalid problem type in test"

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -393,7 +393,7 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
     # initial batch contains one of each pipeline, with default parameters
     next_batch = algo.next_batch()
     estimators_in_first_batch = [p.estimator.name for p in next_batch]
-    if problem_type == 'regression':
+    if problem_type == ProblemTypes.REGRESSION:
         assert estimators_in_first_batch == ['Linear Regressor',
                                              'Elastic Net Regressor',
                                              'Decision Tree Regressor',
@@ -402,7 +402,7 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
                                              'XGBoost Regressor',
                                              'LightGBM Regressor',
                                              'CatBoost Regressor']
-    if problem_type == 'binary':
+    if problem_type == ProblemTypes.BINARY:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
@@ -411,7 +411,7 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
                                              'XGBoost Classifier',
                                              'LightGBM Classifier',
                                              'CatBoost Classifier']
-    if problem_type == 'multiclass':
+    if problem_type == ProblemTypes.MULTICLASS:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -410,17 +410,15 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary, has_min
                                              'Decision Tree Regressor',
                                              'Extra Trees Regressor',
                                              'Random Forest Regressor'] + final_estimators
-    elif problem_type == ProblemTypes.BINARY:
+    if problem_type == ProblemTypes.BINARY:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
                                              'Extra Trees Classifier',
                                              'Random Forest Classifier'] + final_estimators
-    elif problem_type == ProblemTypes.MULTICLASS:
+    if problem_type == ProblemTypes.MULTICLASS:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
                                              'Extra Trees Classifier',
                                              'Random Forest Classifier'] + final_estimators
-    else:
-        assert False, "Invalid problem type in test"

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -370,8 +370,8 @@ def test_iterative_algorithm_results_best_pipeline_info_id(dummy_binary_pipeline
     scores = np.arange(0, len(next_batch))
     for pipeline_num, (score, pipeline) in enumerate(zip(scores, next_batch)):
         algo.add_result(score, pipeline, {"id": algo.pipeline_number + pipeline_num})
-    assert algo._best_pipeline_info[ModelFamily.RANDOM_FOREST]['id'] == 2
-    assert algo._best_pipeline_info[ModelFamily.LINEAR_MODEL]['id'] == 3
+    assert algo._best_pipeline_info[ModelFamily.RANDOM_FOREST]['id'] == 3
+    assert algo._best_pipeline_info[ModelFamily.LINEAR_MODEL]['id'] == 2
 
     for i in range(1, 3):
         next_batch = algo.next_batch()

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -402,7 +402,7 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
                                              'XGBoost Regressor',
                                              'LightGBM Regressor',
                                              'CatBoost Regressor']
-    if problem_type == ProblemTypes.BINARY:
+    elif problem_type == ProblemTypes.BINARY:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
@@ -411,7 +411,7 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
                                              'XGBoost Classifier',
                                              'LightGBM Classifier',
                                              'CatBoost Classifier']
-    if problem_type == ProblemTypes.MULTICLASS:
+    elif problem_type == ProblemTypes.MULTICLASS:
         assert estimators_in_first_batch == ['Elastic Net Classifier',
                                              'Logistic Regression Classifier',
                                              'Decision Tree Classifier',
@@ -420,3 +420,5 @@ def test_iterative_algorithm_first_batch_order(problem_type, X_y_binary):
                                              'XGBoost Classifier',
                                              'LightGBM Classifier',
                                              'CatBoost Classifier']
+    else:
+        assert False, "Invalid problem type in test"


### PR DESCRIPTION
Fix #1341 

Sort first batch of `IterativeAlgorithm` by model family. Linear models first. Anything which isn't listed will appear at the end of the batch.

This is helpful if someone specifies `max_iterations` which is less than the full number which automl would run by default (which is currently 9 for binary/multiclass/regression problem types).