### PR TITLE
Warn users when pipeline parameters aren't used when initializing pipelines

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
+        * Issue a warning to users when a pipeline parameter passed in isn't used in the pipeline :pr:``
     * Fixes
     * Changes
         * Removed ``ComponentGraph.from_list`` and update PipelineBase implementation for creating pipelines from a list of components :pr:`2549`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,7 +2,7 @@ Release Notes
 -------------
 **Future Release**
     * Enhancements
-        * Issue a warning to users when a pipeline parameter passed in isn't used in the pipeline :pr:``
+        * Issue a warning to users when a pipeline parameter passed in isn't used in the pipeline :pr:`2564`
     * Fixes
     * Changes
         * Removed ``ComponentGraph.from_list`` and update PipelineBase implementation for creating pipelines from a list of components :pr:`2549`

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -12,4 +12,5 @@ from .exceptions import (
     NullsInColumnWarning,
     ObjectiveCreationError,
     NoPositiveLabelException,
+    ParameterNotUsedWarning,
 )

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -90,6 +90,8 @@ class NoPositiveLabelException(Exception):
 
 
 class ParameterNotUsedWarning(UserWarning):
+    """Warning thrown when a pipeline parameter isn't used in a defined pipeline's component graph during initialization."""
+
     def __init__(self, components):
         self.components = components
 

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -87,3 +87,11 @@ class ObjectiveCreationError(Exception):
 
 class NoPositiveLabelException(Exception):
     """Exception when a particular classification label for the 'positive' class cannot be found in the column index or unique values"""
+
+
+class ParameterNotUsedWarning(UserWarning):
+    def __init__(self, components):
+        self.components = components
+
+        msg = f"Parameters for components {components} will not be used to instantiate the pipeline since they don't appear in the pipeline"
+        super().__init__(msg)

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -1,3 +1,5 @@
+import warnings
+
 import networkx as nx
 import pandas as pd
 import woodwork as ww

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -6,7 +6,10 @@ import woodwork as ww
 from networkx.algorithms.dag import topological_sort
 from networkx.exception import NetworkXUnfeasible
 
