### PR TITLE
Update ComponentGraph `_validate_component_dict` logic

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,8 @@ Release Notes
 **Future Release**
     * Enhancements
         * Added ``ProphetRegressor`` to estimators :pr:`2242`
+        * Updated ``ComponentGraph`` ``_validate_component_dict`` logic to be stricter about input values :pr:`2599`
+
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -74,14 +74,22 @@ class ComponentGraph:
                     "All components must have exactly one target (.y/y) edge."
                 )
 
-            def f(i):
+            def check_all_inputs_have_correct_syntax(edge):
                 return not (
-                    i.endswith(".y") or i == "y" or i.endswith(".x") or i == "X"
+                    edge.endswith(".y")
+                    or edge == "y"
+                    or edge.endswith(".x")
+                    or edge == "X"
                 )
 
-            if len(list(filter(f, component_inputs))) != 0:
+            if (
+                len(
+                    list(filter(check_all_inputs_have_correct_syntax, component_inputs))
+                )
+                != 0
+            ):
                 raise ValueError(
-                    "All edges must be specified as either an input feature (.x) or input target (.y)."
+                    "All edges must be specified as either an input feature ('X'/.x) or input target ('y'/.y)."
                 )
 
     @property

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -61,11 +61,25 @@ class ComponentGraph:
                 component_input.endswith(".x") or component_input == "X"
                 for component_input in component_inputs
             )
-            has_target_input = any(
+            has_one_target_input = sum(
                 component_input.endswith(".y") or component_input == "y"
                 for component_input in component_inputs
             )
-            if not (has_feature_input and has_target_input):
+            if not has_feature_input:
+                raise ValueError(
+                    "All components must have at least one input feature (.x/X) edge."
+                )
+            if has_one_target_input != 1:
+                raise ValueError(
+                    "All components must have exactly one target (.y/y) edge."
+                )
+
+            def f(i):
+                return not (
+                    i.endswith(".y") or i == "y" or i.endswith(".x") or i == "X"
+                )
+
+            if len(list(filter(f, component_inputs))) != 0:
                 raise ValueError(
                     "All edges must be specified as either an input feature (.x) or input target (.y)."
                 )

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -61,7 +61,7 @@ class ComponentGraph:
                 component_input.endswith(".x") or component_input == "X"
                 for component_input in component_inputs
             )
