### PR TITLE
Add repr to ComponentGraph and use in PipelineBase

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Release**
     * Enhancements
         * Added Gini coefficient as an objective :pr:`2544`
+        * Added ``repr`` to ``ComponentGraph`` :pr:`2565`
     * Fixes
     * Changes
         * Updated ``PipelineBase`` implementation for creating pipelines from a list of components :pr:`2549`

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -10,12 +10,7 @@ from evalml.pipelines.components.transformers.transformer import (
     TargetTransformer,
 )
 from evalml.pipelines.components.utils import handle_component_class
-from evalml.utils import (
-    get_logger,
-    import_or_raise,
-    infer_feature_types,
-    safe_repr,
-)
+from evalml.utils import get_logger, import_or_raise, infer_feature_types
 
 logger = get_logger(__file__)
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -20,7 +20,6 @@ from .components import (
 from .components.utils import all_components, handle_component_class
 
 from evalml.exceptions import ObjectiveCreationError, PipelineScoreError
-from evalml.exceptions.exceptions import MissingComponentError
 from evalml.objectives import get_objective
 from evalml.pipelines import ComponentGraph
 from evalml.pipelines.pipeline_meta import PipelineBaseMeta

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -588,33 +588,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
                 [f"'{key}': {safe_repr(value)}" for key, value in parameters.items()]
             )
 
-        component_strs = []
-        for (
-            component_name,
-            component_info,
-        ) in self.component_graph.component_dict.items():
-            try:
-                component_key = f"'{component_name}': "
-                if isinstance(component_info[0], str):
-                    component_class = handle_component_class(component_info[0])
-                else:
-                    component_class = handle_component_class(component_info[0].name)
-                component_name = f"'{component_class.name}'"
-            except MissingComponentError:
-                # Not an EvalML component, use component class name
-                component_name = f"{component_info[0].__name__}"
-
-            component_edges_str = ""
-            if len(component_info) > 1:
-                component_edges_str = ", "
-                component_edges_str += ", ".join(
-                    [f"'{info}'" for info in component_info[1:]]
-                )
-
-            component_str = f"{component_key}[{component_name}{component_edges_str}]"
-            component_strs.append(component_str)
-        component_dict_str = f"{{{', '.join(component_strs)}}}"
-
+        component_dict_str = repr(self.component_graph)
         parameters_repr = ", ".join(
             [
                 f"'{component}':{{{repr_component(parameters)}}}"

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1881,3 +1881,25 @@ def test_component_graph_with_X_y_inputs_y(mock_fit, mock_fit_transform):
     assert_series_equal(mock_fit_transform.call_args[0][1], y)
     # Check that we use "Log.y" for RF
     assert_series_equal(mock_fit.call_args[0][1], infer_feature_types(np.log(y)))
+
+
+def test_component_graph_repr():
+    # Test with component graph defined by strings
+    component_dict = {
+        "Imputer": ["Imputer", "X", "y"],
+        "OHE": ["One Hot Encoder", "Imputer.x", "y"],
+        "Random Forest Regressor": ["Random Forest Regressor", "OHE.x", "y"],
+    }
+    expected_repr = "{'Imputer': ['Imputer', 'X', 'y'], 'OHE': ['One Hot Encoder', 'Imputer.x', 'y'], 'Random Forest Regressor': ['Random Forest Regressor', 'OHE.x', 'y']}"
+    component_graph = ComponentGraph(component_dict)
+    assert repr(component_graph) == expected_repr
+
+    # Test with component graph defined by strings and objects
+    component_dict_with_objs = {
+        "Imputer": [Imputer, "X", "y"],
+        "OHE": [OneHotEncoder, "Imputer.x", "y"],
+        "Random Forest Classifier": [RandomForestClassifier, "OHE.x", "y"],
+    }
+    expected_repr = "{'Imputer': ['Imputer', 'X', 'y'], 'OHE': ['One Hot Encoder', 'Imputer.x', 'y'], 'Random Forest Classifier': ['Random Forest Classifier', 'OHE.x', 'y']}"
+    component_graph = ComponentGraph(component_dict_with_objs)
+    assert repr(component_graph) == expected_repr


### PR DESCRIPTION
Closes #2204 by adding `repr` to the ComponentGraph class and then cleaning up `PipelineBase`'s `repr` to reuse `ComponentGraph`'s `repr`.

On main:
![image](https://user-images.githubusercontent.com/5422235/127356843-cf12a792-aa15-4ef5-a2c6-d1bf69a4ac7e.png)


After this PR:
![image](https://user-images.githubusercontent.com/5422235/127356361-e8a5c8ab-5601-4614-a547-2587d00fbf84.png)
