### PR TITLE
Remove AutoMLSearch self-reference

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+        * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -312,6 +312,10 @@ class AutoMLSearch:
         self.random_seed = random_seed
         self.n_jobs = n_jobs
 
+        if not self.plot:
+            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
+
+
         if allowed_pipelines is not None and not isinstance(allowed_pipelines, list):
             raise ValueError("Parameter allowed_pipelines must be either None or a list!")
         if allowed_pipelines is not None and not all(isinstance(p, PipelineBase) for p in allowed_pipelines):
@@ -814,6 +818,7 @@ class AutoMLSearch:
             except PipelineNotFoundError:
                 pass
 
+        # True when running in a jupyter notebook, else the plot is an instance of plotly.Figure
         if isinstance(self.search_iteration_plot, SearchIterationPlot):
             self.search_iteration_plot.update(self.results, self.objective)
 
@@ -1080,5 +1085,4 @@ class AutoMLSearch:
         try:
             return PipelineSearchPlots(self.results, self.objective)
         except ImportError:
-            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
-        return None
+            return None

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -315,7 +315,6 @@ class AutoMLSearch:
         if not self.plot:
             logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
 
-
         if allowed_pipelines is not None and not isinstance(allowed_pipelines, list):
             raise ValueError("Parameter allowed_pipelines must be either None or a list!")
         if allowed_pipelines is not None and not all(isinstance(p, PipelineBase) for p in allowed_pipelines):
@@ -1082,6 +1081,7 @@ class AutoMLSearch:
 
     @property
     def plot(self):
+        # Return an instance of the plot with the
         try:
             return PipelineSearchPlots(self.results, self.objective)
         except ImportError:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1081,7 +1081,7 @@ class AutoMLSearch:
 
     @property
     def plot(self):
-        # Return an instance of the plot with the
+        # Return an instance of the plot with the latest scores
         try:
             return PipelineSearchPlots(self.results, self.objective)
         except ImportError:

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -312,12 +312,6 @@ class AutoMLSearch:
         self.random_seed = random_seed
         self.n_jobs = n_jobs
 
-        self.plot = None
-        try:
-            self.plot = PipelineSearchPlots(self)
-        except ImportError:
-            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
-
         if allowed_pipelines is not None and not isinstance(allowed_pipelines, list):
             raise ValueError("Parameter allowed_pipelines must be either None or a list!")
         if allowed_pipelines is not None and not all(isinstance(p, PipelineBase) for p in allowed_pipelines):
@@ -342,7 +336,6 @@ class AutoMLSearch:
                                                    n_splits=3, shuffle=True, random_seed=self.random_seed)
         self.data_splitter = self.data_splitter or default_data_splitter
         self.pipeline_parameters = pipeline_parameters if pipeline_parameters is not None else {}
-        self.search_iteration_plot = None
         self._interrupted = False
         self._frozen_pipeline_parameters = {}
 
@@ -570,9 +563,6 @@ class AutoMLSearch:
         if self.max_time is not None:
             logger.info("Will stop searching for new pipelines after %d seconds.\n" % self.max_time)
         logger.info("Allowed model families: %s\n" % ", ".join([model.value for model in self.allowed_model_families]))
-        self.search_iteration_plot = None
-        if self.plot:
-            self.search_iteration_plot = self.plot.search_iteration_plot(interactive_plot=show_iteration_plot)
 
         self._start = time.time()
 
@@ -1080,3 +1070,19 @@ class AutoMLSearch:
             else:
                 computations.append(computation)
         return scores
+
+    @property
+    def plot(self):
+        try:
+            return PipelineSearchPlots(self.results, self.objective)
+        except ImportError:
+            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
+        return None
+
+    @property
+    def search_iteration_plot(self):
+        try:
+            return self.plot.search_iteration_plot()
+        except ImportError:
+            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
+        return None

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from sklearn.model_selection import BaseCrossValidator
 
