### PR TITLE
Update components with attribute that describes if they can be used in list API for Pipelines

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
         * Added details on how to fix error caused by broken ww schema :pr:`2466`
         * Added ability to use built-in pickle for saving AutoMLSearch :pr:`2463`
         * Updated our components and component graphs to use latest features of ww 0.4.1, e.g. ``concat_columns`` and drop in-place. :pr:`2465`
+        * Updated our components with an attribute that describes if they can be used in list API for pipeline initialization :pr:`2496`
     * Fixes
         * Fixed ``FraudCost`` objective and reverted threshold optimization method for binary classification to ``Golden`` :pr:`2450`
         * Added custom exception message for partial dependence on features with scales that are too small :pr:`2455`

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -26,6 +26,7 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     """
 
     _default_parameters = None
+    _supported_by_list_API = False
 
     def __init__(self, parameters=None, component_obj=None, random_seed=0, **kwargs):
         """Base class for all components.

--- a/evalml/pipelines/components/estimators/estimator.py
+++ b/evalml/pipelines/components/estimators/estimator.py
@@ -28,6 +28,7 @@ class Estimator(ComponentBase):
     # We can't use the inspect module to dynamically determine this because of issue 1582
     predict_uses_y = False
     model_family = ModelFamily.NONE
+    _supported_by_list_API = True
 
     @property
     @classmethod

--- a/evalml/pipelines/components/transformers/column_selectors.py
+++ b/evalml/pipelines/components/transformers/column_selectors.py
@@ -13,6 +13,8 @@ class ColumnSelector(Transformer):
         random_seed (int): Seed for the random number generator. Defaults to 0.
     """
 
+    _supported_by_list_API = True
+
     def __init__(self, columns=None, random_seed=0, **kwargs):
         if columns and not isinstance(columns, list):
             raise ValueError(

--- a/evalml/pipelines/components/transformers/dimensionality_reduction/lda.py
+++ b/evalml/pipelines/components/transformers/dimensionality_reduction/lda.py
@@ -20,6 +20,7 @@ class LinearDiscriminantAnalysis(Transformer):
 
     name = "Linear Discriminant Analysis Transformer"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, n_components=None, random_seed=0, **kwargs):
         if n_components and n_components < 1:

--- a/evalml/pipelines/components/transformers/dimensionality_reduction/pca.py
+++ b/evalml/pipelines/components/transformers/dimensionality_reduction/pca.py
@@ -24,6 +24,7 @@ class PCA(Transformer):
 
     name = "PCA Transformer"
     hyperparameter_ranges = {"variance": Real(0.25, 1)}
+    _supported_by_list_API = True
 
     def __init__(self, variance=0.95, n_components=None, random_seed=0, **kwargs):
         parameters = {"variance": variance, "n_components": n_components}

--- a/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
@@ -41,6 +41,7 @@ class OneHotEncoder(Transformer, metaclass=OneHotEncoderMeta):
 
     name = "One Hot Encoder"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -31,6 +31,7 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
 
     name = "Target Encoder"
     hyperparameter_ranges = {}
+    _supported_by_list_API = False
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -31,7 +31,7 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
 
     name = "Target Encoder"
     hyperparameter_ranges = {}
-    _supported_by_list_API = False
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -18,6 +18,8 @@ class FeatureSelector(Transformer):
         random_seed (int): Seed for the random number generator. Defaults to 0.
     """
 
