### PR TITLE
Delete unreachable line in IterativeAlgorithm

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
         * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr:`2386`
         * Updated Objectives API to allow for sample weighting :pr:`2433`
     * Fixes
+        * Deleted unreachable line from ``IterativeAlgorithm`` :pr:`2464`
     * Changes
         * Pinned Woodwork version between 0.4.1 and 0.4.2 :pr:`2460`
         * Updated psutils minimum version in requirements :pr:`2438`

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -245,12 +245,11 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                         component_parameters[param_name] = value.rvs(
                             random_state=self.random_seed
                         )[0]
-                    elif isinstance(value, Categorical):
+                    # Categorical
+                    else:
                         component_parameters[param_name] = value.rvs(
                             random_state=self.random_seed
                         )
-                    else:
-                        component_parameters[param_name] = value
             if name in self._pipeline_params and self._batch_number == 0:
                 for param_name, value in self._pipeline_params[name].items():
                     component_parameters[param_name] = value


### PR DESCRIPTION
### Pull Request Description
Fixes #2338 

The uncovered line originally mentioned in #2338 is now covered but there's still an uncovered line!

We previously [check](https://github.com/alteryx/evalml/blob/main/evalml/automl/automl_algorithm/iterative_algorithm.py#L109) that all custom_hyperparameters are instances of skopt spaces:

```python
for hyperparam_name_val in self._custom_hyperparameters.values():
    for _, hyperparam_val in hyperparam_name_val.items():
        if not isinstance(hyperparam_val, (Integer, Real, Categorical)):
            raise ValueError(
                "Custom hyperparameters should only contain skopt.Space variables such as Categorical, Integer,"
                " and Real!"
            )
```

So the else clause I'm deleting can't be changed. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
