### PR TITLE
Add Prophet Regressor

### DIFF
--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -65,7 +65,18 @@ jobs:
           # "!" negates return code. exit nonzero if any of these deps are found
           ! pip freeze | grep -E "xgboost|catboost|lightgbm|plotly|ipywidgets|category_encoders"
           exit $?
-      - if: ${{ !matrix.core_dependencies }}
+      - if: ${{ !matrix.core_dependencies && (matrix.command == 'git-test-automl' || matrix.command == 'git-test-other') }}
+        name: Installing Dependencies and Prophet
+        run: |
+          pip install virtualenv
+          virtualenv test_python -q
+          source test_python/bin/activate
+          pip install cmdstan-builder==0.0.4
+          make installdeps
+          make installdeps-test
+          pip uninstall pystan -y
+          pip freeze
+      - if: ${{ !matrix.core_dependencies && (matrix.command == 'git-test-modelunderstanding' || matrix.command == 'git-test-dask') }}
         name: Installing Dependencies
         run: |
           pip install virtualenv
@@ -73,6 +84,7 @@ jobs:
           source test_python/bin/activate
           make installdeps
           make installdeps-test
+          pip uninstall pystan -y
           pip freeze
       - name: Erase Coverage
         run: |

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -84,7 +84,6 @@ jobs:
           source test_python/bin/activate
           make installdeps
           make installdeps-test
-          pip uninstall pystan -y
           pip freeze
       - name: Erase Coverage
         run: |

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -74,7 +74,6 @@ jobs:
           pip install cmdstan-builder==0.0.4
           make installdeps
           make installdeps-test
-          pip uninstall pystan -y
           pip freeze
       - if: ${{ !matrix.core_dependencies && (matrix.command == 'git-test-modelunderstanding' || matrix.command == 'git-test-dask') }}
         name: Installing Dependencies

--- a/.github/workflows/linux_unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_minimum_deps.yml
@@ -35,7 +35,17 @@ jobs:
           virtualenv test_python -q
           source test_python/bin/activate
           python -m pip install --upgrade pip -q
-      - name: install evalml with test dependencies, core dependencies, & optional requirements
+      - if: ${{ matrix.command == 'git-test-automl' || matrix.command == 'git-test-other' }}
+        name: Install evalml with test dependencies, core dependencies, & optional requirements (Prophet)
+        run: |
+          source test_python/bin/activate
+          pip install cmdstan-builder==0.0.4
+          pip install -e . --no-dependencies
+          pip install -r evalml/tests/dependency_update_check/minimum_test_requirements.txt
+          pip install -r evalml/tests/dependency_update_check/minimum_core_requirements.txt
+          pip install -r evalml/tests/dependency_update_check/minimum_requirements.txt
+      - if: ${{ matrix.command == 'git-test-modelunderstanding' || matrix.command == 'git-test-dask' }}
+        name: Install evalml with test dependencies, core dependencies, & optional requirements
         run: |
           source test_python/bin/activate
           pip install -e . --no-dependencies

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ EvalML is an AutoML library which builds, optimizes, and evaluates machine learn
 ```shell
 pip install evalml
 ```
+#### Install with Facebook's Prophet (time series)
+To support the `Prophet` time series estimator, be sure to install it as an extra requirement. Please note that this may take a few minutes.
+Prophet is currently only supported via pip installation in EvalML.
+```
+pip install evalml[prophet]
+```
 
 #### Add-ons
 **Update checker** <br>

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+        * Added ``ProphetRegressor`` to estimators :pr:`2242`
         * Added ``LogTransformer`` and ``TargetDistributionDataCheck`` :pr:`2487`
         * Issue a warning to users when a pipeline parameter passed in isn't used in the pipeline :pr:`2564`
         * Added Gini coefficient as an objective :pr:`2544`
