### PR TITLE
Miscellaneous CI updates

### DIFF
--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -1,4 +1,4 @@
-name: Build Conda Package
+name: Build conda package
 
 on:
   pull_request:

--- a/.github/workflows/detect_changes.yml
+++ b/.github/workflows/detect_changes.yml
@@ -1,4 +1,4 @@
-name: Detect Dependencies Changes
+name: Detect dependency changes
 
 on:
   pull_request:

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -1,4 +1,4 @@
-name: Latest Dependency Checker
+name: Dependency update checker
 on:
   schedule:
       - cron: '0 * * * *'

--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -1,4 +1,4 @@
-name: Lint Tests
+name: Lint
 
 on:
   pull_request:

--- a/.github/workflows/lint_tests.yml
+++ b/.github/workflows/lint_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [ "3.7", "3.8" ]
+        python_version: [ "3.7", "3.8", "3.9" ]
     steps:
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -1,8 +1,8 @@
-name: Nightly Linux Unit Tests
+name: Nightly unit tests, linux
 
 on:
   schedule:
-      - cron: '0 7 * * *'
+      - cron: '0 3 * * *'
 
 jobs:
   unit_tests:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.7', '3.9']
+        python_version: ['3.7', '3.8', '3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-dask']
     steps:
       - name: Set up Python ${{ matrix.python_version }}

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -1,4 +1,4 @@
-name: Linux Unit Tests with Latest Dependencies
+name: Unit tests, linux, latest dependencies
 
 on:
   pull_request:

--- a/.github/workflows/linux_unit_tests_with_minimum_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_minimum_deps.yml
@@ -1,4 +1,4 @@
-name: Linux Unit Tests with Minimum Dependencies
+name: Unit tests, linux, min dependencies
 
 on:
   pull_request:

--- a/.github/workflows/minimum_dependency_checker.yml
+++ b/.github/workflows/minimum_dependency_checker.yml
@@ -1,4 +1,4 @@
-name: Minimum Dependency Checker
+name: Minimum dependency checker
 on:
   push:
     branches:

--- a/.github/workflows/release_notes_updated.yml
+++ b/.github/workflows/release_notes_updated.yml
@@ -1,4 +1,4 @@
-name: Release Notes Updated
+name: Release notes updated
 
 on:
   pull_request:

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.7', '3.9']
+        python_version: ['3.7', '3.8', '3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-dask']
     steps:
       - name: Download Miniconda

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -1,8 +1,8 @@
-name: Nightly Windows Unit Tests
+name: Nightly unit tests, windows
 
 on:
   schedule:
-      - cron: '0 7 * * *'
+      - cron: '0 3 * * *'
 
 jobs:
   win_unit_tests:

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -1,4 +1,4 @@
-name: Windows Unit Tests
+name: Unit tests, windows
 
 on:
   pull_request:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Release Notes
         * Refactored dask tests :pr:`2377`
         * Added the combined dask/non-dask unit tests back and renamed the dask only unit tests. :pr:`2382`
         * Sped up unit tests and split into separate jobs :pr:`2365`
+        * Change CI job names, run lint for python 3.9, run nightlies on python 3.8 at 3am EST :pr:`2395`
 
 .. warning::
 


### PR DESCRIPTION
Follow-on to #2365 which was just merged.

Changes
* Rename tests so they're a little easier to read in the list which appears at the bottom of each PR
* Run lint on python 3.9
* Run nightlies on python 3.8 too (why not?)
* Have the nightlies run at 3am EST instead of 7am, just in case anyone is working early 😆 