### PR TITLE
Added support for Individual Conditional Expectation plots to `graph_partial_dependencies()`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
-        * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr`2386`
+        * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr:`2386`
     * Fixes
     * Changes
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+        * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr`2386`
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -762,7 +762,7 @@ def partial_dependence(
                         ind_data.append(ind_df)
                     else:
                         ind_data[i].concat(ind_df)
-            
+
             for sample in ind_data:
                 sample["class_label"] = np.repeat(classes, len(values[0]))
 
@@ -939,7 +939,7 @@ def graph_partial_dependence(
         )
 
     fig = _go.Figure(layout=layout)
-    if (isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline)):
+    if isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline):
         class_labels = [class_label] if class_label is not None else pipeline.classes_
         _subplots = import_or_raise(
             "plotly.subplots", error_msg="Cannot find dependency plotly.graph_objects"
@@ -959,10 +959,14 @@ def graph_partial_dependence(
         # Don't specify share_xaxis and share_yaxis so that we get tickmarks in each subplot
         fig = _subplots.make_subplots(rows=rows, cols=cols, subplot_titles=class_labels)
         for i, label in enumerate(class_labels):
-            label_df = part_dep.loc[part_dep.class_label == label] if part_dep is not None else ice_data.loc[ice_data.class_label == label]
+            label_df = (
+                part_dep.loc[part_dep.class_label == label]
+                if part_dep is not None
+                else ice_data.loc[ice_data.class_label == label]
+            )
             row = (i + 2) // 2
             col = (i % 2) + 1
-            if ice_data is not None and kind == 'individual':
+            if ice_data is not None and kind == "individual":
                 fig = _add_ice_plot(_go, fig, ice_data, row=row, col=col, label=label)
             else:
                 label_df.drop(columns=["class_label"], inplace=True)
@@ -985,12 +989,14 @@ def graph_partial_dependence(
                         trace = _go.Bar(x=x, y=y, name=label)
                     else:
                         if ice_data is not None:
-                            fig = _add_ice_plot(_go, fig, ice_data, row=row, col=col, label=label)
+                            fig = _add_ice_plot(
+                                _go, fig, ice_data, row=row, col=col, label=label
+                            )
                         trace = _go.Scatter(
                             x=x,
                             y=y,
                             line=dict(width=3, color="rgb(99,110,250)"),
-                            name='Partial Dependence: ' + class_labels_mapping[label],
+                            name="Partial Dependence: " + class_labels_mapping[label],
                         )
                     fig.add_trace(trace, row=row, col=col)
 
@@ -1000,18 +1006,20 @@ def graph_partial_dependence(
             fig.update_layout(coloraxis=dict(colorscale="Bluered_r"), showlegend=False)
         elif mode == "one-way":
             title = f"{feature_name}"
-            x_scale_df = part_dep["feature_values"] if part_dep is not None else ice_data["feature_values"]
-            xrange = (
-                _calculate_axis_range(x_scale_df)
-                if not is_categorical
-                else None
+            x_scale_df = (
+                part_dep["feature_values"]
+                if part_dep is not None
+                else ice_data["feature_values"]
             )
-            yrange = _calculate_axis_range(ice_data.drop("class_label", axis=1)
-                                           if ice_data is not None
-                                           else part_dep["partial_dependence"])
+            xrange = _calculate_axis_range(x_scale_df) if not is_categorical else None
+            yrange = _calculate_axis_range(
+                ice_data.drop("class_label", axis=1)
+                if ice_data is not None
+                else part_dep["partial_dependence"]
+            )
             fig.update_xaxes(title=title, range=xrange)
             fig.update_yaxes(range=yrange)
-    elif kind == 'individual' and ice_data is not None:
+    elif kind == "individual" and ice_data is not None:
         fig = _add_ice_plot(_go, fig, ice_data)
     elif part_dep is not None:
         if ice_data is not None and not is_categorical:

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -755,13 +755,10 @@ def partial_dependence(
                     ind_df.columns = values[1]
                     ind_df.index = values[0]
 
-                    if classes is not None:
-                        ind_df["class_label"] = np.repeat(classes, len(values[0]))
-
                     if n == 0:
                         ind_data.append(ind_df)
                     else:
-                        ind_data[i].concat(ind_df)
+                        ind_data[i] = pd.concat([ind_data[i], ind_df])
 
             for sample in ind_data:
                 sample["class_label"] = np.repeat(classes, len(values[0]))

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -699,15 +699,15 @@ def partial_dependence(
         kind=kind,
     )
 
-    values = preds["values"]
-    if kind != "individual":
-        avg_pred = preds["average"]
-        classes = None
-        if isinstance(pipeline, evalml.pipelines.BinaryClassificationPipeline):
-            classes = [pipeline.classes_[1]]
-        elif isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline):
-            classes = pipeline.classes_
+    classes = None
+    if isinstance(pipeline, evalml.pipelines.BinaryClassificationPipeline):
+        classes = [pipeline.classes_[1]]
+    elif isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline):
+        classes = pipeline.classes_
 
+    values = preds["values"]
+    if kind in ["average", "both"]:
+        avg_pred = preds["average"]
         if isinstance(features, (int, str)):
             avg_data = pd.DataFrame(
                 {
@@ -723,18 +723,8 @@ def partial_dependence(
         if classes is not None:
             avg_data["class_label"] = np.repeat(classes, len(values[0]))
 
-        if kind != "both":
-            return avg_data
-
-    if kind != "average":
+    if kind in ["individual", "both"]:
         ind_preds = preds["individual"]
-
-        classes = None
-        if isinstance(pipeline, evalml.pipelines.BinaryClassificationPipeline):
-            classes = [pipeline.classes_[1]]
-        elif isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline):
-            classes = pipeline.classes_
-
         if isinstance(features, (int, str)):
             ind_data = list()
             for label in ind_preds:
@@ -763,10 +753,12 @@ def partial_dependence(
             for sample in ind_data:
                 sample["class_label"] = np.repeat(classes, len(values[0]))
 
-        if kind != "both":
-            return ind_data
-
+    if kind == "both":
         return (avg_data, ind_data)
+    elif kind == "individual":
+        return ind_data
+    elif kind == "average":
+        return avg_data
 
 
 def _update_fig_with_two_way_partial_dependence(

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -1,5 +1,4 @@
 import copy
-from math import log
 import os
 import warnings
 from collections import OrderedDict
@@ -1009,7 +1008,6 @@ def graph_partial_dependence(
         if "class_label" in part_dep.columns:
             part_dep.drop(columns=["class_label"], inplace=True)
         if mode == "two-way":
-            
             _update_fig_with_two_way_partial_dependence(
                 _go,
                 fig,

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -935,7 +935,10 @@ def graph_partial_dependence(
     if ice_data is not None and not is_categorical:
         fig = _add_ice_plot(_go, fig, ice_data)
 
-    if isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline) and part_dep is not None:
+    if (
+        isinstance(pipeline, evalml.pipelines.MulticlassClassificationPipeline)
+        and part_dep is not None
+    ):
         class_labels = [class_label] if class_label is not None else pipeline.classes_
         _subplots = import_or_raise(
             "plotly.subplots", error_msg="Cannot find dependency plotly.graph_objects"

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -919,7 +919,7 @@ def graph_partial_dependence(
     elif mode == "one-way":
         feature_name = str(features)
         if kind == "individual":
-            title = f"Individual conditional expectation of '{feature_name}'"
+            title = f"Individual Conditional Expectation of '{feature_name}'"
         elif kind == "average":
             title = f"Partial Dependence of '{feature_name}'"
         else:
@@ -1042,6 +1042,9 @@ def graph_partial_dependence(
 
 def _add_ice_plot(_go, fig, ice_data):
     x = ice_data["feature_values"]
+    if "class_label" in ice_data.columns:
+        ice_data.drop(columns=["class_label"], inplace=True)
+    ice_data.drop(columns=["feature_values"], inplace=True)
     for i, sample in enumerate(ice_data):
         fig.add_trace(
             _go.Scatter(

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -857,8 +857,8 @@ def test_jupyter_graph_check(
 
     jupyter_check.return_value = True
     with pytest.warns(None) as graph_valid:
-        graph_partial_dependence(clf, X, features=0, grid_resolution=5)
-        assert len(graph_valid) == 1
+        graph_partial_dependence(clf, X, features=0, grid_resolution=20)
+        assert len(graph_valid) == 0
         import_check.assert_called_with("ipywidgets", warning=True)
     with pytest.warns(None) as graph_valid:
         graph_binary_objective_vs_threshold(test_pipeline, X, y, cbm, steps=5)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -41,7 +41,7 @@ def test_pipeline():
     return TestPipeline(parameters={"Logistic Regression Classifier": {"n_jobs": 1}})
 
 
-def check_partial_dependence_dataframe(pipeline, part_dep, grid_size=20):
+def check_partial_dependence_dataframe(pipeline, part_dep, grid_size=5):
     columns = ["feature_values", "partial_dependence"]
     if isinstance(pipeline, ClassificationPipeline):
         columns.append("class_label")
@@ -94,7 +94,7 @@ def test_partial_dependence_problem_types(
 
     X = make_data_type(data_type, X)
     pipeline.fit(X, y)
-    part_dep = partial_dependence(pipeline, X, features=0, grid_resolution=20)
+    part_dep = partial_dependence(pipeline, X, features=0, grid_resolution=5)
     check_partial_dependence_dataframe(pipeline, part_dep)
     assert not part_dep.isnull().any(axis=None)
 
@@ -109,15 +109,15 @@ def test_partial_dependence_string_feature_name(
     )
     pipeline.fit(X, y)
     part_dep = partial_dependence(
-        pipeline, X, features="mean radius", grid_resolution=20
+        pipeline, X, features="mean radius", grid_resolution=5
     )
     assert list(part_dep.columns) == [
         "feature_values",
         "partial_dependence",
         "class_label",
     ]
-    assert len(part_dep["partial_dependence"]) == 20
-    assert len(part_dep["feature_values"]) == 20
+    assert len(part_dep["partial_dependence"]) == 5
+    assert len(part_dep["feature_values"]) == 5
     assert not part_dep.isnull().any(axis=None)
 
 
@@ -166,7 +166,7 @@ def test_partial_dependence_baseline():
         ValueError,
         match="Partial dependence plots are not supported for Baseline pipelines",
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=20)
+        partial_dependence(pipeline, X, features=0, grid_resolution=5)
 
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
@@ -189,7 +189,7 @@ def test_partial_dependence_catboost(
             parameters={"CatBoost Classifier": {"thread_count": 1}},
         )
         pipeline.fit(X, y)
-        part_dep = partial_dependence(pipeline, X, features=0, grid_resolution=20)
+        part_dep = partial_dependence(pipeline, X, features=0, grid_resolution=5)
         check_partial_dependence_dataframe(pipeline, part_dep)
         assert not part_dep.isnull().all().all()
 
@@ -243,11 +243,11 @@ def test_partial_dependence_xgboost_feature_names(
     X = pd.DataFrame(X)
     X = X.rename(columns={0: "<[0]"})
     pipeline.fit(X, y)
-    part_dep = partial_dependence(pipeline, X, features="<[0]", grid_resolution=20)
+    part_dep = partial_dependence(pipeline, X, features="<[0]", grid_resolution=5)
     check_partial_dependence_dataframe(pipeline, part_dep)
     assert not part_dep.isnull().all().all()
 
-    part_dep = partial_dependence(pipeline, X, features=1, grid_resolution=20)
+    part_dep = partial_dependence(pipeline, X, features=1, grid_resolution=5)
     check_partial_dependence_dataframe(pipeline, part_dep)
     assert not part_dep.isnull().all().all()
 
@@ -358,7 +358,7 @@ def test_partial_dependence_not_fitted(
     with pytest.raises(
         ValueError, match="Pipeline to calculate partial dependence for must be fitted"
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=20)
+        partial_dependence(pipeline, X, features=0, grid_resolution=5)
 
 
 def test_partial_dependence_warning(logistic_regression_binary_pipeline_class):
@@ -372,17 +372,17 @@ def test_partial_dependence_warning(logistic_regression_binary_pipeline_class):
         NullsInColumnWarning,
         match="There are null values in the features, which will cause NaN values in the partial dependence output",
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=20)
+        partial_dependence(pipeline, X, features=0, grid_resolution=5)
     with pytest.warns(
         NullsInColumnWarning,
         match="There are null values in the features, which will cause NaN values in the partial dependence output",
     ):
-        partial_dependence(pipeline, X, features=("a", "b"), grid_resolution=20)
+        partial_dependence(pipeline, X, features=("a", "b"), grid_resolution=5)
     with pytest.warns(
         NullsInColumnWarning,
         match="There are null values in the features, which will cause NaN values in the partial dependence output",
     ):
-        partial_dependence(pipeline, X, features="a", grid_resolution=20)
+        partial_dependence(pipeline, X, features="a", grid_resolution=5)
 
 
 def test_partial_dependence_errors(logistic_regression_binary_pipeline_class):
@@ -397,7 +397,7 @@ def test_partial_dependence_errors(logistic_regression_binary_pipeline_class):
         ValueError,
         match="Too many features given to graph_partial_dependence.  Only one or two-way partial dependence is supported.",
     ):
-        partial_dependence(pipeline, X, features=("a", "b", "c"), grid_resolution=20)
+        partial_dependence(pipeline, X, features=("a", "b", "c"), grid_resolution=5)
 
     with pytest.raises(
         ValueError,
@@ -494,7 +494,7 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
     pipeline.fit(X, y)
 
     avg_pred, ind_preds = partial_dependence(
-        pipeline, X, features=["a", "b"], grid_resolution=20, kind="both"
+        pipeline, X, features=["a", "b"], grid_resolution=5, kind="both"
     )
     assert isinstance(avg_pred, pd.DataFrame)
     assert isinstance(ind_preds, list)
@@ -506,7 +506,7 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
         assert ind_df.shape == (3, 3)
 
     ind_preds = partial_dependence(
-        pipeline, X, features=["a", "b"], grid_resolution=20, kind="individual"
+        pipeline, X, features=["a", "b"], grid_resolution=5, kind="individual"
     )
     assert isinstance(ind_preds, list)
     assert isinstance(ind_preds[0], pd.DataFrame)
@@ -525,7 +525,7 @@ def test_graph_partial_dependence(breast_cancer_local, test_pipeline):
     )
     clf = test_pipeline
     clf.fit(X, y)
-    fig = graph_partial_dependence(clf, X, features="mean radius", grid_resolution=20)
+    fig = graph_partial_dependence(clf, X, features="mean radius", grid_resolution=5)
     assert isinstance(fig, go.Figure)
     fig_dict = fig.to_dict()
     assert fig_dict["layout"]["title"]["text"] == "Partial Dependence of 'mean radius'"
@@ -533,7 +533,7 @@ def test_graph_partial_dependence(breast_cancer_local, test_pipeline):
     assert fig_dict["data"][0]["name"] == "Partial Dependence"
 
     part_dep_data = partial_dependence(
-        clf, X, features="mean radius", grid_resolution=20
+        clf, X, features="mean radius", grid_resolution=5
     )
     assert np.array_equal(fig_dict["data"][0]["x"], part_dep_data["feature_values"])
     assert np.array_equal(
@@ -694,7 +694,7 @@ def test_partial_dependence_percentile_errors(
         ValueError,
         match="Features \\('random_col'\\) are mostly one value, \\(1\\), and cannot be",
     ):
-        partial_dependence(pipeline, X, features="random_col", grid_resolution=20)
+        partial_dependence(pipeline, X, features="random_col", grid_resolution=5)
     with pytest.raises(
         ValueError,
         match="Features \\('random_col'\\) are mostly one value, \\(1\\), and cannot be",
@@ -704,14 +704,14 @@ def test_partial_dependence_percentile_errors(
             X,
             features="random_col",
             percentiles=(0.01, 0.955),
-            grid_resolution=20,
+            grid_resolution=5,
         )
     with pytest.raises(
         ValueError,
         match="Features \\('random_col'\\) are mostly one value, \\(1\\), and cannot be",
     ):
         partial_dependence(
-            pipeline, X, features=2, percentiles=(0.01, 0.955), grid_resolution=20
+            pipeline, X, features=2, percentiles=(0.01, 0.955), grid_resolution=5
         )
     with pytest.raises(
         ValueError,
@@ -722,7 +722,7 @@ def test_partial_dependence_percentile_errors(
             X,
             features=("A", "random_col"),
             percentiles=(0.01, 0.955),
-            grid_resolution=20,
+            grid_resolution=5,
         )
     with pytest.raises(
         ValueError,
@@ -733,11 +733,11 @@ def test_partial_dependence_percentile_errors(
             X,
             features=("random_col", "random_col_2"),
             percentiles=(0.01, 0.955),
-            grid_resolution=20,
+            grid_resolution=5,
         )
 
     part_dep = partial_dependence(
-        pipeline, X, features="random_col", percentiles=(0.01, 0.96), grid_resolution=20
+        pipeline, X, features="random_col", percentiles=(0.01, 0.96), grid_resolution=5
     )
     assert list(part_dep.columns) == [
         "feature_values",
@@ -1094,12 +1094,12 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
         ]
     )
     pl.fit(X, y)
-    dep = partial_dependence(pl, X, features="amount", grid_resolution=20)
+    dep = partial_dependence(pl, X, features="amount", grid_resolution=5)
 
-    assert dep.shape[0] == 20
+    assert dep.shape[0] == 5
     assert dep.shape[0] != max(X.ww.select("categorical").describe().loc["unique"]) + 1
 
-    dep = partial_dependence(pl, X, features="provider", grid_resolution=20)
+    dep = partial_dependence(pl, X, features="provider", grid_resolution=5)
     assert dep.shape[0] == X["provider"].nunique()
     assert dep.shape[0] != max(X.ww.select("categorical").describe().loc["unique"]) + 1
 
@@ -1126,7 +1126,7 @@ def test_graph_partial_dependence_ice_plot(
     clf.fit(X, y)
 
     fig = graph_partial_dependence(
-        clf, X, features=feature, grid_resolution=20, kind="both"
+        clf, X, features=feature, grid_resolution=5, kind="both"
     )
     assert isinstance(fig, go.Figure)
     fig_dict = fig.to_dict()
@@ -1149,7 +1149,7 @@ def test_graph_partial_dependence_ice_plot(
     )
 
     avg_dep_data, ind_dep_data = partial_dependence(
-        clf, X, features=feature, grid_resolution=20, kind="both"
+        clf, X, features=feature, grid_resolution=5, kind="both"
     )
     assert np.array_equal(
         fig_dict["data"][-1]["x"],
@@ -1184,7 +1184,7 @@ def test_graph_partial_dependence_ice_plot(
             )
 
     fig = graph_partial_dependence(
-        clf, X, features=feature, grid_resolution=20, kind="individual"
+        clf, X, features=feature, grid_resolution=5, kind="individual"
     )
     assert isinstance(fig, go.Figure)
     fig_dict = fig.to_dict()
@@ -1203,7 +1203,7 @@ def test_graph_partial_dependence_ice_plot(
     assert fig_dict["data"][0]["name"] == expected_label
 
     ind_dep_data = partial_dependence(
-        clf, X, features=feature, grid_resolution=20, kind="individual"
+        clf, X, features=feature, grid_resolution=5, kind="individual"
     )
 
     for i in range(len(X)):
@@ -1236,7 +1236,7 @@ def test_graph_partial_dependence_ice_plot_two_way_error(test_pipeline):
             clf,
             X,
             features=["mean radius", "mean area"],
-            grid_resolution=20,
+            grid_resolution=5,
             kind="both",
         )
 
@@ -1248,6 +1248,6 @@ def test_graph_partial_dependence_ice_plot_two_way_error(test_pipeline):
             clf,
             X,
             features=["mean radius", "mean area"],
-            grid_resolution=20,
+            grid_resolution=5,
             kind="individual",
         )

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -1106,7 +1106,11 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
 def test_graph_partial_dependence_ice_plot(
-    problem_type, wine_local, breast_cancer_local, test_pipeline, logistic_regression_multiclass_pipeline_class
+    problem_type,
+    wine_local,
+    breast_cancer_local,
+    test_pipeline,
+    logistic_regression_multiclass_pipeline_class,
 ):
     go = pytest.importorskip(
         "plotly.graph_objects",
@@ -1224,7 +1228,9 @@ def test_graph_partial_dependence_ice_plot(
             )
 
 
-def test_graph_partial_dependence_ice_plot_two_way_error(local_breast_cancer, test_pipeline):
+def test_graph_partial_dependence_ice_plot_two_way_error(
+    local_breast_cancer, test_pipeline
+):
     X, y = local_breast_cancer
     clf = test_pipeline
     clf.fit(X, y)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -288,6 +288,26 @@ def test_partial_dependence_multiclass(
     assert len(two_way_part_dep.index) == num_classes * grid_resolution
     assert len(two_way_part_dep.columns) == grid_resolution + 1
 
+    two_way_part_dep, two_way_ice_data = partial_dependence(
+        pipeline=pipeline,
+        X=X,
+        features=("magnesium", "alcohol"),
+        grid_resolution=grid_resolution,
+        kind="both",
+    )
+
+    assert "class_label" in two_way_part_dep.columns
+    assert two_way_part_dep["class_label"].nunique() == num_classes
+    assert len(two_way_part_dep.index) == num_classes * grid_resolution
+    assert len(two_way_part_dep.columns) == grid_resolution + 1
+
+    assert len(two_way_ice_data) == len(X)
+    for ind_data in two_way_ice_data:
+        assert "class_label" in ind_data.columns
+        assert two_way_part_dep["class_label"].nunique() == num_classes
+        assert len(two_way_part_dep.index) == num_classes * grid_resolution
+        assert len(two_way_part_dep.columns) == grid_resolution + 1
+
 
 def test_partial_dependence_multiclass_numeric_labels(
     logistic_regression_multiclass_pipeline_class, X_y_multi

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -1229,9 +1229,9 @@ def test_graph_partial_dependence_ice_plot(
 
 
 def test_graph_partial_dependence_ice_plot_two_way_error(
-    local_breast_cancer, test_pipeline
+    breast_cancer_local, test_pipeline
 ):
-    X, y = local_breast_cancer
+    X, y = breast_cancer_local
     clf = test_pipeline
     clf.fit(X, y)
     with pytest.raises(

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -1106,7 +1106,7 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
 
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
 def test_graph_partial_dependence_ice_plot(
-    problem_type, test_pipeline, logistic_regression_multiclass_pipeline_class
+    problem_type, wine_local, breast_cancer_local, test_pipeline, logistic_regression_multiclass_pipeline_class
 ):
     go = pytest.importorskip(
         "plotly.graph_objects",
@@ -1117,10 +1117,10 @@ def test_graph_partial_dependence_ice_plot(
         test_pipeline = logistic_regression_multiclass_pipeline_class(
             parameters={"Logistic Regression Classifier": {"n_jobs": 1}}
         )
-        X, y = load_wine()
+        X, y = wine_local
         feature = "ash"
     else:
-        X, y = load_breast_cancer()
+        X, y = breast_cancer_local
         feature = "mean radius"
     clf = test_pipeline
     clf.fit(X, y)
@@ -1224,8 +1224,8 @@ def test_graph_partial_dependence_ice_plot(
             )
 
 
-def test_graph_partial_dependence_ice_plot_two_way_error(test_pipeline):
-    X, y = load_breast_cancer()
+def test_graph_partial_dependence_ice_plot_two_way_error(local_breast_cancer, test_pipeline):
+    X, y = local_breast_cancer
     clf = test_pipeline
     clf.fit(X, y)
     with pytest.raises(


### PR DESCRIPTION
This implementation extends `graph_partial_dependencies()` by adding support for plotting Individual Conditional Expectations (ICE) behind a Partial Dependency plot. In addition, `partial_dependence()` has been updated to be able to generate the ICE data (as `graph_partial_dependencies()` uses this function to get the plot data). 

Single Class:
![image](https://user-images.githubusercontent.com/8752455/122282774-ca1b7200-ceb9-11eb-834a-ab73fef12f3c.png)

Multiclass:
![image](https://user-images.githubusercontent.com/8752455/122593011-0a523000-d033-11eb-911b-aab63d2330cf.png)

Multiclass ICE only:
![image](https://user-images.githubusercontent.com/8752455/122592960-fad2e700-d032-11eb-9e50-62ead2ccafa5.png)
 

By default, ICE plots are not shown when partial dependency plots are created. Setting `kind='individual'` or `kind='both'` will show the ICE plot.

Caveats: 
- Does not work for creating two-way partial dependency plots as there is no clean way to display ICE plots over a Contour plot. `partial_dependence()` is able to calculate the data behind the two-way partial dependency plot and return it as a list of DataFrames (with each DataFrame representing one sample). For now, a `ValueError` is thrown when an ICE plot is attempted for a two-way partial dependency. 

Once the implementation clears, I can update the documentation example to show an ICE plot.

Resolves #2025 