### PR TITLE
Minor ``PipelineBase`` cleanup: remove ``_compute_features_during_fit``

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Removed private method ``_compute_features_during_fit`` from ``PipelineBase`` :pr:`2359`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -223,11 +223,11 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         X_t = self.component_graph.compute_final_component_features(X, y=y)
         return X_t
 
-    def _compute_features_during_fit(self, X, y):
-        self.input_target_name = y.name
-        X_t = self.component_graph.fit_features(X, y)
-        self.input_feature_names = self.component_graph.input_feature_names
-        return X_t
+    # def _compute_features_during_fit(self, X, y):
+    #     self.input_target_name = y.name
+    #     X_t = self.component_graph.fit_features(X, y)
+    #     self.input_feature_names = self.component_graph.input_feature_names
+    #     return X_t
 
     def _fit(self, X, y):
         self.input_target_name = y.name

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -223,12 +223,6 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         X_t = self.component_graph.compute_final_component_features(X, y=y)
         return X_t
 
-    # def _compute_features_during_fit(self, X, y):
-    #     self.input_target_name = y.name
-    #     X_t = self.component_graph.fit_features(X, y)
-    #     self.input_feature_names = self.component_graph.input_feature_names
-    #     return X_t
-
     def _fit(self, X, y):
         self.input_target_name = y.name
         self.component_graph.fit(X, y)

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -78,7 +78,10 @@ class TimeSeriesClassificationPipeline(
         X, y = self._convert_to_woodwork(X, y)
         self._encoder.fit(y)
         y = self._encode_targets(y)
-        X_t = self._compute_features_during_fit(X, y)
+
+        self.input_target_name = y.name
+        X_t = self.component_graph.fit_features(X, y)
+
         y_shifted = y.shift(-self.gap)
         X_t, y_shifted = drop_rows_with_nans(X_t, y_shifted)
         self.estimator.fit(X_t, y_shifted)

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -69,8 +69,10 @@ class TimeSeriesRegressionPipeline(
 
         X = infer_feature_types(X)
         y = infer_feature_types(y)
-        X_t = self._compute_features_during_fit(X, y)
 
+        self.input_target_name = y.name
+        X_t = self.component_graph.fit_features(X, y)
+    
         y_shifted = y.shift(-self.gap)
         X_t, y_shifted = drop_rows_with_nans(X_t, y_shifted)
         self.estimator.fit(X_t, y_shifted)

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -72,7 +72,7 @@ class TimeSeriesRegressionPipeline(
 
         self.input_target_name = y.name
         X_t = self.component_graph.fit_features(X, y)
-    
+
         y_shifted = y.shift(-self.gap)
         X_t, y_shifted = drop_rows_with_nans(X_t, y_shifted)
         self.estimator.fit(X_t, y_shifted)


### PR DESCRIPTION
I removed `_compute_features_during_fit` because we called `self.input_feature_names = self.component_graph.input_feature_names` in `_compute_features_during_fit` and then again before returning in the time-series regression pipelines' `fit` method. Moving just these two lines here helps remove the redundancy and avoid bugs with setting the attribute twice.