### PR TITLE
Support for NaN types for NLP in AutoMLSearch

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Release Notes
         * Added support for `NaN` values in ``TextFeaturizer`` :pr:`2532`
         * Added ``SelectByType`` transformer :pr:`2531`
         * Added separate thresholds for percent null rows and columns in ``HighlyNullDataCheck`` :pr:`2562`
-        * Added support for `NaN` natural language values :pr:``
+        * Added support for `NaN` natural language values :pr:`2577`
     * Fixes
         * Raised error message for types ``URL``, ``NaturalLanguage``, and ``EmailAddress`` in ``partial_dependence`` :pr:`2573`
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Added support for `NaN` values in ``TextFeaturizer`` :pr:`2532`
         * Added ``SelectByType`` transformer :pr:`2531`
         * Added separate thresholds for percent null rows and columns in ``HighlyNullDataCheck`` :pr:`2562`
+        * Added support for `NaN` natural language values :pr:``
     * Fixes
     * Changes
         * Updated ``PipelineBase`` implementation for creating pipelines from a list of components :pr:`2549`

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -148,7 +148,6 @@ class LightGBMClassifier(Estimator):
         X_encoded = _rename_column_names_to_numeric(X)
         rename_cols_dict = dict(zip(X.columns, X_encoded.columns))
         cat_cols = [rename_cols_dict[col] for col in cat_cols]
-
         if len(cat_cols) == 0:
             return X_encoded
         if fit:

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -148,6 +148,7 @@ class LightGBMClassifier(Estimator):
         X_encoded = _rename_column_names_to_numeric(X)
         rename_cols_dict = dict(zip(X.columns, X_encoded.columns))
         cat_cols = [rename_cols_dict[col] for col in cat_cols]
+
         if len(cat_cols) == 0:
             return X_encoded
         if fit:

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -150,7 +150,9 @@ class TextFeaturizer(TextTransformer):
             for column, derived_features in lsa_features.items():
                 X_lsa.loc[nan_mask[column], derived_features] = None
         X_lsa.ww.init(logical_types={col: "Double" for col in X_lsa.columns})
-        X_nlp_primitives.ww.init(logical_types={col: "Double" for col in X_nlp_primitives.columns})
+        X_nlp_primitives.ww.init(
+            logical_types={col: "Double" for col in X_nlp_primitives.columns}
+        )
         X_ww = X_ww.ww.drop(self._text_columns)
         for col in X_nlp_primitives:
             X_ww.ww[col] = X_nlp_primitives[col]

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -2,7 +2,6 @@ import string
 
 import featuretools as ft
 import nlp_primitives
-import pandas as pd
 
 from evalml.pipelines.components.transformers.preprocessing import (
     LSA,
@@ -141,17 +140,17 @@ class TextFeaturizer(TextTransformer):
             {s: "NaturalLanguage" for s in self._text_columns},
         )
         X_lsa = self._lsa.transform(X_ww_altered)
+        X_nlp_primitives.set_index(X_ww.index, inplace=True)
         if any_nans:
             primitive_features = self._get_primitives_provenance(self._features)
             for column, derived_features in primitive_features.items():
-                X_nlp_primitives.loc[nan_mask[column], derived_features] = pd.NA
+                X_nlp_primitives.loc[nan_mask[column], derived_features] = None
 
             lsa_features = self._lsa._get_feature_provenance()
             for column, derived_features in lsa_features.items():
-                X_lsa.loc[nan_mask[column], derived_features] = pd.NA
-
-        X_nlp_primitives.set_index(X_ww.index, inplace=True)
-
+                X_lsa.loc[nan_mask[column], derived_features] = None
+        X_lsa = X_lsa.astype("float64")
+        X_nlp_primitives = X_nlp_primitives.astype("float64")
         X_ww = X_ww.ww.drop(self._text_columns)
         for col in X_nlp_primitives:
             X_ww.ww[col] = X_nlp_primitives[col]

