### PR TITLE
v0.25.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.25.0 Jun. 01, 2021**
+    * Enhancements
         * Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported :pr:`2181`
         * Added a new callback parameter for ``explain_predictions_best_worst`` :pr:`2308`
     * Fixes

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -20,4 +20,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = '0.24.2'
+__version__ = '0.25.0'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.24.2',
+    version='0.25.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.25.0 Jun. 1, 2021
### Enhancements
- Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported #2181
- Added a new callback parameter for ``explain_predictions_best_worst`` #2308
### Fixes
### Changes
- Deleted the ``return_pandas`` flag from our demo data loaders #2181
### Documentation Changes
### Testing Changes
- Ignoring ``test_saving_png_file`` while building conda package #2323
### Breaking Changes
- Deleted the ``return_pandas`` flag from our demo data loaders #2181
- Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported #2181
- Due to the weak-ref in woodwork, set the result of ``infer_feature_types`` to a variable before accessing woodwork #2181