-from evalml.exceptions.exceptions import MissingComponentError
+from evalml.exceptions.exceptions import (
+    MissingComponentError,
+    ParameterNotUsedWarning,
+)
 from evalml.pipelines.components import ComponentBase, Estimator, Transformer
 from evalml.pipelines.components.transformers.transformer import (
     TargetTransformer,
@@ -84,12 +87,7 @@ class ComponentGraph:
         param_set = set(s for s in parameters.keys() if s not in ["pipeline"])
         diff = param_set.difference(set(self.component_instances.keys()))
         if len(diff):
-            warnings.warn(
-                "Parameters for components {} will not be used to instantiate the pipeline since they don't appear in the pipeline".format(
-                    diff
-                ),
-                UserWarning,
-            )
+            warnings.warn(ParameterNotUsedWarning(diff))
         self._is_instantiated = True
         component_instances = {}
         for component_name, component_class in self.component_instances.items():

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -176,8 +176,16 @@ class ComponentGraph:
             raise ValueError(
                 f"Cannot reinstantiate a component graph that was previously instantiated"
             )
-
         parameters = parameters or {}
+        param_set = set(s for s in parameters.keys() if s not in ["pipeline"])
+        diff = param_set.difference(set(self.component_instances.keys()))
+        if len(diff):
+            warnings.warn(
+                "Parameters for components {} will not be used to instantiate the pipeline since they don't appear in the pipeline".format(
+                    diff
+                ),
+                UserWarning,
+            )
         self._is_instantiated = True
         component_instances = {}
         for component_name, component_class in self.component_instances.items():

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -28,6 +28,7 @@ from evalml.automl.utils import (
 )
 from evalml.exceptions import (
     AutoMLSearchException,
+    ParameterNotUsedWarning,
     PipelineNotFoundError,
     PipelineNotYetFittedError,
     PipelineScoreError,
@@ -4939,7 +4940,7 @@ def test_pipeline_parameter_warnings_component_graphs(
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings(
             "always",
-            message="Parameters for components {} will not be used".format(set_values),
+            category=ParameterNotUsedWarning,
         )
         automl = AutoMLSearch(
             X_train=X,
@@ -4954,3 +4955,5 @@ def test_pipeline_parameter_warnings_component_graphs(
         with env.test_context(score_return_value={automl.objective.name: 1.0}):
             automl.search()
     assert len(w) == (1 if len(set_values) else 0)
+    if len(w):
+        assert w[0].message.components == set_values

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -4898,3 +4898,58 @@ def test_data_splitter_gives_pipelines_same_data(
         assert all(
             len(data_hash_dictionary[i]) == 1 for i in range(n_splits)
         ), "There should only be one hash per split."
+
+
+@pytest.mark.parametrize(
+    "allowed_component_graphs",
+    [None, {"graph": ["Imputer", "Logistic Regression Classifier"]}],
+)
+@pytest.mark.parametrize(
+    "pipeline_parameters,set_values",
+    [
+        ({"Logistic Regression Classifier": {"penalty": "l1"}}, {}),
+        (
+            {
+                "Imputer": {"numeric_impute_strategy": "mean"},
+                "Logistic Regression Classifier": {"penalty": "l1"},
+            },
+            {},
+        ),
+        (
+            {
+                "Undersampler": {"sampling_ratio": 0.05},
+                "Logistic Regression Classifier": {"penalty": "l1"},
+            },
+            {"Undersampler"},
+        ),
+        (
+            {
+                "Undersampler": {"sampling_ratio": 0.05},
+                "SMOTE Oversampler": {"sampling_ratio": 0.10},
+            },
+            {"Undersampler", "SMOTE Oversampler"},
+        ),
+    ],
+)
+def test_pipeline_parameter_warnings_component_graphs(
+    pipeline_parameters, set_values, allowed_component_graphs, AutoMLTestEnv, X_y_binary
+):
+    X, y = X_y_binary
+    with warnings.catch_warnings(record=True) as w:
+        warnings.filterwarnings(
+            "always",
+            message="Parameters for components {} will not be used".format(set_values),
+        )
+        automl = AutoMLSearch(
+            X_train=X,
+            y_train=y,
+            problem_type="binary",
+            max_batches=2,
+            n_jobs=1,
+            allowed_component_graphs=allowed_component_graphs,
+            pipeline_parameters=pipeline_parameters,
+        )
+        env = AutoMLTestEnv("binary")
+        with env.test_context(score_return_value={automl.objective.name: 1.0}):
+            automl.search()
+    assert len(w) == (1 if len(set_values) else 0)

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -9,7 +9,7 @@ from sklearn.model_selection import StratifiedKFold
 from evalml import AutoMLSearch
 from evalml.automl.callbacks import raise_error_callback
 from evalml.automl.pipeline_search_plots import SearchIterationPlot
-from evalml.exceptions import PipelineNotFoundError
+from evalml.exceptions import ParameterNotUsedWarning, PipelineNotFoundError
 from evalml.model_family import ModelFamily
 from evalml.objectives import (
     FraudCost,
@@ -1543,9 +1543,8 @@ def test_time_series_pipeline_parameter_warnings(
         "delay_target": False,
         "delay_features": True,
     }
-    message = "Parameters for components {} will not be used".format(set_values)
     with warnings.catch_warnings(record=True) as w:
-        warnings.filterwarnings("always", message)
+        warnings.filterwarnings("always", category=ParameterNotUsedWarning)
         automl = AutoMLSearch(
             X_train=X,
             y_train=y,
@@ -1561,4 +1560,4 @@ def test_time_series_pipeline_parameter_warnings(
     # We throw a warning about time series being in beta
     assert len(w) == (2 if len(set_values) else 1)
     if len(w) == 2:
-        assert message in str(w[1].message)
+        assert w[1].message.components == set_values

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -1532,7 +1532,7 @@ def test_automl_search_sampler_k_neighbors_no_error(
                 "Undersampler": {"sampling_ratio": 0.05},
                 "SMOTE Oversampler": {"sampling_ratio": 0.10},
             },
-            {"Undersampler", "SMOTE Oversampler"},
+            {"SMOTE Oversampler", "Undersampler"},
         ),
     ],
 )

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -1527,13 +1527,6 @@ def test_automl_search_sampler_k_neighbors_no_error(
             },
             {"Undersampler"},
         ),
-        (
-            {
-                "Undersampler": {"sampling_ratio": 0.05},
-                "SMOTE Oversampler": {"sampling_ratio": 0.10},
-            },
-            {"SMOTE Oversampler", "Undersampler"},
-        ),
     ],
 )
 def test_time_series_pipeline_parameter_warnings(

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -12,7 +12,7 @@ from pandas.testing import (
 )
 from woodwork.logical_types import Double, Integer
 
-from evalml.exceptions import MissingComponentError
+from evalml.exceptions import MissingComponentError, ParameterNotUsedWarning
 from evalml.pipelines import ComponentGraph
 from evalml.pipelines.components import (
     DateTimeFeaturizer,
@@ -1923,10 +1923,12 @@ def test_component_graph_instantiate_parameters(pipeline_parameters, set_values)
     with warnings.catch_warnings(record=True) as w:
         warnings.filterwarnings(
             "always",
-            message="Parameters for components {} will not be used".format(set_values),
+            category=ParameterNotUsedWarning,
         )
         component_graph.instantiate(pipeline_parameters)
     assert len(w) == (1 if len(set_values) else 0)
+    if len(w):
+        assert w[0].message.components == set_values
 
 
 def test_component_graph_repr():

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1888,6 +1888,7 @@ def test_component_graph_with_X_y_inputs_y(mock_fit, mock_fit_transform):
     "pipeline_parameters,set_values",
     [
         ({"Logistic Regression Classifier": {"penalty": "l1"}}, {}),
+        ({"Logistic Regression": {"penalty": "l1"}}, {"Logistic Regression"}),
         (
             {"Random Forest Classifier": {"n_estimators": 10}},
             {"Random Forest Classifier"},
@@ -1909,20 +1910,6 @@ def test_component_graph_with_X_y_inputs_y(mock_fit, mock_fit_transform):
     ],
 )
 def test_component_graph_instantiate_parameters(pipeline_parameters, set_values):
-    component_list = [
-        "Imputer",
-        "Standard Scaler",
-        "Logistic Regression Classifier",
-    ]
-    component_graph = ComponentGraph.from_list(component_list)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.filterwarnings(
-            "always",
-            message="Parameters for components {} will not be used".format(set_values),
-        )
-        component_graph.instantiate(pipeline_parameters)
-    assert len(w) == (1 if len(set_values) else 0)
-
     graph = {
         "Imputer": ["Imputer", "x", "y"],
         "Scaler": ["Standard Scaler", "Imputer.x", "y"],


### PR DESCRIPTION
fix #1839 

I opted to use warnings rather than raise errors since pipeline initialization occurs during AutoMLSearch as well. In the case where users pass in a valid `pipeline_param`, we don't want to error it out since we pass the entirety of `pipeline_parameters` to every pipeline we initialize. 
```python
automl = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', 
                      pipeline_parameters={"CatBoost Classifier": {'n_estimators': 20}}), max_batches=2)
```
It would also be too much logic to include in `AutoMLSearch` to filter out only the appropriate components we need from pipeline parameters into the pipelines we are initializing. (ie determining which components are necessary in which pipelines before `make_pipelines` so we can trim and pass the appropriate pipeline parameters)

In this scenario, we don't want to raise an error since that would prevent `AutoMLSearch` from happening. 

However, raising a warning allows the search to continue while also giving the user feedback on whether or not the component parameters are being used. 