### PR TITLE
Rename `ComponentGraph`'s `get_parents` to `get_inputs`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
 .. warning::
 
     **Breaking Changes**
+        * Renamed ``ComponentGraph``'s ``get_parents`` to ``get_inputs`` :pr:`2540`
 
 
 **v0.29.0 Jul. 21, 2021**

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Renamed ``ComponentGraph``'s ``get_parents`` to ``get_inputs`` :pr:`2540`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -253,7 +253,7 @@ class ComponentGraph:
 
         parent_inputs = [
             parent_input
-            for parent_input in self.get_parents(self.compute_order[-1])
+            for parent_input in self.get_inputs(self.compute_order[-1])
             if parent_input[-2:] != ".y"
         ]
         for parent in parent_inputs:
@@ -320,7 +320,7 @@ class ComponentGraph:
             x_inputs = []
             y_input = None
 
-            for parent_input in self.get_parents(component_name):
+            for parent_input in self.get_inputs(component_name):
                 if parent_input[-2:] == ".y" or parent_input == "y":
                     if y_input is not None:
                         raise ValueError(
@@ -499,14 +499,14 @@ class ComponentGraph:
             if isinstance(component_class, Estimator)
         ]
 
-    def get_parents(self, component_name):
-        """Finds all of the inputs for a given component, including the names of all parent nodes of the given component
+    def get_inputs(self, component_name):
+        """Retrieves all inputs for a given component.
 
         Arguments:
-            component_name (str): Name of the child component to look up
+            component_name (str): Name of the component to look up.
 
         Returns:
-            list[str]: List of inputs to use
+            list[str]: List of inputs to for the component.
         """
         try:
             component_info = self.component_dict[component_name]
@@ -663,7 +663,7 @@ class ComponentGraph:
 
     def _get_parent_y(self, component_name):
         """Helper for inverse_transform method."""
-        parents = self.get_parents(component_name)
+        parents = self.get_inputs(component_name)
         return next(iter(p[:-2] for p in parents if ".y" in p), None)
 
     def inverse_transform(self, y):

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -506,7 +506,7 @@ class ComponentGraph:
             component_name (str): Name of the component to look up.
 
         Returns:
-            list[str]: List of inputs to for the component.
+            list[str]: List of inputs for the component to use.
         """
         try:
             component_info = self.component_dict[component_name]

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -443,32 +443,32 @@ def test_parents(example_graph):
     graph = example_graph
     component_graph = ComponentGraph(graph)
 
