### PR TITLE
Codecov Upload Reports fix

### DIFF
--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -83,4 +83,5 @@ jobs:
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
         * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
     * Fixes
+        * Pass token to authorize uploading of codecov reports :pr:
     * Changes
         * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,12 +4,12 @@ Release Notes
     * Enhancements
         * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
     * Fixes
-        * Pass token to authorize uploading of codecov reports :pr:
     * Changes
         * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
     * Documentation Changes
     * Testing Changes
         * Update minimum unit tests to run on all pull requests :pr:`2314`
+        * Pass token to authorize uploading of codecov reports :pr:`2344`
 
 .. warning::
 


### PR DESCRIPTION
Fixes issue with Codecov where reports were not being uploaded properly. From now on the CODECOV_TOKEN will be passed to authorize the upload.