-from .pipeline_search_plots import PipelineSearchPlots
+from .pipeline_search_plots import PipelineSearchPlots, SearchIterationPlot
 
 from evalml.automl.automl_algorithm import IterativeAlgorithm
 from evalml.automl.callbacks import log_error_callback
@@ -336,6 +336,7 @@ class AutoMLSearch:
                                                    n_splits=3, shuffle=True, random_seed=self.random_seed)
         self.data_splitter = self.data_splitter or default_data_splitter
         self.pipeline_parameters = pipeline_parameters if pipeline_parameters is not None else {}
+        self.search_iteration_plot = None
         self._interrupted = False
         self._frozen_pipeline_parameters = {}
 
@@ -563,6 +564,9 @@ class AutoMLSearch:
         if self.max_time is not None:
             logger.info("Will stop searching for new pipelines after %d seconds.\n" % self.max_time)
         logger.info("Allowed model families: %s\n" % ", ".join([model.value for model in self.allowed_model_families]))
+        self.search_iteration_plot = None
+        if self.plot:
+            self.search_iteration_plot = self.plot.search_iteration_plot(interactive_plot=show_iteration_plot)
 
         self._start = time.time()
 
@@ -810,8 +814,8 @@ class AutoMLSearch:
             except PipelineNotFoundError:
                 pass
 
-        if self.search_iteration_plot:
-            self.search_iteration_plot.update()
+        if isinstance(self.search_iteration_plot, SearchIterationPlot):
+            self.search_iteration_plot.update(self.results, self.objective)
 
         if self.add_result_callback:
             self.add_result_callback(self._results['pipeline_results'][pipeline_id], pipeline, self)
@@ -1075,14 +1079,6 @@ class AutoMLSearch:
     def plot(self):
         try:
             return PipelineSearchPlots(self.results, self.objective)
-        except ImportError:
-            logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
-        return None
-
-    @property
-    def search_iteration_plot(self):
-        try:
-            return self.plot.search_iteration_plot()
         except ImportError:
             logger.warning("Unable to import plotly; skipping pipeline search plotting\n")
         return None

--- a/evalml/automl/pipeline_search_plots.py
+++ b/evalml/automl/pipeline_search_plots.py
@@ -8,13 +8,11 @@ class SearchIterationPlot:
         if jupyter_check():
             import_or_raise("ipywidgets", warning=True)
 
-        self.results = results
-        self.objective = objective
         self.best_score_by_iter_fig = None
         self.curr_iteration_scores = list()
         self.best_iteration_scores = list()
 
-        title = 'Pipeline Search: Iteration vs. {}<br><sub>Gray marker indicates the score at current iteration</sub>'.format(self.objective.name)
+        title = 'Pipeline Search: Iteration vs. {}<br><sub>Gray marker indicates the score at current iteration</sub>'.format(objective.name)
         data = [
             self._go.Scatter(x=[], y=[], mode='lines+markers', name='Best Score'),
             self._go.Scatter(x=[], y=[], mode='markers', name='Iter score', marker={'color': 'gray'})
@@ -31,12 +29,12 @@ class SearchIterationPlot:
         }
         self.best_score_by_iter_fig = self._go.FigureWidget(data, layout)
         self.best_score_by_iter_fig.update_layout(showlegend=False)
-        self.update()
+        self.update(results, objective)
 
-    def update(self):
-        if len(self.results['search_order']) > 0 and len(self.results['pipeline_results']) > 0:
-            iter_idx = self.results['search_order']
-            pipeline_res = self.results['pipeline_results']
+    def update(self, results, objective):
+        if len(results['search_order']) > 0 and len(results['pipeline_results']) > 0:
+            iter_idx = results['search_order']
+            pipeline_res = results['pipeline_results']
             iter_scores = [pipeline_res[i]["mean_cv_score"] for i in iter_idx]
 
             iter_score_pairs = zip(iter_idx, iter_scores)
