### PR TITLE
Release v0.28.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,17 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.28.0 Jul. 2, 2021**
+    * Enhancements
         * Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence :pr:`2386`
         * Exposed ``thread_count`` for Catboost estimators as ``n_jobs`` parameter :pr:`2410`
         * Updated Objectives API to allow for sample weighting :pr:`2433`
@@ -19,10 +30,6 @@ Release Notes
         * Changed ``build_conda_pkg`` CI job to run only when dependencies are updates :pr:`2446`
         * Updated workflows to store pytest runtimes as test artifacts :pr:`2448`
         * Added ``AutoMLTestEnv`` test fixture for making it easy to mock automl tests :pr:`2406`
-
-.. warning::
-
-    **Breaking Changes**
 
 **v0.27.0 Jun. 22, 2021**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
 
 setup(
     name='evalml',
-    version='0.27.0',
+    version='0.28.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.28.0 Jul. 2, 2021
### Enhancements
- Added support for showing a Individual Conditional Expectations plot when graphing Partial Dependence #2386
- Exposed ``thread_count`` for Catboost estimators as ``n_jobs`` parameter #2410
- Updated Objectives API to allow for sample weighting #2433
### Fixes
- Deleted unreachable line from ``IterativeAlgorithm`` #2464
### Changes
- Pinned Woodwork version between 0.4.1 and 0.4.2 #2460
- Updated psutils minimum version in requirements #2438
- Updated ``log_error_callback`` to not include filepath in logged message #2429
### Documentation Changes
- Sped up docs #2430
- Removed mentions of ``DataTable`` and ``DataColumn`` from the docs #2445
### Testing Changes
- Added slack integration for nightlies tests #2436
- Changed ``build_conda_pkg`` CI job to run only when dependencies are updates #2446
- Updated workflows to store pytest runtimes as test artifacts #2448
- Added ``AutoMLTestEnv`` test fixture for making it easy to mock automl tests #2406