### PR TITLE
PipelineBase.compute_estimator_features fails for Undersampler

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Fixes
         * Removed data splitter sampler calls during training :pr:`2253`
         * Set minimum required version for for pyzmq, colorama, and docutils :pr:`2254`
+        * Changed BaseSampler to return None instead of y :pr:`2272`
     * Changes
         * Updated pipeline ``repr()`` and ``generate_pipeline_code`` to return pipeline instances without generating custom pipeline class :pr:`2227`
     * Documentation Changes

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -57,7 +57,7 @@ class BaseSampler(Transformer):
         X = infer_feature_types(X)
         if y is not None:
             y = infer_feature_types(y)
-        return X, y
+        return X, None
 
 
 class BaseOverSampler(BaseSampler):

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -556,9 +556,12 @@ def test_transformer_transform_output_type(X_y_binary):
 
             component.fit(X, y=y)
             transform_output = component.transform(X, y=y)
-            if isinstance(component, TargetImputer) or 'sampler' in component.name:
+            if isinstance(component, TargetImputer):
                 assert isinstance(transform_output[0], ww.DataTable)
                 assert isinstance(transform_output[1], ww.DataColumn)
+            elif 'sampler' in component.name:
+                assert isinstance(transform_output[0], ww.DataTable)
+                assert transform_output[1] is None
             else:
                 assert isinstance(transform_output, ww.DataTable)
 
@@ -580,7 +583,6 @@ def test_transformer_transform_output_type(X_y_binary):
                 assert len(transform_output[1].shape) == 1
             elif 'sampler' in component.name:
                 assert transform_output[0].shape == X.shape
-                assert transform_output[1].shape[0] == X.shape[0]
             else:
                 assert transform_output.shape == X.shape
                 assert (list(transform_output.columns) == list(X_cols_expected))