--- a/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/text_featurizer.py
@@ -149,8 +149,8 @@ class TextFeaturizer(TextTransformer):
             lsa_features = self._lsa._get_feature_provenance()
             for column, derived_features in lsa_features.items():
                 X_lsa.loc[nan_mask[column], derived_features] = None
-        X_lsa = X_lsa.astype("float64")
-        X_nlp_primitives = X_nlp_primitives.astype("float64")
+        X_lsa.ww.init(logical_types={col: "Double" for col in X_lsa.columns})
+        X_nlp_primitives.ww.init(logical_types={col: "Double" for col in X_nlp_primitives.columns})
         X_ww = X_ww.ww.drop(self._text_columns)
         for col in X_nlp_primitives:
             X_ww.ww[col] = X_nlp_primitives[col]

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -4936,7 +4936,12 @@ def test_pipeline_parameter_warnings_component_graphs(
 
 
 @pytest.mark.parametrize("nans", [None, pd.NA, np.nan])
-def test_search_with_text_nans(nans):
+@patch("evalml.pipelines.components.Estimator.fit")
+@patch(
+    "evalml.pipelines.BinaryClassificationPipeline.score",
+    return_value={"Log Loss Binary": 0.5},
+)
+def test_search_with_text_nans(mock_score, mock_fit, nans):
     X = pd.DataFrame(
         {
             "a": [np.nan] + [i for i in range(99)],
@@ -4945,6 +4950,11 @@ def test_search_with_text_nans(nans):
     )
     X.ww.init(logical_types={"b": "NaturalLanguage"})
     y = pd.Series([0] * 25 + [1] * 75)
-
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", max_iterations=2)
+    automl = AutoMLSearch(
+        X_train=X, y_train=y, problem_type="binary", optimize_thresholds=False
+    )
     automl.search()
+    for (x, _), _ in mock_fit.call_args_list:
+        assert all(
+            [str(types) == "Double" for types in x.ww.types["Logical Type"].values]
+        )

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -4933,3 +4933,18 @@ def test_pipeline_parameter_warnings_component_graphs(
     assert len(w) == (1 if len(set_values) else 0)
     if len(w):
         assert w[0].message.components == set_values
+
+
+@pytest.mark.parametrize("nans", [None, pd.NA, np.nan])
+def test_search_with_text_nans(nans):
+    X = pd.DataFrame(
+        {
+            "a": [np.nan] + [i for i in range(99)],
+            "b": [np.nan] + [f"string {i} is valid" for i in range(99)],
+        }
+    )
+    X.ww.init(logical_types={"b": "NaturalLanguage"})
+    y = pd.Series([0] * 25 + [1] * 75)
+
+    automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", max_iterations=2)
+    automl.search()

--- a/evalml/tests/component_tests/test_text_featurizer.py
+++ b/evalml/tests/component_tests/test_text_featurizer.py
@@ -536,4 +536,4 @@ def test_multiple_nan_allowed(nones):
     # these columns should not have any null values
     assert not X_t[cols].iloc[:3, :].isnull().any().any()
     assert not X_t[X_t.columns.difference(cols)].isnull().any().any()
-    assert all([types == "float64" for types in X_t[cols].dtypes])
+    assert all([pd.api.types.is_numeric_dtype(types) for types in X_t[cols].dtypes])

--- a/evalml/tests/component_tests/test_text_featurizer.py
+++ b/evalml/tests/component_tests/test_text_featurizer.py
@@ -536,3 +536,4 @@ def test_multiple_nan_allowed(nones):
     # these columns should not have any null values
     assert not X_t[cols].iloc[:3, :].isnull().any().any()
     assert not X_t[X_t.columns.difference(cols)].isnull().any().any()
+    assert all([types == "float64" for types in X_t[cols].dtypes])


### PR DESCRIPTION
close #2515 

Added some support to make sure missing natural language types are supported in `AutoMLSearch`. We change `pd.NA` to `None` to ensure we can preserve the `float64` type that we expect from the text featurizer.