### PR TITLE
Provide details on how to fix error when ww schema is broken

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Release Notes
         * Exposed ``thread_count`` for Catboost estimators as ``n_jobs`` parameter :pr:`2410`
         * Updated Objectives API to allow for sample weighting :pr:`2433`
         * Added ability to use built-in pickle for saving AutoMLSearch :pr:`2463`
+        * Added details on how to fix error caused by broken ww schema :pr:`2466`
     * Fixes
         * Deleted unreachable line from ``IterativeAlgorithm`` :pr:`2464`
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,8 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+        * Added details on how to fix error caused by broken ww schema :pr:`2466`
+        * Added ability to use built-in pickle for saving AutoMLSearch :pr:`2463`
     * Fixes
         * Fixed ``FraudCost`` objective and reverted threshold optimization method for binary classification to ``Golden`` :pr:`2450`
         * Added custom exception message for partial dependence on features with scales that are too small :pr:`2455`
@@ -18,8 +20,6 @@ Release Notes
         * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr:`2386`
         * Exposed ``thread_count`` for Catboost estimators as ``n_jobs`` parameter :pr:`2410`
         * Updated Objectives API to allow for sample weighting :pr:`2433`
-        * Added ability to use built-in pickle for saving AutoMLSearch :pr:`2463`
-        * Added details on how to fix error caused by broken ww schema :pr:`2466`
     * Fixes
         * Deleted unreachable line from ``IterativeAlgorithm`` :pr:`2464`
     * Changes

--- a/evalml/tests/utils_tests/test_woodwork_utils.py
+++ b/evalml/tests/utils_tests/test_woodwork_utils.py
@@ -183,8 +183,23 @@ def test_infer_feature_types_raises_invalid_schema_error():
         infer_feature_types(df, feature_types={0: "Integer"})
 
     # Raise error when user breaks the schema and then passes it to evalml
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Dataframe types are not consistent with logical types. This usually happens "
+            "when a data transformation does not go through the ww accessor."
+        ),
+    ):
         df.iloc[2, 0] = 3
         df.ww.init(logical_types={0: "Integer"})
         df.iloc[2, 0] = None
         infer_feature_types(df, feature_types={0: "Integer"})
+
+    with pytest.raises(
+        ValueError,
+        match="The following columns in the typing information were missing from the DataFrame",
+    ):
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        df.ww.init()
+        df.drop(columns=["b"], inplace=True)
+        infer_feature_types(df)

--- a/evalml/tests/utils_tests/test_woodwork_utils.py
+++ b/evalml/tests/utils_tests/test_woodwork_utils.py
@@ -197,7 +197,7 @@ def test_infer_feature_types_raises_invalid_schema_error():
 
     with pytest.raises(
         ValueError,
-        match="The following columns in the typing information were missing from the DataFrame",
+        match="Please initialize ww with df.ww.init()",
     ):
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
         df.ww.init()

--- a/evalml/utils/woodwork_utils.py
+++ b/evalml/utils/woodwork_utils.py
@@ -67,7 +67,14 @@ def infer_feature_types(data, feature_types=None):
         if isinstance(data, pd.DataFrame) and not ww.is_schema_valid(
             data, data.ww.schema
         ):
-            raise ValueError(ww.get_invalid_schema_message(data, data.ww.schema))
+            ww_error = ww.get_invalid_schema_message(data, data.ww.schema)
+            if "dtype mismatch" in ww_error:
+                ww_error = (
+                    "Dataframe types are not consistent with logical types. This usually happens "
+                    "when a data transformation does not go through the ww accessor. Call df.ww.init() to "
+                    f"get rid of this message. This is a more detailed message about the mismatch: {ww_error}"
+                )
+            raise ValueError(ww_error)
         data.ww.init(schema=data.ww.schema)
         return data
 

--- a/evalml/utils/woodwork_utils.py
+++ b/evalml/utils/woodwork_utils.py
@@ -74,6 +74,8 @@ def infer_feature_types(data, feature_types=None):
                     "when a data transformation does not go through the ww accessor. Call df.ww.init() to "
                     f"get rid of this message. This is a more detailed message about the mismatch: {ww_error}"
                 )
+            else:
+                ww_error = f"{ww_error}. Please initialize ww with df.ww.init() to get rid of this message."
             raise ValueError(ww_error)
         data.ww.init(schema=data.ww.schema)
         return data


### PR DESCRIPTION
### Pull Request Description
Fixes #2353 

This is the new stacktrace:
```python
from evalml.pipelines import ComponentGraph
from evalml.demos import load_fraud
cg = ComponentGraph({"Imputer": ["Imputer"],
                     "DateTime": ["DateTime Featurization Component", "Imputer.x"],
                     "OneHot": ["One Hot Encoder", "DateTime.x"],
                     "TargetImputer": ["Target Imputer", "OneHot.x", "OneHot.y"],
                     "Logistic": ["Logistic Regression Classifier", "TargetImputer.x", "TargetImputer.y"]})
cg.instantiate({})
X, y = load_fraud(1000)
X["card_id"] = X["provider"].astype("category")
cg.fit(X, y)
```

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-74772725e1f8> in <module>
      9 X, y = load_fraud(1000)
     10 X["card_id"] = X["provider"].astype("category")
---> 11 cg.fit(X, y)

~/sources/evalml/evalml/pipelines/component_graph.py in fit(self, X, y)
    194             y (pd.Series): The target training data of length [n_samples]
    195         """
--> 196         X = infer_feature_types(X)
    197         y = infer_feature_types(y)
    198         self._compute_features(self.compute_order, X, y, fit=True)

~/sources/evalml/evalml/utils/woodwork_utils.py in infer_feature_types(data, feature_types)
     75                     f"get rid of this message. This is a more detailed message about the mismatch: {ww_error}"
     76                 )
---> 77             raise ValueError(ww_error)
     78         data.ww.init(schema=data.ww.schema)
     79         return data

ValueError: Dataframe types are not consistent with logical types. This usually happens when a data transformation does not go through the ww accessor. Call df.ww.init() to get rid of this message. This is a more detailed message about the mismatch: dtype mismatch for column card_id between DataFrame dtype, category, and Integer dtype, int64
```


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