@@ -456,7 +457,6 @@ Release Notes
         * Addressed bug with ``partial_dependence`` and categorical data with more categories than grid resolution :pr:`1748`
         * Removed ``random_state`` arg from ``get_pipelines`` in ``AutoMLSearch`` :pr:`1719`
         * Pinned pyzmq at less than 22.0.0 till we add support :pr:`1756`
-        * Remove ``ProphetRegressor`` from main as windows tests were flaky :pr:`1764`
     * Changes
         * Updated components and pipelines to return ``Woodwork`` data structures :pr:`1668`
         * Updated ``clone()`` for pipelines and components to copy over random state automatically :pr:`1753`

--- a/evalml/model_family/model_family.py
+++ b/evalml/model_family/model_family.py
@@ -40,6 +40,9 @@ class ModelFamily(Enum):
     BASELINE = "baseline"
     """Baseline model family."""
 
+    PROPHET = "prophet"
+    """Prophet model family."""
+
     NONE = "none"
     """None"""
 
@@ -57,8 +60,10 @@ class ModelFamily(Enum):
             ModelFamily.BASELINE.name: "Baseline",
             ModelFamily.ENSEMBLE.name: "Ensemble",
             ModelFamily.ARIMA.name: "ARIMA",
+            ModelFamily.PROPHET.name: "Prophet",
             ModelFamily.NONE.name: "None",
         }
+
         return model_family_dict[self.name]
 
     def __repr__(self):

--- a/evalml/pipelines/__init__.py
+++ b/evalml/pipelines/__init__.py
@@ -33,6 +33,7 @@ from .components import (
     SVMClassifier,
     SVMRegressor,
     ARIMARegressor,
+    ProphetRegressor,
 )
 
 from .component_graph import ComponentGraph