-    assert component_graph.get_parents("Imputer") == []
-    assert component_graph.get_parents("OneHot_RandomForest") == ["Imputer.x"]
-    assert component_graph.get_parents("OneHot_ElasticNet") == ["Imputer.x"]
-    assert component_graph.get_parents("Random Forest") == ["OneHot_RandomForest.x"]
-    assert component_graph.get_parents("Elastic Net") == ["OneHot_ElasticNet.x"]
-    assert component_graph.get_parents("Logistic Regression") == [
+    assert component_graph.get_inputs("Imputer") == []
+    assert component_graph.get_inputs("OneHot_RandomForest") == ["Imputer.x"]
+    assert component_graph.get_inputs("OneHot_ElasticNet") == ["Imputer.x"]
+    assert component_graph.get_inputs("Random Forest") == ["OneHot_RandomForest.x"]
+    assert component_graph.get_inputs("Elastic Net") == ["OneHot_ElasticNet.x"]
+    assert component_graph.get_inputs("Logistic Regression") == [
         "Random Forest",
         "Elastic Net",
     ]
 
     with pytest.raises(ValueError, match="not in the graph"):
-        component_graph.get_parents("Fake component")
+        component_graph.get_inputs("Fake component")
 
     component_graph.instantiate({})
-    assert component_graph.get_parents("Imputer") == []
-    assert component_graph.get_parents("OneHot_RandomForest") == ["Imputer.x"]
-    assert component_graph.get_parents("OneHot_ElasticNet") == ["Imputer.x"]
-    assert component_graph.get_parents("Random Forest") == ["OneHot_RandomForest.x"]
-    assert component_graph.get_parents("Elastic Net") == ["OneHot_ElasticNet.x"]
-    assert component_graph.get_parents("Logistic Regression") == [
+    assert component_graph.get_inputs("Imputer") == []
+    assert component_graph.get_inputs("OneHot_RandomForest") == ["Imputer.x"]
+    assert component_graph.get_inputs("OneHot_ElasticNet") == ["Imputer.x"]
+    assert component_graph.get_inputs("Random Forest") == ["OneHot_RandomForest.x"]
+    assert component_graph.get_inputs("Elastic Net") == ["OneHot_ElasticNet.x"]
+    assert component_graph.get_inputs("Logistic Regression") == [
         "Random Forest",
         "Elastic Net",
     ]
 
     with pytest.raises(ValueError, match="not in the graph"):
-        component_graph.get_parents("Fake component")
+        component_graph.get_inputs("Fake component")
 
 
 def test_get_last_component(example_graph):
@@ -1423,18 +1423,18 @@ def test_component_graph_sampler():
 
     component_graph = ComponentGraph(graph)
     component_graph.instantiate({})
-    assert component_graph.get_parents("Imputer") == []
-    assert component_graph.get_parents("OneHot") == ["Imputer.x"]
-    assert component_graph.get_parents("Undersampler") == ["OneHot.x"]
-    assert component_graph.get_parents("Random Forest") == [
+    assert component_graph.get_inputs("Imputer") == []
+    assert component_graph.get_inputs("OneHot") == ["Imputer.x"]
+    assert component_graph.get_inputs("Undersampler") == ["OneHot.x"]
+    assert component_graph.get_inputs("Random Forest") == [
         "Undersampler.x",
         "Undersampler.y",
     ]
-    assert component_graph.get_parents("Elastic Net") == [
+    assert component_graph.get_inputs("Elastic Net") == [
         "Undersampler.x",
         "Undersampler.y",
     ]
-    assert component_graph.get_parents("Logistic Regression") == [
+    assert component_graph.get_inputs("Logistic Regression") == [
         "Random Forest",
         "Elastic Net",
     ]
@@ -1469,10 +1469,10 @@ def test_component_graph_sampler_list():
             "Undersampler.y",
         ],
     }
-    assert component_graph.get_parents("Imputer") == []
-    assert component_graph.get_parents("One Hot Encoder") == ["Imputer.x"]
-    assert component_graph.get_parents("Undersampler") == ["One Hot Encoder.x"]
-    assert component_graph.get_parents("Random Forest Classifier") == [
+    assert component_graph.get_inputs("Imputer") == []
+    assert component_graph.get_inputs("One Hot Encoder") == ["Imputer.x"]
+    assert component_graph.get_inputs("Undersampler") == ["One Hot Encoder.x"]
+    assert component_graph.get_inputs("Random Forest Classifier") == [
         "Undersampler.x",
         "Undersampler.y",
     ]
@@ -1501,16 +1501,16 @@ def test_component_graph_dataset_with_target_imputer():
 
     component_graph = ComponentGraph(graph)
     component_graph.instantiate({})
-    assert component_graph.get_parents("Target Imputer") == []
-    assert component_graph.get_parents("OneHot") == [
+    assert component_graph.get_inputs("Target Imputer") == []
+    assert component_graph.get_inputs("OneHot") == [
         "Target Imputer.x",
         "Target Imputer.y",
     ]
-    assert component_graph.get_parents("Random Forest") == [
+    assert component_graph.get_inputs("Random Forest") == [
         "OneHot.x",
         "Target Imputer.y",
     ]
-    assert component_graph.get_parents("Elastic Net") == [
+    assert component_graph.get_inputs("Elastic Net") == [
         "OneHot.x",
         "Target Imputer.y",
     ]
@@ -2100,8 +2100,8 @@ def test_component_graph_with_X_y_inputs_X(mock_fit):
     component_graph = ComponentGraph(graph)
     component_graph.instantiate({})
     mock_fit.return_value = X
-    assert component_graph.get_parents("DummyColumnNameTransformer") == ["X", "y"]
-    assert component_graph.get_parents("Imputer") == [
+    assert component_graph.get_inputs("DummyColumnNameTransformer") == ["X", "y"]
+    assert component_graph.get_inputs("Imputer") == [
         "DummyColumnNameTransformer.x",
         "X",
         "y",
@@ -2136,9 +2136,9 @@ def test_component_graph_with_X_y_inputs_y(mock_fit, mock_fit_transform):
     mock_fit_transform.return_value = X
     component_graph = ComponentGraph(graph)
     component_graph.instantiate({})
-    assert component_graph.get_parents("Log") == ["X", "y"]
-    assert component_graph.get_parents("Imputer") == ["Log.x", "y"]
-    assert component_graph.get_parents("Random Forest") == ["Imputer.x", "Log.y"]
+    assert component_graph.get_inputs("Log") == ["X", "y"]
+    assert component_graph.get_inputs("Imputer") == ["Log.x", "y"]
+    assert component_graph.get_inputs("Random Forest") == ["Imputer.x", "Log.y"]
 
     component_graph.fit(X, y)
     # Check that we use "y" for Imputer, not "Log.y"


### PR DESCRIPTION
Breaking up #2490 into smaller and cleaner PRs :)

This PR renames `ComponentGraph`'s `get_parents` to `get_inputs`; I think this is a little more descriptive of what the method does, especially now that we are requiring .x/.y to be explicitly stated.