### PR TITLE
Release v0.24.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.24.1 May. 16, 2021**
+    * Enhancements
         * Integrated ``ARIMARegressor`` into AutoML :pr:`2009`
         * Updated ``HighlyNullDataCheck`` to also perform a null row check :pr:`2222`
         * Set ``max_depth`` to 1 in calls to featuretools dfs :pr:`2231`
@@ -17,9 +29,6 @@ Release Notes
         * Change number of cores for pytest from 4 to 2 :pr:`2266`
         * Add minimum dependency checker to generate minimum requirement files :pr:`2267`
 
-.. warning::
-
-    **Breaking Changes**
 
 **v0.24.0 May. 04, 2021**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.24.0'
+__version__ = '0.24.1'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.24.0',
+    version='0.24.1',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.24.1 May. 17, 2021
### Enhancements
- Integrated ``ARIMARegressor`` into AutoML #2009
- Updated ``HighlyNullDataCheck`` to also perform a null row check #2222
- Set ``max_depth`` to 1 in calls to featuretools dfs #2231
### Fixes
- Removed data splitter sampler calls during training #2253
- Set minimum required version for for pyzmq, colorama, and docutils #2254
- Changed BaseSampler to return None instead of y #2272
### Changes
- Updated pipeline ``repr()`` and ``generate_pipeline_code`` to return pipeline instances without generating custom pipeline class #2227
### Documentation Changes
- Capped Sphinx version under 4.0.0 #2244
### Testing Changes
- Change number of cores for pytest from 4 to 2 #2266
- Add minimum dependency checker to generate minimum requirement files #2267