@@ -51,8 +49,8 @@ class SearchIterationPlot:
                     best_iteration_scores.append(score)
                     curr_best = score
                 else:
-                    if self.objective.greater_is_better and score > curr_best \
-                            or not self.objective.greater_is_better and score < curr_best:
+                    if objective.greater_is_better and score > curr_best \
+                            or not objective.greater_is_better and score < curr_best:
                         best_iteration_scores.append(score)
                         curr_best = score
                     else:

--- a/evalml/automl/pipeline_search_plots.py
+++ b/evalml/automl/pipeline_search_plots.py
@@ -1,19 +1,20 @@
 from evalml.utils import import_or_raise, jupyter_check
 
 
-class SearchIterationPlot():
-    def __init__(self, data, show_plot=True):
+class SearchIterationPlot:
+    def __init__(self, results, objective):
         self._go = import_or_raise("plotly.graph_objects", error_msg="Cannot find dependency plotly.graph_objects")
 
         if jupyter_check():
             import_or_raise("ipywidgets", warning=True)
 
-        self.data = data
+        self.results = results
+        self.objective = objective
         self.best_score_by_iter_fig = None
         self.curr_iteration_scores = list()
         self.best_iteration_scores = list()
 
-        title = 'Pipeline Search: Iteration vs. {}<br><sub>Gray marker indicates the score at current iteration</sub>'.format(self.data.objective.name)
+        title = 'Pipeline Search: Iteration vs. {}<br><sub>Gray marker indicates the score at current iteration</sub>'.format(self.objective.name)
         data = [
             self._go.Scatter(x=[], y=[], mode='lines+markers', name='Best Score'),
             self._go.Scatter(x=[], y=[], mode='markers', name='Iter score', marker={'color': 'gray'})
@@ -33,9 +34,9 @@ class SearchIterationPlot():
         self.update()
 
     def update(self):
-        if len(self.data.results['search_order']) > 0 and len(self.data.results['pipeline_results']) > 0:
-            iter_idx = self.data.results['search_order']
-            pipeline_res = self.data.results['pipeline_results']
+        if len(self.results['search_order']) > 0 and len(self.results['pipeline_results']) > 0:
+            iter_idx = self.results['search_order']
+            pipeline_res = self.results['pipeline_results']
             iter_scores = [pipeline_res[i]["mean_cv_score"] for i in iter_idx]
 
             iter_score_pairs = zip(iter_idx, iter_scores)
@@ -50,8 +51,8 @@ class SearchIterationPlot():
                     best_iteration_scores.append(score)
                     curr_best = score
                 else:
-                    if self.data.objective.greater_is_better and score > curr_best \
-                            or not self.data.objective.greater_is_better and score < curr_best:
+                    if self.objective.greater_is_better and score > curr_best \
+                            or not self.objective.greater_is_better and score < curr_best:
                         best_iteration_scores.append(score)
                         curr_best = score
                     else:
@@ -71,14 +72,15 @@ class PipelineSearchPlots:
     """Plots for the AutoMLSearch class.
     """
 
-    def __init__(self, data):
+    def __init__(self, results, objective):
         """Make plots for the AutoMLSearch class.
 
         Arguments:
             data (AutoMLSearch): Automated pipeline search object
         """
         self._go = import_or_raise("plotly.graph_objects", error_msg="Cannot find dependency plotly.graph_objects")
-        self.data = data
+        self.results = results
+        self.objective = objective
 
     def search_iteration_plot(self, interactive_plot=False):
         """Shows a plot of the best score at each iteration using data gathered during training.
@@ -87,11 +89,11 @@ class PipelineSearchPlots:
             plot
         """
         if not interactive_plot:
-            plot_obj = SearchIterationPlot(self.data)
+            plot_obj = SearchIterationPlot(self.results, self.objective)
             return self._go.Figure(plot_obj.best_score_by_iter_fig)
         try:
             ipython_display = import_or_raise("IPython.display", error_msg="Cannot find dependency IPython.display")
-            plot_obj = SearchIterationPlot(self.data)
+            plot_obj = SearchIterationPlot(self.results, self.objective)
             ipython_display.display(plot_obj.best_score_by_iter_fig)
             return plot_obj
         except ImportError:

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -372,7 +372,6 @@ def test_plot_iterations_ipython_mock(mock_ipython_display, X_y_binary):
     automl.search()
     plot = automl.plot.search_iteration_plot(interactive_plot=True)
     assert isinstance(plot, SearchIterationPlot)
-    assert isinstance(plot.results, dict)
     mock_ipython_display.assert_called_with(plot.best_score_by_iter_fig)
 
 

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -372,7 +372,7 @@ def test_plot_iterations_ipython_mock(mock_ipython_display, X_y_binary):
     automl.search()
     plot = automl.plot.search_iteration_plot(interactive_plot=True)
     assert isinstance(plot, SearchIterationPlot)
-    assert isinstance(plot.data, AutoMLSearch)
+    assert isinstance(plot.results, dict)
     mock_ipython_display.assert_called_with(plot.best_score_by_iter_fig)
 
 

--- a/evalml/tests/automl_tests/test_pipeline_search_plots.py
+++ b/evalml/tests/automl_tests/test_pipeline_search_plots.py
@@ -36,7 +36,7 @@ def test_search_iteration_plot_class():
             })
 
     mock_data = MockResults()