--- a/evalml/pipelines/components/__init__.py
+++ b/evalml/pipelines/components/__init__.py
@@ -21,6 +21,7 @@ from .estimators import (
     DecisionTreeRegressor,
     TimeSeriesBaselineEstimator,
     KNeighborsClassifier,
+    ProphetRegressor,
     SVMClassifier,
     SVMRegressor,
     ARIMARegressor,

--- a/evalml/pipelines/components/estimators/__init__.py
+++ b/evalml/pipelines/components/estimators/__init__.py
@@ -25,4 +25,5 @@ from .regressors import (
     DecisionTreeRegressor,
     SVMRegressor,
     ARIMARegressor,
+    ProphetRegressor,
 )

--- a/evalml/pipelines/components/estimators/regressors/__init__.py
+++ b/evalml/pipelines/components/estimators/regressors/__init__.py
@@ -8,5 +8,6 @@ from .et_regressor import ExtraTreesRegressor
 from .baseline_regressor import BaselineRegressor
 from .decision_tree_regressor import DecisionTreeRegressor
 from .time_series_baseline_estimator import TimeSeriesBaselineEstimator
+from .prophet_regressor import ProphetRegressor
 from .svm_regressor import SVMRegressor
 from .arima_regressor import ARIMARegressor

--- a/evalml/pipelines/components/estimators/regressors/prophet_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/prophet_regressor.py
@@ -1,0 +1,161 @@
+import copy
+
+import numpy as np
+import pandas as pd
+from skopt.space import Real
+
+from evalml.model_family import ModelFamily
+from evalml.pipelines.components.estimators import Estimator
+from evalml.problem_types import ProblemTypes
+from evalml.utils import import_or_raise, infer_feature_types
+from evalml.utils.gen_utils import classproperty
+
+
+class ProphetRegressor(Estimator):
+    """
+    Prophet is a procedure for forecasting time series data based on an additive model where non-linear trends are fit with yearly, weekly, and daily seasonality, plus holiday effects.
+    It works best with time series that have strong seasonal effects and several seasons of historical data. Prophet is robust to missing data and shifts in the trend, and typically handles outliers well.
+
+    More information here: https://facebook.github.io/prophet/
+
+    """
+
+    name = "Prophet Regressor"
+    hyperparameter_ranges = {
+        "changepoint_prior_scale": Real(0.001, 0.5),
+        "seasonality_prior_scale": Real(0.01, 10),
+        "holidays_prior_scale": Real(0.01, 10),
+        "seasonality_mode": ["additive", "multiplicative"],
+    }
+    """{
+        "changepoint_prior_scale": Real(0.001, 0.5),
+        "seasonality_prior_scale": Real(0.01, 10),
+        "holidays_prior_scale": Real(0.01, 10),
+        "seasonality_mode": ["additive", "multiplicative"],
+    }"""
+    model_family = ModelFamily.PROPHET
+    """ModelFamily.PROPHET"""
+    supported_problem_types = [ProblemTypes.TIME_SERIES_REGRESSION]
+    """[ProblemTypes.TIME_SERIES_REGRESSION]"""
+
+    def __init__(
+        self,
+        date_column="ds",
+        changepoint_prior_scale=0.05,
+        seasonality_prior_scale=10,
+        holidays_prior_scale=10,
+        seasonality_mode="additive",
+        random_seed=0,
+        stan_backend="CMDSTANPY",
+        **kwargs
+    ):
+        self.date_column = date_column
+
+        parameters = {
+            "changepoint_prior_scale": changepoint_prior_scale,
+            "seasonality_prior_scale": seasonality_prior_scale,
+            "holidays_prior_scale": holidays_prior_scale,
+            "seasonality_mode": seasonality_mode,
+            "stan_backend": stan_backend,
+        }
+
+        parameters.update(kwargs)
+
+        c_error_msg = (
+            "cmdstanpy is not installed. Please install using `pip install cmdstanpy`."
+        )
+        _ = import_or_raise("cmdstanpy", error_msg=c_error_msg)
+
+        p_error_msg = (
+            "prophet is not installed. Please install using `pip install prophet`."
+        )
+        prophet = import_or_raise("prophet", error_msg=p_error_msg)
+
+        prophet_regressor = prophet.Prophet(**parameters)
+        super().__init__(
+            parameters=parameters,
+            component_obj=prophet_regressor,
+            random_state=random_seed,
+        )
+
+    @staticmethod
+    def build_prophet_df(X, y=None, date_column="ds"):
+        if X is not None:
+            X = copy.deepcopy(X)
+        if y is not None:
+            y = copy.deepcopy(y)
+
+        if date_column in X.columns:
+            date_col = X[date_column]
+        elif isinstance(X.index, pd.DatetimeIndex):
+            date_col = X.reset_index()
+            date_col = date_col["index"]
+        elif isinstance(y.index, pd.DatetimeIndex):
+            date_col = y.reset_index()
+            date_col = date_col["index"]
+        else:
+            msg = "Prophet estimator requires input data X to have a datetime column specified by the 'date_column' parameter. If it doesn't find one, it will look for the datetime column in the index of X or y."
+            raise ValueError(msg)
+
+        date_col = date_col.rename("ds")
+        prophet_df = date_col.to_frame()
+        if y is not None:
+            y.index = prophet_df.index
+            prophet_df["y"] = y
+        return prophet_df
+
+    def fit(self, X, y=None):
+        if X is None:
+            X = pd.DataFrame()
+
+        X, y = super()._manage_woodwork(X, y)
+
+        prophet_df = ProphetRegressor.build_prophet_df(
+            X=X, y=y, date_column=self.date_column
+        )
+
+        self._component_obj.fit(prophet_df)
+        return self
+
+    def predict(self, X, y=None):
+        if X is None:
+            X = pd.DataFrame()
+
+        X = infer_feature_types(X)
+
+        prophet_df = ProphetRegressor.build_prophet_df(
+            X=X, y=y, date_column=self.date_column
+        )
+
+        y_pred = self._component_obj.predict(prophet_df)["yhat"]
+        return y_pred
+
+    def get_params(self):
+        return self.__dict__["_parameters"]
+
+    @property
+    def feature_importance(self):
+        """
+        Returns array of 0's with len(1) as feature_importance is not defined for Prophet regressor.
+        """
+        return np.zeros(1)
+
+    @classproperty
+    def default_parameters(cls):
+        """Returns the default parameters for this component.
+
+        Our convention is that Component.default_parameters == Component().parameters.
+
+        Returns:
+            dict: default parameters for this component.
+        """
+
+        parameters = {
+            "changepoint_prior_scale": 0.05,
+            "seasonality_prior_scale": 10,
+            "holidays_prior_scale": 10,
+            "seasonality_mode": "additive",
+            "stan_backend": "CMDSTANPY",
+        }
+
+        return parameters

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -44,6 +44,7 @@ from evalml.pipelines.components import (
     OneHotEncoder,
     PerColumnImputer,
     PolynomialDetrender,
+    ProphetRegressor,
     RandomForestClassifier,
     RandomForestRegressor,
     RFClassifierSelectFromModel,
@@ -507,6 +508,20 @@ def test_describe_component():
                 "n_jobs": -1,
                 "bagging_fraction": 0.9,
                 "bagging_freq": 0,
+            },
+        }
+    except ImportError:
+        pass
+    try:
+        prophet_regressor = ProphetRegressor()
+        assert prophet_regressor.describe(return_dict=True) == {
+            "name": "Prophet Regressor",
+            "parameters": {
+                "changepoint_prior_scale": 0.05,
+                "holidays_prior_scale": 10,
+                "seasonality_mode": "additive",
+                "seasonality_prior_scale": 10,
+                "stan_backend": "CMDSTANPY",
             },
         }
     except ImportError:
@@ -1297,6 +1312,8 @@ def test_estimators_accept_all_kwargs(
         )
     if estimator_class.model_family == ModelFamily.ENSEMBLE:
         params = estimator.parameters
+    elif estimator_class.model_family == ModelFamily.PROPHET:
+        params = estimator.get_params()
     else:
         params = estimator._component_obj.get_params()
         if "random_state" in params:

--- a/evalml/tests/component_tests/test_prophet_regressor.py
+++ b/evalml/tests/component_tests/test_prophet_regressor.py
@@ -1,0 +1,151 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pytest import importorskip
+
+from evalml.model_family import ModelFamily
+from evalml.pipelines.components import ProphetRegressor
+from evalml.problem_types import ProblemTypes
+
+prophet = importorskip("prophet", reason="Skipping test because prophet not installed")
+
+
+def test_model_family():
+    assert ProphetRegressor.model_family == ModelFamily.PROPHET
+
+
+def test_cmdstanpy_backend():
+    m = prophet.Prophet(stan_backend="CMDSTANPY")
+    assert m.stan_backend.get_type() == "CMDSTANPY"
+
+
+def test_problem_types():
+    assert set(ProphetRegressor.supported_problem_types) == {
+        ProblemTypes.TIME_SERIES_REGRESSION
+    }
+
+
+def test_init_with_other_params():
+    clf = ProphetRegressor(
+        daily_seasonality=True,
+        mcmc_samples=5,
+        interval_width=0.8,
+        uncertainty_samples=0,
+    )
+    assert clf.parameters == {
+        "changepoint_prior_scale": 0.05,
+        "daily_seasonality": True,
+        "holidays_prior_scale": 10,
+        "interval_width": 0.8,
+        "mcmc_samples": 5,
+        "seasonality_mode": "additive",
+        "seasonality_prior_scale": 10,
+        "uncertainty_samples": 0,
+        "stan_backend": "CMDSTANPY",
+    }
+
+
+def test_feature_importance(ts_data):
+    X, y = ts_data
+    clf = ProphetRegressor(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    clf.fit(X, y)
+    clf.feature_importance == np.zeros(1)
+
+
+def test_get_params(ts_data):
+    clf = ProphetRegressor()
+    assert clf.get_params() == {
+        "changepoint_prior_scale": 0.05,
+        "seasonality_prior_scale": 10,
+        "holidays_prior_scale": 10,
+        "seasonality_mode": "additive",
+        "stan_backend": "CMDSTANPY",
+    }
+
+
+def test_fit_predict_ts_with_X_index(ts_data):
+    X, y = ts_data
+    assert isinstance(X.index, pd.DatetimeIndex)
+
+    p_clf = prophet.Prophet(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    prophet_df = ProphetRegressor.build_prophet_df(X=X, y=y, date_column="ds")
+
+    p_clf.fit(prophet_df)
+    y_pred_p = p_clf.predict(prophet_df)["yhat"]
+
+    clf = ProphetRegressor(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+
+    assert (y_pred == y_pred_p).all()
+
+
+def test_fit_predict_ts_with_y_index(ts_data):
+    X, y = ts_data
+    X = X.reset_index(drop=True)
+    assert isinstance(y.index, pd.DatetimeIndex)
+
+    p_clf = prophet.Prophet(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    prophet_df = ProphetRegressor.build_prophet_df(X=X, y=y, date_column="ds")
+
+    p_clf.fit(prophet_df)
+    y_pred_p = p_clf.predict(prophet_df)["yhat"]
+
+    clf = ProphetRegressor(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    clf.fit(X, y)
+    y_pred = clf.predict(X, y)
+
+    assert (y_pred == y_pred_p).all()
+
+
+def test_fit_predict_ts_no_X(ts_data):
+    X, y = ts_data
+
+    p_clf = prophet.Prophet(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    prophet_df = ProphetRegressor.build_prophet_df(
+        X=pd.DataFrame(), y=y, date_column="ds"
+    )
+
+    p_clf.fit(prophet_df)
+    y_pred_p = p_clf.predict(prophet_df)["yhat"]
+
+    clf = ProphetRegressor(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    clf.fit(X=None, y=y)
+    y_pred = clf.predict(X=None, y=y)
+
+    assert (y_pred == y_pred_p).all()
+
+
+def test_fit_predict_date_col(ts_data):
+    X, y = ts_data
+
+    p_clf = prophet.Prophet(uncertainty_samples=False, changepoint_prior_scale=2.0)
+    prophet_df = ProphetRegressor.build_prophet_df(X=X, y=y, date_column="ds")
+
+    p_clf.fit(prophet_df)
+    y_pred_p = p_clf.predict(prophet_df)["yhat"]
+
+    X = X.reset_index()
+    X = X["index"].rename("ds").to_frame()
+    clf = ProphetRegressor(
+        date_column="ds", uncertainty_samples=False, changepoint_prior_scale=2.0
+    )
+    clf.fit(X, y)
+    y_pred = clf.predict(X)
+
+    assert (y_pred == y_pred_p).all()
+
+
+def test_fit_predict_no_date_col_or_index(ts_data):
+    X, y = ts_data
+    X = X.reset_index(drop=True)
+    y = y.reset_index(drop=True)
+    assert not isinstance(X.index, pd.DatetimeIndex)
+    assert not isinstance(y.index, pd.DatetimeIndex)
+
+    clf = ProphetRegressor()
+    with pytest.raises(
+        ValueError,
+        match="Prophet estimator requires input data X to have a datetime column",
+    ):
+        clf.fit(X, y)

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -26,16 +26,19 @@ multiclass = pd.Series([0] * 800 + [1] * 150 + [2] * 50)
 
 
 def test_all_components(
-    has_minimal_dependencies, is_running_py_39_or_above, is_using_conda
+    has_minimal_dependencies,
+    is_running_py_39_or_above,
+    is_using_conda,
+    is_using_windows,
 ):
     if has_minimal_dependencies:
         n_components = 41
     elif is_using_conda:
         n_components = 52
-    elif is_running_py_39_or_above:
-        n_components = 51
-    else:
+    elif is_running_py_39_or_above or is_using_windows:
         n_components = 53
+    else:
+        n_components = 54
     assert len(all_components()) == n_components
 
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -178,6 +178,11 @@ def is_using_conda(pytestconfig):
 
 
 @pytest.fixture
+def is_using_windows(pytestconfig):
+    return sys.platform in ["win32", "cygwin"]
+
+
+@pytest.fixture
 def is_running_py_39_or_above():
     return sys.version_info >= (3, 9)
 

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -18,7 +18,7 @@ pandas==1.3.1
 plotly==5.1.0
 pmdarima==1.8.0
 psutil==5.8.0
-pyzmq==22.1.0
+pyzmq==22.2.0
 requirements-parser==0.2.0
 scikit-learn==0.24.2
 scikit-optimize==0.8.1

--- a/evalml/tests/model_family_tests/test_model_family.py
+++ b/evalml/tests/model_family_tests/test_model_family.py
@@ -18,6 +18,7 @@ def correct_model_families():
         ModelFamily.K_NEIGHBORS,
         ModelFamily.SVM,
         ModelFamily.ARIMA,
+        ModelFamily.PROPHET,
         ModelFamily.NONE,
     ]
     yield correct_model_families
@@ -37,6 +38,7 @@ def test_handle_string(correct_model_families):
         "k_neighbors",
         "svm",
         "ARIMA",
+        "prophet",
         "none",
     ]
     for model_family in zip(model_families, correct_model_families):

--- a/evalml/tests/utils_tests/test_dependencies.py
+++ b/evalml/tests/utils_tests/test_dependencies.py
@@ -14,7 +14,10 @@ def _get_req_name(name):
 
 
 def test_has_minimal_deps(
-    has_minimal_dependencies, is_running_py_39_or_above, is_using_conda
+    has_minimal_dependencies,
+    is_running_py_39_or_above,
+    is_using_conda,
+    is_using_windows,
 ):
     reqs_path = (
         pathlib.Path(__file__).absolute().parents[3].joinpath("requirements.txt")

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -120,6 +120,7 @@ def get_random_seed(
 
 class classproperty:
     """Allows function to be accessed as a class level property.
+
     Example:
 
     .. code-block::
@@ -180,6 +181,7 @@ _not_used_in_automl = {
     "KNeighborsClassifier",
     "SVMClassifier",
     "SVMRegressor",
+    "ProphetRegressor",
 }
 
 
@@ -221,8 +223,8 @@ def get_importable_subclasses(base_class, used_in_automl=True):
 
 def _rename_column_names_to_numeric(X, flatten_tuples=True):
     """Used in LightGBM and XGBoost estimator classes to rename column names
-        when the input is a pd.DataFrame in case it has column names that contain symbols ([, ], <)
-        that these estimators cannot natively handle.
+    when the input is a pd.DataFrame in case it has column names that contain symbols ([, ], <)
+    that these estimators cannot natively handle.
 
     Arguments:
         X (pd.DataFrame): The input training data of shape [n_samples, n_features]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ with open("README.md", "r") as fh:
 
 extras_require = {
     'update_checker': ['alteryx-open-src-update-checker >= 2.0.0'],
+    'prophet': ['cmdstan-builder == 0.0.4']
 }
 
 setup(


### PR DESCRIPTION
Fixes #1499 

Thanks to a conversation with @dsherry , @kmax12 , and @tyler3991, we made the decision to include Prophet alongside the `cmdstanpy` backend. The reasoning behind this is that because we aren't distributing Prophet code (simply requiring the user to install it as a dependency) we are in the same position as Prophet is regarding its use of `pystan 2` and its GPLv3 license. As we aren't distributing the underlying code, we (and Prophet) aren't required to be under the same copyleft license.

However, because we have to think downstream to Tempo and whether it will be installed on-premises (which would require packaging up dependencies and distributing them), we can't rely on `pystan 2` as a backend. Because Prophet doesn't support `pystan 3` yet (which uses a permissive license), we will have to rely on `cmdstanpy`.

For more information read [here](https://alteryx.quip.com/aBgLAxP5WoiE/Licensing-Prophet)

This PR only deals with adding the estimator so we can get it into main. I'll be raising another PR to add it to AutoML alongside perf tests.