### PR TITLE
Install prophet during linux nightlies

### DIFF
--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -3,8 +3,6 @@ name: Nightly unit tests, linux
 on:
   schedule:
       - cron: '0 7 * * *'
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   unit_tests:
@@ -24,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: install-prophet-linux-nightlies
+          ref: main
       - name: Update apt and install Graphviz
         run: sudo apt update && sudo apt install -y graphviz
       - name: Create virtual environment, upgrade pip

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: main
+          ref: install-prophet-linux-nightlies
       - name: Update apt and install Graphviz
         run: sudo apt update && sudo apt install -y graphviz
       - name: Create virtual environment, upgrade pip

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -3,6 +3,8 @@ name: Nightly unit tests, linux
 on:
   schedule:
       - cron: '0 7 * * *'
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   unit_tests:
@@ -31,8 +33,21 @@ jobs:
           virtualenv test_python -q
           source test_python/bin/activate
           python -m pip install --upgrade pip -q
-      - name: Installing Latest Dependency Versions
+      - if: ${{ (matrix.command == 'git-test-automl' || matrix.command == 'git-test-other') }}
+        name: Installing Latest Dependencies and Prophet
         run: |
+          pip install virtualenv
+          virtualenv test_python -q
+          source test_python/bin/activate
+          pip install cmdstan-builder==0.0.4
+          make installdeps
+          make installdeps-test
+          pip freeze
+      - if: ${{ (matrix.command == 'git-test-modelunderstanding' || matrix.command == 'git-test-dask') }}
+        name: Installing Latest Dependencies
+        run: |
+          pip install virtualenv
+          virtualenv test_python -q
           source test_python/bin/activate
           make installdeps
           make installdeps-test

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Documentation Changes
     * Testing Changes
         * Changed the lint CI job to only check against python 3.9 via the `-t` flag :pr:`2586`
+        * Installed Prophet in linux nightlies test and fixed ``test_all_components`` :pr:`2598`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -35,8 +35,12 @@ def test_all_components(
         n_components = 41
     elif is_using_conda:
         n_components = 52
-    elif is_running_py_39_or_above or is_using_windows:
+    elif is_using_windows and not is_running_py_39_or_above:
         n_components = 53
+    elif is_using_windows and is_running_py_39_or_above:
+        n_components = 51
+    elif not is_using_windows and is_running_py_39_or_above:
+        n_components = 52
     else:
         n_components = 54
     assert len(all_components()) == n_components

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -31,15 +31,23 @@ def test_all_components(
     is_using_conda,
     is_using_windows,
 ):
+    # The total number of minimal components is 41
+    # The total number of components is 54
+    # Depending on the environment the detrender/Arima and/or Prophet will not be installed
+
     if has_minimal_dependencies:
         n_components = 41
     elif is_using_conda:
+        # No prophet and no arima
         n_components = 52
     elif is_using_windows and not is_running_py_39_or_above:
+        # No prophet
         n_components = 53
     elif is_using_windows and is_running_py_39_or_above:
+        # No detrender, no arima, no prophet
         n_components = 51
     elif not is_using_windows and is_running_py_39_or_above:
+        # No detrender or arima
         n_components = 52
     else:
         n_components = 54


### PR DESCRIPTION
### Pull Request Description

Fixes nightlies by installing prophet . They originally failed because `test_all_components` was expecting Prophet to be installed but it was missing from the build script. 

You can see the nightlies passing here: https://github.com/alteryx/evalml/actions/runs/1102244065

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
