### PR TITLE
Release v0.24.2

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,17 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.24.2 May. 24, 2021**
+    * Enhancements
         * Added oversamplers to AutoMLSearch :pr:`2213` :pr:`2286`
         * Added dictionary input functionality for ``Undersampler`` component :pr:`2271`
         * Changed the default parameter values for ``Elastic Net Classifier`` and ``Elastic Net Regressor`` :pr:`2269`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 warnings.filterwarnings('ignore', 'The following selectors were not present in your DataTable')
 
 
-__version__ = '0.24.1'
+__version__ = '0.24.2'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.24.1',
+    version='0.24.2',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.24.2 May. 24, 2021
### Enhancements
- Added oversamplers to AutoMLSearch #2213 #2286
- Added dictionary input functionality for ``Undersampler`` component #2271
- Changed the default parameter values for ``Elastic Net Classifier`` and ``Elastic Net Regressor`` #2269
### Fixes
- Set default `n_jobs` to 1 for `StackedEnsembleClassifier` and `StackedEnsembleRegressor` until fix for text-based parallelism in sklearn stacking can be found #2295
### Changes
- Updated ``start_iteration_callback`` to accept a pipeline instance instead of a pipeline class and no longer accept pipeline parameters as a parameter #2290
### Documentation Changes
### Testing Changes
- Use codecov action to update coverage reports #2238
- Removed MarkupSafe dependency version pin from requirements.txt and moved instead into RTD docs build CI #2261
### Breaking Changes
- Updated ``start_iteration_callback`` to accept a pipeline instance instead of a pipeline class and no longer accept pipeline parameters as a parameter #2290