### PR TITLE
Remove excess data splitter calls

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
         * Set ``max_depth`` to 1 in calls to featuretools dfs :pr:`2231`
     * Fixes
+        * Removed data splitter sampler calls during training :pr:``
     * Changes
         * Updated pipeline ``repr()`` and ``generate_pipeline_code`` to return pipeline instances without generating custom pipeline class :pr:`2227`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
     * Enhancements
         * Set ``max_depth`` to 1 in calls to featuretools dfs :pr:`2231`
     * Fixes
-        * Removed data splitter sampler calls during training :pr:``
+        * Removed data splitter sampler calls during training :pr:`2253`
     * Changes
         * Updated pipeline ``repr()`` and ``generate_pipeline_code`` to return pipeline instances without generating custom pipeline class :pr:`2227`
     * Documentation Changes

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -651,10 +651,6 @@ class AutoMLSearch:
             if self._train_best_pipeline:
                 X_train = self.X_train
                 y_train = self.y_train
-                if hasattr(self.data_splitter, "transform_sample"):
-                    train_indices = self.data_splitter.transform_sample(X_train, y_train)
-                    X_train = X_train.iloc[train_indices]
-                    y_train = y_train.iloc[train_indices]
                 best_pipeline = self._engine.submit_training_job(self.automl_config, best_pipeline,
                                                                  X_train, y_train).get_result()
             self._best_pipeline = best_pipeline
@@ -1019,12 +1015,6 @@ class AutoMLSearch:
         computations = []
         X_train = self.X_train
         y_train = self.y_train
-
-        # Apply sampling
-        if hasattr(self.data_splitter, "transform_sample"):
-            train_indices = self.data_splitter.transform_sample(X_train, y_train)
-            X_train = X_train.iloc[train_indices]
-            y_train = y_train.iloc[train_indices]
 
         for pipeline in pipelines:
             computations.append(self._engine.submit_training_job(self.automl_config, pipeline, X_train, y_train))


### PR DESCRIPTION
Noticed that my previous PR removing the sampling data splitter didn't remove some extra lines that called the data splitter.

Since we are now defaulting to StratifiedKFold and no longer have data splitters with a `transform_sample` method, I removed the excess code