### PR TITLE
Updated workflows to store pytest runtimes as test artifacts 

### DIFF
--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -82,6 +82,11 @@ jobs:
         run: |
           source test_python/bin/activate
           make ${{matrix.command}}
+      - name: Upload pytest duration artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-duration-report
+          path: test-report/{{matrix.command}}-junit.xml
       - name: install coverage
         run: pip install coverage
       - name: Upload coverage to Codecov

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: pytest-duration-report
-          path: test-report/{{matrix.command}}-junit.xml
+          path: test-report/${{matrix.command}}-junit.xml
       - name: install coverage
         run: pip install coverage
       - name: Upload coverage to Codecov

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: pytest-duration-report
-          path: test-report/${{matrix.command}}-junit.xml
+          path: test-reports/${{matrix.command}}-junit.xml
       - name: install coverage
         run: pip install coverage
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -31,35 +31,35 @@ test-dask:
 
 .PHONY: git-test-dask
 git-test-dask:
-	pytest evalml/tests/automl_tests/dask_tests/ -n 1 --doctest-modules --cov=evalml/tests/automl_tests/dask_tests/ --junitxml=test-reports/junit.xml --doctest-continue-on-failure  --timeout 300 --durations 0
+	pytest evalml/tests/automl_tests/dask_tests/ -n 1 --doctest-modules --cov=evalml/tests/automl_tests/dask_tests/ --junitxml=test-reports/git-test-dask-junit.xml --doctest-continue-on-failure  --timeout 300 --durations 0
 
 .PHONY: git-test-minimal-deps-dask
 git-test-minimal-deps-dask:
-	pytest evalml/tests/automl_tests/dask_tests/  -n 1 --doctest-modules --cov=evalml/tests/automl_tests/dask_tests/  --junitxml=test-reports/junit.xml --doctest-continue-on-failure --has-minimal-dependencies --timeout 300 --durations 0
+	pytest evalml/tests/automl_tests/dask_tests/  -n 1 --doctest-modules --cov=evalml/tests/automl_tests/dask_tests/  --junitxml=test-reports/git-test-minimal-deps-dask-junit.xml --doctest-continue-on-failure --has-minimal-dependencies --timeout 300 --durations 0
 
 .PHONY: git-test-automl-core
 git-test-automl-core:
-	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-automl
 git-test-automl:
-	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure
+	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-junit.xml --doctest-continue-on-failure
 
 .PHONY: git-test-modelunderstanding-core
 git-test-modelunderstanding-core:
-	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-modelunderstanding
 git-test-modelunderstanding:
-	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure
+	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-junit.xml --doctest-continue-on-failure
 
 .PHONY: git-test-other-core
 git-test-other-core:
-	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-other
 git-test-other:
-	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/junit.xml --doctest-continue-on-failure
+	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-junit.xml --doctest-continue-on-failure
 
 .PHONY: installdeps
 installdeps:

--- a/Makefile
+++ b/Makefile
@@ -39,27 +39,27 @@ git-test-minimal-deps-dask:
 
 .PHONY: git-test-automl-core
 git-test-automl-core:
-	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-automl
 git-test-automl:
-	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-junit.xml --doctest-continue-on-failure
+	pytest evalml/tests/automl_tests evalml/tests/tuner_tests -n 2 --ignore=evalml/tests/automl_tests/dask_tests --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-automl-junit.xml --doctest-continue-on-failure
 
 .PHONY: git-test-modelunderstanding-core
 git-test-modelunderstanding-core:
-	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests/model_understanding_tests -n 2 --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-modelunderstanding
 git-test-modelunderstanding:
-	pytest evalml/tests/model_understanding_tests -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-junit.xml --doctest-continue-on-failure
+	pytest evalml/tests/model_understanding_tests -n 2 --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-modelunderstanding-junit.xml --doctest-continue-on-failure
 
 .PHONY: git-test-other-core
 git-test-other-core:
-	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
+	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-core-junit.xml --doctest-continue-on-failure --has-minimal-dependencies
 
 .PHONY: git-test-other
 git-test-other:
-	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 100 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-junit.xml --doctest-continue-on-failure
+	pytest evalml/tests --ignore evalml/tests/automl_tests/ --ignore evalml/tests/tuner_tests/ --ignore evalml/tests/model_understanding_tests/ -n 2 --durations 0 --timeout 300 --doctest-modules --cov=evalml --junitxml=test-reports/git-test-other-junit.xml --doctest-continue-on-failure
 
 .PHONY: installdeps
 installdeps:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
     * Testing Changes
         * Added slack integration for nightlies tests :pr:`2436`
         * Changed ``build_conda_pkg`` CI job to run only when dependencies are updates :pr:`2446`
+        * Updated workflows to store pytest runtimes as test artifacts :pr:`2448`
 
 .. warning::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ python_files = evalml/tests/*
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+junit_duration_report = call
 [flake8]
 max-line-length = 88
 extend-ignore = E203


### PR DESCRIPTION
Closes #2396.

Example of artifact: https://github.com/alteryx/evalml/actions/runs/980439245