### PR TITLE
[DRAFT] - Make woodwork version less restrictive

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -11,7 +11,7 @@ psutil>=5.6.3
 requirements-parser>=0.2.0
 shap>=0.36.0
 texttable>=1.6.2
-woodwork==0.3.1
+woodwork>=0.3.0,<0.5.0
 dask>=2.12.0
 featuretools>=0.21.0
 nlp-primitives>=1.1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,7 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
-        * Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported :pr:`2181`
+        * Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported :pr:`2181`, :pr:`2310`
     * Fixes
     * Changes
         * Deleted the ``return_pandas`` flag from our demo data loaders :pr:`2181`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -28,5 +28,5 @@ shap==0.39.0
 sktime==0.6.1
 statsmodels==0.12.2
 texttable==1.6.3
-woodwork==0.3.1
+woodwork==0.4.0
 xgboost==1.2.1


### PR DESCRIPTION
- We released woodwork v0.4.0, with no breaking changes. This MR allows users to install either version. 