### PR TITLE
Release v0.26.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,18 @@
 Release Notes
 -------------
-**Future Releases**
+**Future Release**
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.26.0 Jun. 08, 2021**
     * Enhancements
         * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
         * Added support for nonlinear pipelines for ``generate_pipeline_code`` :pr:`2332`
@@ -10,7 +22,7 @@ Release Notes
     * Changes
         * Cleaned up ``PipelineBase``'s ``component_graph`` and ``_component_graph`` attributes. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` :pr:`2332`
         * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
-    * Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` :pr:`2317`
+        * Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` :pr:`2317`
     * Documentation Changes
     * Testing Changes
         * Update minimum unit tests to run on all pull requests :pr:`2314`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='evalml',
-    version='0.25.0',
+    version='0.26.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.26.0 Jun. 8, 2021
### Enhancements
- Removed self-reference from ``AutoMLSearch`` #2304
- Added support for nonlinear pipelines for ``generate_pipeline_code`` #2332
- Added ``inverse_transform`` method to pipelines #2256`
### Fixes
- Preserve user-specified woodwork types throughout pipeline fit/predict #2297
### Changes
- Cleaned up ``PipelineBase``'s ``component_graph`` and ``_component_graph`` attributes. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` #2332
- Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` #2306
- Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` #2317
### Documentation Changes
### Testing Changes
- Update minimum unit tests to run on all pull requests #2314
- Pass token to authorize uploading of codecov reports #2344
### Breaking Changes
- Removed ``PipelineBase``'s ``_component_graph`` attribute. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` #2332
- `pipeline_parameters` will no longer accept `skopt.space` variables since hyperparameter ranges will now be specified through `custom_hyperparameters` #2317