+    _supported_by_list_API = True
+
     def get_names(self):
         """Get names of selected features.
 

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -28,6 +28,7 @@ class Imputer(Transformer):
     _valid_numeric_impute_strategies = set(
         ["mean", "median", "most_frequent", "constant"]
     )
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/per_column_imputer.py
@@ -25,6 +25,7 @@ class PerColumnImputer(Transformer):
 
     name = "Per Column Imputer"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -22,6 +22,7 @@ class SimpleImputer(Transformer):
 
     name = "Simple Imputer"
     hyperparameter_ranges = {"impute_strategy": ["mean", "median", "most_frequent"]}
+    _supported_by_list_API = True
 
     def __init__(
         self, impute_strategy="most_frequent", fill_value=None, random_seed=0, **kwargs

--- a/evalml/pipelines/components/transformers/imputers/target_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/target_imputer.py
@@ -47,6 +47,7 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
 
     name = "Target Imputer"
     hyperparameter_ranges = {"impute_strategy": ["mean", "median", "most_frequent"]}
+    _supported_by_list_API = False
 
     def __init__(
         self, impute_strategy="most_frequent", fill_value=None, random_seed=0, **kwargs

--- a/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
@@ -75,6 +75,7 @@ class DateTimeFeaturizer(Transformer):
         "day_of_week": _extract_day_of_week,
         "hour": _extract_hour,
     }
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/delayed_feature_transformer.py
@@ -24,6 +24,7 @@ class DelayedFeatureTransformer(Transformer):
     name = "Delayed Feature Transformer"
     hyperparameter_ranges = {}
     needs_fitting = False
+    _supported_by_list_API = True
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
+++ b/evalml/pipelines/components/transformers/preprocessing/drop_null_columns.py
@@ -14,6 +14,7 @@ class DropNullColumns(Transformer):
 
     name = "Drop Null Columns Transformer"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, pct_null_threshold=1.0, random_seed=0, **kwargs):
         if pct_null_threshold < 0 or pct_null_threshold > 1:

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -18,6 +18,7 @@ class DFSTransformer(Transformer):
 
     name = "DFS Transformer"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, index="index", random_seed=0, **kwargs):
         parameters = {"index": index}

--- a/evalml/pipelines/components/transformers/preprocessing/lsa.py
+++ b/evalml/pipelines/components/transformers/preprocessing/lsa.py
@@ -18,6 +18,7 @@ class LSA(TextTransformer):
 
     name = "LSA Transformer"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, random_seed=0, **kwargs):
         self._lsa_pipeline = make_pipeline(

--- a/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
+++ b/evalml/pipelines/components/transformers/preprocessing/polynomial_detrender.py
@@ -17,8 +17,8 @@ class PolynomialDetrender(TargetTransformer):
     """
 
     name = "Polynomial Detrender"
-
     hyperparameter_ranges = {"degree": Integer(1, 3)}
+    _supported_by_list_API = False
 
     def __init__(self, degree=1, random_seed=0, **kwargs):
         if not isinstance(degree, int):

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -19,6 +19,7 @@ class TextFeaturizer(TextTransformer):
 
     name = "Text Featurization Component"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, random_seed=0, **kwargs):
         self._trans = [

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -16,6 +16,8 @@ class BaseSampler(Transformer):
         random_seed (int): Seed for the random number generator. Defaults to 0.
     """
 
+    _supported_by_list_API = False
+
     def fit(self, X, y):
         """Resample the data using the sampler. Since our sampler doesn't need to be fit, we do nothing here.
 

--- a/evalml/pipelines/components/transformers/scalers/standard_scaler.py
+++ b/evalml/pipelines/components/transformers/scalers/standard_scaler.py
@@ -19,6 +19,7 @@ class StandardScaler(Transformer):
 
     name = "Standard Scaler"
     hyperparameter_ranges = {}
+    _supported_by_list_API = True
 
     def __init__(self, random_seed=0, **kwargs):
         parameters = {}

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -68,6 +68,12 @@ from evalml.pipelines.components.ensemble import (
     StackedEnsembleClassifier,
     StackedEnsembleRegressor,
 )
+from evalml.pipelines.components.transformers.samplers.base_sampler import (
+    BaseSampler,
+)
+from evalml.pipelines.components.transformers.transformer import (
+    TargetTransformer,
+)
 from evalml.pipelines.components.utils import (
     _all_estimators,
     _all_transformers,
@@ -1628,3 +1634,15 @@ def test_estimator_fit_respects_custom_indices(
     estimator.fit(X, y)
     pd.testing.assert_index_equal(X.index, X_original_index)
     pd.testing.assert_index_equal(y.index, y_original_index)
+
+
+def test_component_parameters_supported_by_list_API():
+    for component_class in all_components():
+        if (
+            issubclass(component_class, BaseSampler)
+            or issubclass(component_class, TargetTransformer)
+            or component_class in [TargetImputer]
+        ):
+            assert not component_class._supported_by_list_API
+        else:
+            assert component_class._supported_by_list_API

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ category_encoders>=2.2.2
 statsmodels >= 0.12.2
 imbalanced-learn>=0.8.0
 pmdarima==1.8.0
-sktime>=0.5.3;python_version<"3.9"
+sktime>=0.5.3,<0.7.0;python_version<"3.9"


### PR DESCRIPTION
Closes #2494 

Adds a private variable to be used in deprecating our list API for complex pipelines. I chose to be more restrictive by setting  `_supported_by_list_API = False` as the default and requiring components to override this. This is so when we add new components such as the LogTransformer (where `_supported_by_list_API` should be set to False), there is not a chance of accidentally forgetting to set the value.

On the other hand, this means for other components where ``_supported_by_list_API` should be True and we forget to set it, we have a bug of being too restrictive.

I like this behavior better than setting the default to True and then accidentally enabling some components where `_supported_by_list_API` should have been set to False to run with undefined / inaccurate behavior, but open to discussion of course 😁 

--
Alternatively: Do all `_supported_by_list_API = False` components also happen to be components that could potentially modify the target? Would it be safe and more descriptive to call the attribute `modifies_target`?