-            has_one_target_input = sum(
+            num_target_inputs = sum(
                 component_input.endswith(".y") or component_input == "y"
                 for component_input in component_inputs
             )
@@ -69,7 +69,7 @@ class ComponentGraph:
                 raise ValueError(
                     "All components must have at least one input feature (.x/X) edge."
                 )
-            if has_one_target_input != 1:
+            if num_target_inputs != 1:
                 raise ValueError(
                     "All components must have exactly one target (.y/y) edge."
                 )

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -666,12 +666,12 @@ def test_computation_input_custom_index(index, example_graph):
 @patch(f"{__name__}.TransformerB.transform")
 @patch(f"{__name__}.TransformerA.transform")
 def test_component_graph_evaluation_plumbing(
-    mock_transa,
-    mock_transb,
-    mock_transc,
-    mock_preda,
-    mock_predb,
-    mock_predc,
+    mock_transform_a,
+    mock_transform_b,
+    mock_transform_c,
+    mock_predict_a,
+    mock_predict_b,
+    mock_predict_c,
     dummy_components,
 ):
     (
@@ -682,14 +682,14 @@ def test_component_graph_evaluation_plumbing(
         EstimatorB,
         EstimatorC,
     ) = dummy_components
-    mock_transa.return_value = pd.DataFrame(
+    mock_transform_a.return_value = pd.DataFrame(
         {"feature trans": [1, 0, 0, 0, 0, 0], "feature a": np.ones(6)}
     )
-    mock_transb.return_value = pd.DataFrame({"feature b": np.ones(6) * 2})
-    mock_transc.return_value = pd.DataFrame({"feature c": np.ones(6) * 3})
-    mock_preda.return_value = pd.Series([0, 0, 0, 1, 0, 0])
-    mock_predb.return_value = pd.Series([0, 0, 0, 0, 1, 0])
-    mock_predc.return_value = pd.Series([0, 0, 0, 0, 0, 1])
+    mock_transform_b.return_value = pd.DataFrame({"feature b": np.ones(6) * 2})
+    mock_transform_c.return_value = pd.DataFrame({"feature c": np.ones(6) * 3})
+    mock_predict_a.return_value = pd.Series([0, 0, 0, 1, 0, 0])
+    mock_predict_b.return_value = pd.Series([0, 0, 0, 0, 1, 0])
+    mock_predict_c.return_value = pd.Series([0, 0, 0, 0, 0, 1])
     graph = {
         "transformer a": [TransformerA, "X", "y"],
         "transformer b": [TransformerB, "transformer a.x", "y"],
@@ -713,9 +713,9 @@ def test_component_graph_evaluation_plumbing(
     component_graph.fit(X, y)
     predict_out = component_graph.predict(X)
 
-    assert_frame_equal(mock_transa.call_args[0][0], X)
+    assert_frame_equal(mock_transform_a.call_args[0][0], X)
     assert_frame_equal(
-        mock_transb.call_args[0][0],
+        mock_transform_b.call_args[0][0],
         pd.DataFrame(
             {
                 "feature trans": pd.Series([1, 0, 0, 0, 0, 0], dtype="int64"),
@@ -725,7 +725,7 @@ def test_component_graph_evaluation_plumbing(
         ),
     )
     assert_frame_equal(
-        mock_transc.call_args[0][0],
+        mock_transform_c.call_args[0][0],
         pd.DataFrame(
             {
                 "feature trans": pd.Series([1, 0, 0, 0, 0, 0], dtype="int64"),
@@ -735,9 +735,9 @@ def test_component_graph_evaluation_plumbing(
             columns=["feature trans", "feature a", "feature b"],
         ),
     )
-    assert_frame_equal(mock_preda.call_args[0][0], X)
+    assert_frame_equal(mock_predict_a.call_args[0][0], X)
     assert_frame_equal(
-        mock_predb.call_args[0][0],
+        mock_predict_b.call_args[0][0],
         pd.DataFrame(
             {
                 "feature trans": pd.Series([1, 0, 0, 0, 0, 0], dtype="int64"),
@@ -747,7 +747,7 @@ def test_component_graph_evaluation_plumbing(
         ),
     )
     assert_frame_equal(
-        mock_predc.call_args[0][0],
+        mock_predict_c.call_args[0][0],
         pd.DataFrame(
             {
                 "feature trans": pd.Series([1, 0, 0, 0, 0, 0], dtype="int64"),

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1921,14 +1921,14 @@ def test_component_graph_defines_edges_with_bad_syntax():
     ):
         ComponentGraph(
             {
-                "Imputer": [Imputer, "X", "y"],  # offending line
+                "Imputer": [Imputer, "X", "y"],
                 "One Hot Encoder": [OneHotEncoder, "Imputer.x", "y"],
                 "Target Imputer": [
                     TargetImputer,
-                    "Imputer",
+                    "Imputer",  # offending line: "Imputer" not allowed
                     "One Hot Encoder.x",
                     "y",
-                ],  # offending line: Imputer not allowed
+                ],
                 "Random Forest Classifier": [
                     RandomForestClassifier,
                     "One Hot Encoder.x",


### PR DESCRIPTION
- Remove "Cannot have multiple y parents for a single component" check in _compute_features, all checking is done in `_validate_component_dict` now.
- Cleaned up and added edge case to `_validate_component_dict` (where user specifies .x, .y, but also "thisisnotvalid" 😂). Before, this check would pass as long as there was one .x, one .y properly. This update ensures that all specified values must be .x/.y/X, y :)