### PR TITLE
v0.29.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.29.0 Jul. 21, 2021**
+    * Enhancements
         * Updated 1-way partial dependence support for datetime features :pr:`2454`
         * Added details on how to fix error caused by broken ww schema :pr:`2466`
         * Added ability to use built-in pickle for saving AutoMLSearch :pr:`2463`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
 
 setup(
     name='evalml',
-    version='0.28.0',
+    version='0.29.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.29.0 Jul. 21, 2021
### Enhancements
- Updated 1-way partial dependence support for datetime features #2454
- Added details on how to fix error caused by broken ww schema #2466
- Added ability to use built-in pickle for saving AutoMLSearch #2463
- Updated our components and component graphs to use latest features of ww 0.4.1, e.g. ``concat_columns`` and drop in-place. #2465
- Added new, concurrent.futures based engine for parallel AutoML #2506
- Added support for new Woodwork ``Unknown`` type in AutoMLSearch #2477
- Updated our components with an attribute that describes if they modify features or targets and can be used in list API for pipeline initialization #2504
- Updated ``ComponentGraph`` to accept X and y as inputs #2507
- Removed unused ``TARGET_BINARY_INVALID_VALUES`` from ``DataCheckMessageCode`` enum and fixed formatting of objective documentation #2520
### Fixes
- Fixed ``FraudCost`` objective and reverted threshold optimization method for binary classification to ``Golden`` #2450
- Added custom exception message for partial dependence on features with scales that are too small #2455
- Ensures the typing for Ordinal and Datetime ltypes are passed through _retain_custom_types_and_initalize_woodwork #2461
- Updated to work with Pandas 1.3.0 #2442
- Updated to work with sktime 0.7.0 #2499
### Changes
- Updated XGBoost dependency to ``>=1.4.2`` #2484, #2498
- Added a ``DeprecationWarning`` about deprecating the list API for ``ComponentGraph`` #2488
- Updated ``make_pipeline`` for AutoML to create dictionaries, not lists, to initialize pipelines #2504
- No longer installing graphviz on windows in our CI pipelines because release 0.17 breaks windows 3.7 #2516
### Documentation Changes
- Moved docstrings from ``__init__`` to class pages, added missing docstrings for missing classes, and updated missing default values #2452
- Build documentation with sphinx-autoapi #2458
- Change ``autoapi_ignore`` to only ignore files in ``evalml/tests/*`` #2530 
### Testing Changes
- Fixed flaky dask tests #2471
- Removed shellcheck action from ``build_conda_pkg`` action #2514
- Added a tmp_dir fixture that deletes its contents after tests run #2505
- Added a test that makes sure all pipelines in ``AutoMLSearch`` get the same data splits #2513
- Condensed warning output in test logs #2521
### Breaking Changes
- `NaN` values in the `Natural Language` type are no longer supported by the Imputer with the pandas upgrade. #2477