### PR TITLE
Release v0.27.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,10 +2,28 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.27.0 Jun. 22, 2021**
+    * Enhancements
+        * Adds force plots for prediction explanations :pr:`2157`
+        * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
+        * Added support for nonlinear pipelines for ``generate_pipeline_code`` :pr:`2332`
+        * Added ``inverse_transform`` method to pipelines :pr:`2256`
+        * Add optional automatic update checker :pr:`2350`
+        * Added ``search_order`` to ``AutoMLSearch``'s ``rankings`` and ``full_rankings`` tables :pr:`2345`
         * Updated threshold optimization method for binary classification :pr:`2315`
         * Updated demos to pull data from S3 instead of including demo data in package :pr:`2387`
         * Upgrade woodwork version to v0.4.1 :pr:`2379`
     * Fixes
+        * Preserve user-specified woodwork types throughout pipeline fit/predict :pr:`2297`
         * Fixed ``ComponentGraph`` appending target to ``final_component_features`` if there is a component that returns both X and y :pr:`2358`
         * Fixed partial dependence graph method failing on multiclass problems when the class labels are numeric :pr:`2372`
         * Added ``thresholding_objective`` argument to ``AutoMLSearch`` for binary classification problems :pr:`2320`
@@ -14,6 +32,9 @@ Release Notes
         * Pinned pytest-timeout to fix minimum dependence checker :pr:`2425`
         * Replaced ``Elastic Net Classifier`` base class with ``Logistsic Regression`` to avoid ``NaN`` outputs :pr:`2420`
     * Changes
+        * Cleaned up ``PipelineBase``'s ``component_graph`` and ``_component_graph`` attributes. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` :pr:`2332`
+        * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
+        * Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` :pr:`2317`
         * Replaced `allowed_pipelines` with `allowed_component_graphs` :pr:`2364`
         * Removed private method ``_compute_features_during_fit`` from ``PipelineBase`` :pr:`2359`
         * Updated ``compute_order`` in ``ComponentGraph`` to be a read-only property :pr:`2408`
@@ -25,6 +46,8 @@ Release Notes
         * Fixed lead scoring weights in the demos documentation :pr:`2315`
         * Fixed start page code and description dataset naming discrepancy :pr:`2370`
     * Testing Changes
+        * Update minimum unit tests to run on all pull requests :pr:`2314`
+        * Pass token to authorize uploading of codecov reports :pr:`2344`
         * Add ``pytest-timeout``. All tests that run longer than 6 minutes will fail. :pr:`2374`
         * Separated the dask tests out into separate github action jobs to isolate dask failures. :pr:`2376`
         * Refactored dask tests :pr:`2377`
@@ -37,33 +60,8 @@ Release Notes
 
     **Breaking Changes**
         * `AutoMLSearch` will accept `allowed_component_graphs` instead of `allowed_pipelines` :pr:`2364`
-
-
-**v0.26.0 Jun. 08, 2021**
-    * Enhancements
-        * Adds force plots for prediction explanations :pr:`2157`
-        * Removed self-reference from ``AutoMLSearch`` :pr:`2304`
-        * Added support for nonlinear pipelines for ``generate_pipeline_code`` :pr:`2332`
-        * Added ``inverse_transform`` method to pipelines :pr:`2256`
-        * Add optional automatic update checker :pr:`2350`
-        * Added ``search_order`` to ``AutoMLSearch``'s ``rankings`` and ``full_rankings`` tables :pr:`2345`
-    * Fixes
-        * Preserve user-specified woodwork types throughout pipeline fit/predict :pr:`2297`
-    * Changes
-        * Cleaned up ``PipelineBase``'s ``component_graph`` and ``_component_graph`` attributes. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` :pr:`2332`
-        * Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` :pr:`2306`
-        * Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` :pr:`2317`
-    * Documentation Changes
-    * Testing Changes
-        * Update minimum unit tests to run on all pull requests :pr:`2314`
-        * Pass token to authorize uploading of codecov reports :pr:`2344`
-
-.. warning::
-
-    **Breaking Changes**
         * Removed ``PipelineBase``'s ``_component_graph`` attribute. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` :pr:`2332`
         * `pipeline_parameters` will no longer accept `skopt.space` variables since hyperparameter ranges will now be specified through `custom_hyperparameters` :pr:`2317`