@@ -1122,7 +1124,11 @@ def test_transformer_fit_and_transform_respect_custom_indices(use_custom_index, 
     pd.testing.assert_index_equal(X.index, X_original_index)
     pd.testing.assert_index_equal(y.index, y_original_index)
 
-    if 'sampler' in transformer.name or transformer_class == TargetImputer:
+    if 'sampler' in transformer.name:
+        X_t, y_t = transformer.transform(X, y)
+        X_t = X_t.to_dataframe()
+        assert y_t is None
+    elif transformer_class == TargetImputer:
         X_t, y_t = transformer.transform(X, y)
         X_t = X_t.to_dataframe()
         pd.testing.assert_index_equal(y_t.to_series().index, y_original_index, check_names=check_names)

--- a/evalml/tests/component_tests/test_oversamplers.py
+++ b/evalml/tests/component_tests/test_oversamplers.py
@@ -107,7 +107,7 @@ def test_oversample_imbalanced_binary(data_type, sampler, make_data_type):
         y = y.values
 
     np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(None, transform_y)
 
 
 @pytest.mark.parametrize("sampling_ratio", [0.2, 0.5])
@@ -148,7 +148,7 @@ def test_oversample_imbalanced_multiclass(data_type, sampler, sampling_ratio, ma
         y = y.values
 
     np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(None, transform_y)
 
 
 @pytest.mark.parametrize("sampler", [SMOTESampler, SMOTENCSampler, SMOTENSampler])
@@ -237,8 +237,6 @@ def test_smotenc_output_shape(X_y_binary):
         snc.fit(X_ww, y_value)
         X_out, y_out = snc.transform(X_ww, y_value)
         assert X_out.shape[1] == X_ww.shape[1]
-        assert y_out.shape[0] == X_out.shape[0]
 
         X_out, y_out = snc.fit_transform(X_ww, y)
         assert X_out.shape[1] == X_ww.shape[1]
-        assert y_out.shape[0] == X_out.shape[0]

--- a/evalml/tests/component_tests/test_undersampler.py
+++ b/evalml/tests/component_tests/test_undersampler.py
@@ -73,4 +73,4 @@ def test_undersample_imbalanced(data_type, make_data_type):
         y = y.values
 
     np.testing.assert_equal(X, transform_X.to_dataframe().values)
-    np.testing.assert_equal(y, transform_y.to_series().values)
+    np.testing.assert_equal(None, transform_y)

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -290,3 +290,17 @@ def test_get_permutation_importance_correlated_features(logistic_regression_bina
     correlated_importance_val = importance["importance"][importance.index[importance["feature"] == "correlated"][0]]
     not_correlated_importance_val = importance["importance"][importance.index[importance["feature"] == "not correlated"][0]]
     assert correlated_importance_val > not_correlated_importance_val
+
+def test_undersampler(X_y_binary):
+    """Smoke test to enable hotfix for 0.24.0.  Prior to the 0.24.0 hotfix, this test will
+    generate a ValueError within calculate_permutation_importance.
+
+    TODO: Remove with github issue #2273
+    """
+    X, y = X_y_binary
+    X = pd.DataFrame(X)
+    y = pd.Series(y)
+    pipeline = BinaryClassificationPipeline(component_graph=["Undersampler", "Elastic Net Classifier"])
+    pipeline.fit(X=X, y=y)
+    pipeline.predict(X)
+    test = calculate_permutation_importance(pipeline, X, y, objective="Log Loss Binary")

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -291,6 +291,7 @@ def test_get_permutation_importance_correlated_features(logistic_regression_bina
     not_correlated_importance_val = importance["importance"][importance.index[importance["feature"] == "not correlated"][0]]
     assert correlated_importance_val > not_correlated_importance_val
 
+
 def test_undersampler(X_y_binary):
     """Smoke test to enable hotfix for 0.24.0.  Prior to the 0.24.0 hotfix, this test will
     generate a ValueError within calculate_permutation_importance.
@@ -304,3 +305,4 @@ def test_undersampler(X_y_binary):
     pipeline.fit(X=X, y=y)
     pipeline.predict(X)
     test = calculate_permutation_importance(pipeline, X, y, objective="Log Loss Binary")
+    assert test is not None


### PR DESCRIPTION
**Background**
Our `ComponentGraph` (first added in Dec 2020) was not originally intended to support transformer components which can alter the supervised target data.

The undersampler was recently added as a component in the graph (#2030 ). The undersampler component is the first component we've had which alters the target data. The way the undersampler currently works is:
* First we assume that in the `ComponentGraph`, each transformers' `fit_transform` is called only during fit, whereas `transform` is called during predict.
* Define undersampler `fit_transform` to apply undersampling to the input data and target at the same time.
* Define undersampler `transform` to be a no-op, and to pass both X and y through from input to output, because we assume this only happens at pipeline `predict`-time.

When we added the undersampler in #2030 and related PRs, we added test coverage for evaluating the component, and for using the component in a pipeline and calling pipeline `fit`/`predict`. That all works just great. What we didn't add coverage for is for calling the method `PipelineBase.compute_estimator_features` on a pipeline with the undersampler in it! This is used by permutation importance, which is how we first noticed the bug.

**Symptoms**
Calling `PipelineBase.compute_estimator_features` on a pipeline which uses the undersampler results in a stack trace. Reproducer at the bottom.

**Cause**
Because undersampler `transform` returns both X and y, our current `ComponentGraph` impl [will save the unmodified target returned from that method under the key `"Undersampler.y"`](https://github.com/alteryx/evalml/blob/main/evalml/pipelines/component_graph.py#L242) in the component features dict during evaluation. This doesn't cause problems during pipeline fit and predict, but when features are computed for each transformer [in `_fit_transform_features_helper`,](https://github.com/alteryx/evalml/blob/main/evalml/pipelines/component_graph.py#L168) that code erroneously grabs the `"Undersampler.y"` output **and appends it to the input of the next component**, which in automl and in our reproducer happens to be the estimator. This is why one of the stack traces at the bottom comes from the estimator and mentions too many features being present.

**Solution**
This PR has a quick fix to change `BaseSampler.transform` to return None instead of y. This means that [when the features are computed for each transformer](https://github.com/alteryx/evalml/blob/main/evalml/pipelines/component_graph.py#L168), the resulting component output dict will no longer contain a key `"Undersampler.y"`.

Long-term: we need to add test coverage to ensure all pipeline methods work properly for components which modify the target like the undersampler.

@dsherry had a spike which cleans up the component graph impl and would fix this issue, #2110 . And another spike #2210 which simplifies the sampler API, although that wouldn't have fixed the issue here directly.

**Repro**
The following
```python
import pandas as pd
import evalml
from sklearn.datasets import make_classification
X, y = make_classification()
X = pd.DataFrame(X)
y = pd.Series(y)
pipeline = evalml.pipelines.BinaryClassificationPipeline(component_graph=['Undersampler', 'Elastic Net Classifier'])
pipeline.fit(X, y)
pipeline.predict(X)
evalml.model_understanding.calculate_permutation_importance(pipeline, X, y, objective='Log Loss Binary')
```
runs fine until the call to `calculate_permutation_importance`, which produces this stack trace
```bash
<ipython-input-13-98cd846c0e1d> in <module>
----> 1 evalml.model_understanding.calculate_permutation_importance(pipeline, X, y, objective='Log Loss Binary')
~/development/evalml/evalml/model_understanding/graphs.py in calculate_permutation_importance(pipeline, X, y, objective, n_repeats, n_jobs, random_seed)
--> 385         perm_importance = _fast_permutation_importance(pipeline, X, y, objective, n_repeats=n_repeats, n_jobs=n_jobs,
~/development/evalml/evalml/model_understanding/graphs.py in _fast_permutation_importance(pipeline, X, y, objective, n_repeats, n_jobs, random_seed)
--> 350     baseline_score = scorer(pipeline, precomputed_features, y, objective)
~/development/evalml/evalml/model_understanding/graphs.py in scorer(pipeline, features, y, objective)
--> 342             preds = pipeline.estimator.predict_proba(features)
~/development/evalml/evalml/pipelines/components/component_base_meta.py in _check_for_fit(self, X, y)
---> 27                 return method(self, X)
~/development/evalml/evalml/pipelines/components/estimators/estimator.py in predict_proba(self, X)
---> 79             pred_proba = self._component_obj.predict_proba(X)
... (and then more frames in sklearn linear estimator)

ValueError: X has 21 features per sample; expecting 20
```
If you run the above but add a name to the pd Series for the target, you get a slightly different stack trace ending with
```bash
ValueError: Input contains NaN, infinity or a value too large for dtype('float64').
```
because the component graph somehow ends up returning all-nans for the target passed from the undersampler to the target.