### PR TITLE
Change autoapi_ignore to fix rtd

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ extensions = [
 ]
 
 autoapi_dirs = ['../../evalml']
-autoapi_ignore = ["*test*"]
+autoapi_ignore = ["*/evalml/tests/*"]
 autoapi_options = ['members', 'undoc-members', 'show-module-summary', 'imported-members', 'inherited-members']
 autoapi_add_toctree_entry = False
 autoapi_template_dir = "_auto_api_templates"

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,6 +24,7 @@ Release Notes
     * Documentation Changes
         * Moved docstrings from ``__init__`` to class pages, added missing docstrings for missing classes, and updated missing default values :pr:`2452`
         * Build documentation with sphinx-autoapi :pr:`2458`
+        * Change ``autoapi_ignore`` to only ignore files in ``evalml/tests/*`` :pr:`2530` 
     * Testing Changes
         * Fixed flaky dask tests :pr:`2471`
         * Removed shellcheck action from ``build_conda_pkg`` action :pr:`2514`


### PR DESCRIPTION
### Pull Request Description

Currently, RTD `latest` is breaking - https://readthedocs.com/projects/feature-labs-inc-evalml/builds/681063/

The problem is that I told autoapi to ignore test files with `*test*` but the problem is that RTD checks our code into a directory called `latest` so `*test*` ignores everything 🙈 

I changed it so that only files in `evalml/tests` are ignored now. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