-
 
 **v0.25.0 Jun. 01, 2021**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
 
 setup(
     name='evalml',
-    version='0.26.0',
+    version='0.27.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.27.0 Jun. 22, 2021
### Enhancements
- Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported #2181
- Added a new callback parameter for ``explain_predictions_best_worst`` #2308
### Fixes
### Changes
- Deleted the ``return_pandas`` flag from our demo data loaders #2181
- Moved ``default_parameters`` to ``ComponentGraph`` from ``PipelineBase`` #2307
### Documentation Changes
- Updated the release procedure documentation #2230
### Testing Changes
- Ignoring ``test_saving_png_file`` while building conda package #2323
### Breaking Changes
- Deleted the ``return_pandas`` flag from our demo data loaders #2181
- Upgraded minimum woodwork to version 0.3.1. Previous versions will not be supported #2181
- Due to the weak-ref in woodwork, set the result of ``infer_feature_types`` to a variable before accessing woodwork #2181
(base) RM-MB-151:evalml karsten.chu$ tools/format_release_notes.sh 
# v0.27.0 Jun. 22, 2021
### Enhancements
- Adds force plots for prediction explanations #2157
- Removed self-reference from ``AutoMLSearch`` #2304
- Added support for nonlinear pipelines for ``generate_pipeline_code`` #2332
- Added ``inverse_transform`` method to pipelines #2256
- Add optional automatic update checker #2350
- Added ``search_order`` to ``AutoMLSearch``'s ``rankings`` and ``full_rankings`` tables #2345
- Updated threshold optimization method for binary classification #2315
- Updated demos to pull data from S3 instead of including demo data in package #2387
- Upgrade woodwork version to v0.4.1 #2379
### Fixes
- Preserve user-specified woodwork types throughout pipeline fit/predict #2297
- Fixed ``ComponentGraph`` appending target to ``final_component_features`` if there is a component that returns both X and y #2358
- Fixed partial dependence graph method failing on multiclass problems when the class labels are numeric #2372
- Added ``thresholding_objective`` argument to ``AutoMLSearch`` for binary classification problems #2320
- Added change for ``k_neighbors`` parameter in SMOTE Oversamplers to automatically handle small samples #2375
- Changed naming for ``Logistic Regression Classifier`` file #2399
- Pinned pytest-timeout to fix minimum dependence checker #2425
- Replaced ``Elastic Net Classifier`` base class with ``Logistsic Regression`` to avoid ``NaN`` outputs #2420
### Changes
- Cleaned up ``PipelineBase``'s ``component_graph`` and ``_component_graph`` attributes. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` #2332
- Added and applied  ``black`` linting package to the EvalML repo in place of ``autopep8`` #2306
- Separated `custom_hyperparameters` from pipelines and added them as an argument to ``AutoMLSearch`` #2317
- Replaced `allowed_pipelines` with `allowed_component_graphs` #2364
- Removed private method ``_compute_features_during_fit`` from ``PipelineBase`` #2359
- Updated ``compute_order`` in ``ComponentGraph`` to be a read-only property #2408
- Unpinned PyZMQ version in requirements.txt #2389 
- Uncapping LightGBM version in requirements.txt #2405
- Updated minimum version of plotly #2415
- Removed ``SensitivityLowAlert`` objective from core objectives #2418
### Documentation Changes
- Fixed lead scoring weights in the demos documentation #2315
- Fixed start page code and description dataset naming discrepancy #2370
### Testing Changes
- Update minimum unit tests to run on all pull requests #2314
- Pass token to authorize uploading of codecov reports #2344
- Add ``pytest-timeout``. All tests that run longer than 6 minutes will fail. #2374
- Separated the dask tests out into separate github action jobs to isolate dask failures. #2376
- Refactored dask tests #2377
- Added the combined dask/non-dask unit tests back and renamed the dask only unit tests. #2382
- Sped up unit tests and split into separate jobs #2365
- Change CI job names, run lint for python 3.9, run nightlies on python 3.8 at 3am EST #2395 #2398
- Set fail-fast to false for CI jobs that run for PRs #2402
### Breaking Changes
- `AutoMLSearch` will accept `allowed_component_graphs` instead of `allowed_pipelines` #2364
- Removed ``PipelineBase``'s ``_component_graph`` attribute. Updated ``PipelineBase`` ``__repr__`` and added ``__eq__`` for ``ComponentGraph`` #2332
- `pipeline_parameters` will no longer accept `skopt.space` variables since hyperparameter ranges will now be specified through `custom_hyperparameters` #2317