### PR TITLE
Docs build: refactor markupsafe dependency pin to be outside of requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,6 @@ python:
   version: 3.8
   install:
     - requirements: docs/readthedocs-requirements.txt
-    - requirements: docs-requirements.txt
     - method: pip
       path: .
+    - requirements: docs-requirements.txt

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -3,4 +3,3 @@ pydata-sphinx-theme>=0.3.1
 Sphinx>=2.0.1,<4.0.0
 nbconvert>=5.5.0
 nbsphinx>=0.8.5
-MarkupSafe==1.1.1

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Removed MarkupSafe dependency version pin from requirements.txt and moved instead into RTD docs build CI :pr:`2261`
 
 .. warning::
 

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -9,7 +9,6 @@ imbalanced-learn==0.8.0
 ipywidgets==7.6.3
 kaleido==0.2.1
 lightgbm==3.0.0
-MarkupSafe==1.1.1
 matplotlib==3.4.2
 matplotlib-inline==0.1.2
 networkx==2.5.1

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -4,7 +4,6 @@ ipywidgets==7.5
 xgboost==0.82
 catboost==0.20
 lightgbm==2.3.1
-MarkupSafe==1.1.1
 matplotlib==3.3.3
 graphviz==0.13
 seaborn==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ ipywidgets>=7.5
 xgboost>=0.82,<1.3.0
 catboost>=0.20
 lightgbm>=2.3.1,<3.1.0
-MarkupSafe==1.1.1
 matplotlib>=3.3.3
 graphviz>=0.13
 seaborn>=0.11.1


### PR DESCRIPTION
Follow-up from #2244 .

Since `MarkupSafe` is only needed for the docs, and is not needed to run evalml, it shouldn't be listed in our `requirements.txt`. So this PR moves it out of there.

Thanks to @rwedge for the ultimate solution!