### PR TITLE
Remove shellcheck from build_conda_pkg

### DIFF
--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
+    paths:
+      - 'requirements.txt'
+      - 'core-requirements.txt'
+      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   build_conda_pkg:

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -6,24 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - 'requirements.txt'
-      - 'core-requirements.txt'
-      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Shellcheck
-        uses: reviewdog/action-shellcheck@v1
-        with:
-          python-version: '3.8.x'
   build_conda_pkg:
     runs-on: ubuntu-latest
-    needs: shellcheck
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Release Notes
         * Moved docstrings from ``__init__`` to class pages, added missing docstrings for missing classes, and updated missing default values :pr:`2452`
     * Testing Changes
         * Fixed flaky dask tests :pr:`2471`
+        * Removed shellcheck action from ``build_conda_pkg`` action :pr:`2514`
 
 .. warning::
 


### PR DESCRIPTION
### Pull Request Description
Fixes #2400 

The minimum dependency tests were not running `shellcheck` - it was `build_conda_pkg` that was reporting the results of `shellcheck` along the minimum dependency tests. See this pr https://github.com/alteryx/evalml/pull/2488/checks that doesn't run `build_conda_pkg` and `shellcheck` does not show up anywhere.

I think we should remove shellcheck. The first commit ran `build_conda_pkg` without shellcheck and it passed.


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
