### PR TITLE
Adding inverse transform method to pipelines (#2256)

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
+        * Added ``inverse_transform`` method to pipelines :pr:`2256``
     * Fixes
     * Changes
         * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
@@ -47,6 +48,7 @@ Release Notes
     * Changes
         * Updated ``start_iteration_callback`` to accept a pipeline instance instead of a pipeline class and no longer accept pipeline parameters as a parameter :pr:`2290`
         * Refactored ``calculate_permutation_importance`` method and add per-column permutation importance method :pr:`2302`
+        * Updated logging information in ``AutoMLSearch.__init__`` to clarify pipeline generation :pr:`2263`
     * Documentation Changes
         * Minor changes to the release procedure :pr:`2230`
     * Testing Changes
@@ -70,7 +72,6 @@ Release Notes
         * Set minimum required version for for pyzmq, colorama, and docutils :pr:`2254`
         * Changed BaseSampler to return None instead of y :pr:`2272`
     * Changes
-        * Updated logging information in ``AutoMLSearch.__init__`` to clarify pipeline generation :pr:`2263`
         * Removed ensemble split and indices in ``AutoMLSearch`` :pr:`2260`
         * Updated pipeline ``repr()`` and ``generate_pipeline_code`` to return pipeline instances without generating custom pipeline class :pr:`2227`
     * Documentation Changes

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -4,6 +4,9 @@ from networkx.algorithms.dag import topological_sort
 from networkx.exception import NetworkXUnfeasible
 
 from evalml.pipelines.components import ComponentBase, Estimator, Transformer
+from evalml.pipelines.components.transformers.transformer import (
+    TargetTransformer,
+)
 from evalml.pipelines.components.utils import handle_component_class
 from evalml.utils import import_or_raise, infer_feature_types
 
@@ -84,10 +87,23 @@ class ComponentGraph:
         """
         component_dict = {}
         previous_component = None
-        for component_name, component_class in cls.linearized_component_graph(
-            component_list
-        ):
 
+        component_list = cls.linearized_component_graph(component_list)
+
+        # Logic is as follows: Create the component dict for the non-target transformers as expected.
+        # If there are target transformers present, connect them together and then pass the final output
+        # to the sampler (if present) or the final estimator
+
+        target_transformers = list(
+            filter(lambda tup: issubclass(tup[1], TargetTransformer), component_list)
+        )
+        not_target_transformers = list(
+            filter(
+                lambda tup: not issubclass(tup[1], TargetTransformer), component_list
+            )
+        )
+
+        for component_name, component_class in not_target_transformers:
             component_dict[component_name] = [component_class]
             if previous_component is not None:
                 if "sampler" in previous_component:
@@ -97,6 +113,29 @@ class ComponentGraph:
                 else:
                     component_dict[component_name].append(f"{previous_component}.x")
             previous_component = component_name
+
+        previous_component = None
+        for component_name, component_class in target_transformers:
+            component_dict[component_name] = [component_class]
+            if previous_component is not None:
+                component_dict[component_name].append(f"{previous_component}.y")
+            previous_component = component_name
+
+        if target_transformers:
+            sampler_index = next(
+                iter(
+                    [
+                        i
+                        for i, tup in enumerate(not_target_transformers)
+                        if "sampler" in tup[0]
+                    ]
+                ),
+                -1,
+            )
+            component_dict[not_target_transformers[sampler_index][0]].append(
+                f"{target_transformers[-1][0]}.y"
+            )
+
         return cls(component_dict, random_seed=random_seed)
 
     def instantiate(self, parameters):
@@ -546,3 +585,31 @@ class ComponentGraph:
         else:
             self._i = 0
             raise StopIteration
+
+    def _get_parent_y(self, component_name):
+        """Helper for inverse_transform method."""
+        parents = self.get_parents(component_name)
+        return next(iter(p[:-2] for p in parents if ".y" in p), None)
+
+    def inverse_transform(self, y):
+        """Apply component inverse_transform methods to estimator predictions in reverse order.
+
+        Components that implement inverse_transform are PolynomialDetrender, LabelEncoder (tbd).
+
+        Arguments:
+            y: (pd.Series): Final component features
+        """
+        data_to_transform = infer_feature_types(y)
+        current_component = self.compute_order[-1]
+        has_incoming_y_from_parent = True
+        while has_incoming_y_from_parent:
+            parent_y = self._get_parent_y(current_component)
+            if parent_y:
+                component = self.get_component(parent_y)
+                if isinstance(component, TargetTransformer):
+                    data_to_transform = component.inverse_transform(data_to_transform)
+                current_component = parent_y
+            else:
+                has_incoming_y_from_parent = False
+
+        return data_to_transform

--- a/evalml/pipelines/components/component_base_meta.py
+++ b/evalml/pipelines/components/component_base_meta.py
@@ -21,7 +21,8 @@ class ComponentBaseMeta(BaseMeta):
                     f"This {klass} is not fitted yet. You must fit {klass} before calling {method.__name__}."
                 )
             elif method.__name__ == "inverse_transform":
-                return method(self, X, y)
+                # Since inverse transform only takes one argument, the y is actually "called" X in this piece of code.
+                return method(self, X)
             elif X is None and y is None:
                 return method(self)
             elif y is None:

--- a/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
+++ b/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
@@ -1,11 +1,13 @@
 import pandas as pd
 from skopt.space import Integer
 
-from evalml.pipelines.components.transformers.transformer import Transformer
+from evalml.pipelines.components.transformers.transformer import (
+    TargetTransformer,
+)
 from evalml.utils import import_or_raise, infer_feature_types
 
 
-class PolynomialDetrender(Transformer):
+class PolynomialDetrender(TargetTransformer):
     """Removes trends from time series by fitting a polynomial to the data."""
 
     name = "Polynomial Detrender"
@@ -90,7 +92,7 @@ class PolynomialDetrender(Transformer):
         """
         return self.fit(X, y).transform(X, y)
 
-    def inverse_transform(self, X, y):
+    def inverse_transform(self, y):
         """Adds back fitted trend to target variable.
 
         Arguments:
@@ -106,4 +108,4 @@ class PolynomialDetrender(Transformer):
         y_dt = infer_feature_types(y)
         y_t = self._component_obj.inverse_transform(y_dt)
         y_t = infer_feature_types(pd.Series(y_t, index=y_dt.index))
-        return X, y_t
+        return y_t

--- a/evalml/pipelines/components/transformers/transformer.py
+++ b/evalml/pipelines/components/transformers/transformer.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 import pandas as pd
 
 from evalml.exceptions import MethodPropertyNotFoundError
@@ -74,3 +76,18 @@ class Transformer(ComponentBase):
 
     def _get_feature_provenance(self):
         return {}
+
+
+class TargetTransformer(Transformer):
+    """A component that transforms the target."""
+
+    @abstractmethod
+    def inverse_transform(self, y):
+        """Inverts the transformation done by the transform method.
+
+         Arguments:
+            y (pd.Series): Target transformed by this component.
+
+        Returns:
+            pd.Seriesø: Target without the transformation.
+        """

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -708,3 +708,13 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             and objective.is_defined_for_problem_type(self.problem_type)
             and objective.can_optimize_threshold
         )
+
+    def inverse_transform(self, y):
+        """Apply component inverse_transform methods to estimator predictions in reverse order.
+
+        Components that implement inverse_transform are PolynomialDetrender, LabelEncoder (tbd).
+
+        Arguments:
+            y (pd.Series): Final component features
+        """
+        return self._component_graph.inverse_transform(y)

--- a/evalml/pipelines/pipeline_meta.py
+++ b/evalml/pipelines/pipeline_meta.py
@@ -24,6 +24,8 @@ class PipelineBaseMeta(BaseMeta):
                 return method(self, X)
             elif method.__name__ == "predict":
                 return method(self, X, objective)
+            elif method.__name__ == "inverse_transform":
+                return method(self, X)
             else:
                 return method(self)
 

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -101,6 +101,9 @@ class TimeSeriesRegressionPipeline(
         if self.estimator.predict_uses_y:
             y_arg = y
         predictions = self.estimator.predict(features_no_nan, y_arg)
+
+        predictions.index = y.index
+        predictions = self.inverse_transform(predictions)
         predictions = predictions.rename(self.input_target_name)
         padded = pad_with_nans(
             predictions, max(0, features.shape[0] - predictions.shape[0])

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -40,7 +40,7 @@ def test_polynomial_detrender_raises_value_error_target_is_none(ts_data):
     pdt = PolynomialDetrender(degree=3).fit(X, y)
 
     with pytest.raises(ValueError, match="y cannot be None for PolynomialDetrender!"):
-        pdt.inverse_transform(X, None)
+        pdt.inverse_transform(None)
 
 
 @pytest.mark.parametrize("input_type", ["np", "pd", "ww"])
@@ -94,9 +94,8 @@ def test_polynomial_detrender_inverse_transform(degree, use_int_index, ts_data):
 
     detrender = PolynomialDetrender(degree=degree)
     output_X, output_y = detrender.fit_transform(X, y)
-    output_inverse_X, output_inverse_y = detrender.inverse_transform(output_X, output_y)
+    output_inverse_y = detrender.inverse_transform(output_y)
     pd.testing.assert_series_equal(y, output_inverse_y, check_dtype=False)
-    pd.testing.assert_frame_equal(X, output_inverse_X)
 
 
 def test_polynomial_detrender_needs_monotonic_index(ts_data):

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -15,6 +15,7 @@ from evalml.pipelines import (
 )
 from evalml.preprocessing.utils import is_classification
 from evalml.problem_types import ProblemTypes
+from evalml.utils import infer_feature_types, pad_with_nans
 
 
 @pytest.mark.parametrize(
@@ -704,3 +705,42 @@ def test_binary_predict_pipeline_use_objective(
     fraud_cost = FraudCost(amount_col=0)
     binary_pipeline.score(X, y, ["precision", "auc", fraud_cost])
     mock_decision_function.assert_called()
+
+
+@pytest.mark.parametrize(
+    "component_graph",
+    [
+        {
+            "Polynomial Detrender": ["Polynomial Detrender"],
+            "DelayedFeatures": ["Delayed Feature Transformer"],
+            "Regressor": [
+                "Linear Regressor",
+                "DelayedFeatures.x",
+                "Polynomial Detrender.y",
+            ],
+        },
+        ["Polynomial Detrender", "Delayed Feature Transformer", "Linear Regressor"],
+    ],
+)
+def test_time_series_pipeline_with_detrender(component_graph, ts_data):
+    pytest.importorskip(
+        "sktime",
+        reason="Skipping polynomial detrending tests because sktime not installed",
+    )
+    X, y = ts_data
+    pipeline = TimeSeriesRegressionPipeline(
+        component_graph=component_graph,
+        parameters={
+            "pipeline": {"gap": 1, "max_delay": 2, "date_index": None},
+            "DelayedFeatures": {"max_delay": 2},
+        },
+    )
+    pipeline.fit(X, y)
+    predictions = pipeline.predict(X, y)
+    features = pipeline.compute_estimator_features(X, y)
+    detrender = pipeline._component_graph.get_component("Polynomial Detrender")
+    preds = pipeline.estimator.predict(features.iloc[2:])
+    preds.index = y.index[2:]
+    expected = detrender.inverse_transform(preds)
+    expected = infer_feature_types(pad_with_nans(expected, 2))
+    pd.testing.assert_series_equal(predictions, expected)


### PR DESCRIPTION
* Adding inverse transform

* Release notes for PR 2256

* Inverse transform only takes y

* Skipping polynomial detrender test

* Adding docstring for pipeline inverse transform

* Add PR 2256 to future release section

* Docstring for SubsetData test transformer

* Fix PipelineBase.inverse_transform docstring

* Update release notes

* Change variable names in ComponentGraph.from_list

* Add/fix docstrings

* Deleting whitespace

* Linting polynomial detrender

* Fixing unit tests

* Linting with black

### Pull Request Description
(replace this text with your description)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