-    plot = SearchIterationPlot(mock_data)
+    plot = SearchIterationPlot(mock_data.results, mock_data.objective)
 
     # Check best score trace
     plot_data = plot.best_score_by_iter_fig.data[0]
@@ -65,11 +65,11 @@ def test_jupyter(import_check, jupyter_check):
     pytest.importorskip('plotly.graph_objects', reason='Skipping plotting test because plotly not installed')
     jupyter_check.return_value = True
     with pytest.warns(None) as graph_valid:
-        SearchIterationPlot(mock_data)
+        SearchIterationPlot(mock_data.results, mock_data.objective)
         assert len(graph_valid) == 0
         import_check.assert_called_with('ipywidgets', warning=True)
 
     jupyter_check.return_value = False
     with pytest.warns(None) as graph_valid:
-        SearchIterationPlot(mock_data)
+        SearchIterationPlot(mock_data.results, mock_data.objective)
         assert len(graph_valid) == 0


### PR DESCRIPTION
### Pull Request Description
Fixes #2226 

We see slightly lower memory usage at the peak (~500 mb) and the memory after the peak is lower and starts to decrease (line after peak has a negative slope as opposed to being constant). 


### Memory for all unit tests
![unit_test_memory_main](https://user-images.githubusercontent.com/41651716/119536605-1e5d8700-bd3e-11eb-8b85-801310ae4192.png)


![unit_test_memory_no_circ_ref_in_plot](https://user-images.githubusercontent.com/41651716/119536396-e5bdad80-bd3d-11eb-9239-079ad04e503b.png)

### Memory for automl tests

![automl-tests-main](https://user-images.githubusercontent.com/41651716/119536676-2fa69380-bd3e-11eb-93ff-99949c6931ad.png)


![2226-automl-tests-no-circ-ref](https://user-images.githubusercontent.com/41651716/119536689-33d2b100-bd3e-11eb-891c-5f93551195a8.png)


### Plot still works for jupyter notebook

```python
from evalml import AutoMLSearch
from evalml.automl.callbacks import raise_error_callback
import pandas as pd
X = pd.read_csv("/Users/freddy.boulton/Downloads/titanic_text.csv")
y = X.pop('Survived')
automl = AutoMLSearch(X, y, problem_type="binary", error_callback=raise_error_callback, max_batches=10, ensembling=True)
automl.search()
```

![image](https://user-images.githubusercontent.com/41651716/119546075-5a95e500-bd48-11eb-9d66-98ab97b69db6.png)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
