### PR TITLE
Support relative forecasting for ARIMA

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
         * Updated ``ComponentGraph`` to handle not calling samplers' transform during predict, and updated samplers' transform methods s.t. ``fit_transform`` is equivalent to ``fit(X, y).transform(X, y)`` :pr:`2583`
         * Updated ``ComponentGraph`` ``_validate_component_dict`` logic to be stricter about input values :pr:`2599`
         * Patched bug in ``xgboost`` estimators where predicting on a feature matrix of only booleans would throw an exception. :pr:`2602`
-        * Updated ``ARIMARegressor`` to use relative forecasting to predict values :pr:``
+        * Updated ``ARIMARegressor`` to use relative forecasting to predict values :pr:`2613`
     * Fixes
         * Updated ``get_best_sampler_for_data`` to consider all non-numeric datatypes as categorical for SMOTE :pr:`2590`
         * Fixed inconsistent test results from `TargetDistributionDataCheck` :pr:`2608`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Updated ``ComponentGraph`` to handle not calling samplers' transform during predict, and updated samplers' transform methods s.t. ``fit_transform`` is equivalent to ``fit(X, y).transform(X, y)`` :pr:`2583`
         * Updated ``ComponentGraph`` ``_validate_component_dict`` logic to be stricter about input values :pr:`2599`
         * Patched bug in ``xgboost`` estimators where predicting on a feature matrix of only booleans would throw an exception. :pr:`2602`
+        * Updated ``ARIMARegressor`` to use relative forecasting to predict values :pr:``
     * Fixes
         * Updated ``get_best_sampler_for_data`` to consider all non-numeric datatypes as categorical for SMOTE :pr:`2590`
         * Fixed inconsistent test results from `TargetDistributionDataCheck` :pr:`2608`

--- a/evalml/pipelines/components/estimators/regressors/arima_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/arima_regressor.py
@@ -143,7 +143,7 @@ class ARIMARegressor(Estimator):
                 f" Found {dates.shape[1]} columns."
             )
         freq = "M" if pd.infer_freq(dates) == "MS" else pd.infer_freq(dates)
-        dates = dates.to_period(freq=freq)
+        dates = pd.DatetimeIndex(dates, freq=freq)
         X, y = self._match_indices(X, y, dates)
         if predict:
             arima_model_msg = (
@@ -152,7 +152,9 @@ class ARIMARegressor(Estimator):
             forecasting_ = import_or_raise(
                 "sktime.forecasting.base", error_msg=arima_model_msg
             )
-            fh_ = forecasting_.ForecastingHorizon([i+1 for i in range(len(dates))], is_relative=True)
+            fh_ = forecasting_.ForecastingHorizon(
+                [i + 1 for i in range(len(dates))], is_relative=True
+            )
             return X, y, fh_
         else:
             return X, y, None

--- a/evalml/pipelines/components/estimators/regressors/arima_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/arima_regressor.py
@@ -152,7 +152,7 @@ class ARIMARegressor(Estimator):
             forecasting_ = import_or_raise(
                 "sktime.forecasting.base", error_msg=arima_model_msg
             )
-            fh_ = forecasting_.ForecastingHorizon(dates, is_relative=False)
+            fh_ = forecasting_.ForecastingHorizon([i+1 for i in range(len(dates))], is_relative=True)
             return X, y, fh_
         else:
             return X, y, None

--- a/evalml/tests/component_tests/test_arima_regressor.py
+++ b/evalml/tests/component_tests/test_arima_regressor.py
@@ -121,7 +121,7 @@ def test_fit_predict_ts_with_only_datetime_column_in_X(
     assert isinstance(X.index, pd.DatetimeIndex)
     assert isinstance(y.index, pd.DatetimeIndex)
 
-    fh_ = forecasting.ForecastingHorizon(y_test.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(y=y)
@@ -144,7 +144,7 @@ def test_fit_predict_ts_with_X_and_y_index_out_of_sample(
     assert isinstance(X.index, pd.DatetimeIndex)
     assert isinstance(y.index, pd.DatetimeIndex)
 
-    fh_ = forecasting.ForecastingHorizon(y_test.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -175,7 +175,7 @@ def test_fit_predict_ts_with_X_and_y_index(
     mock_get_dates.return_value = (X.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon(y.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -205,7 +205,7 @@ def test_fit_predict_ts_with_X_not_y_index(
     mock_get_dates.return_value = (X.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon(y.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -236,7 +236,7 @@ def test_fit_predict_ts_with_y_not_X_index(
     mock_get_dates.return_value = (y.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon(y.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -321,7 +321,7 @@ def test_fit_predict_ts_no_X_out_of_sample(
     X, y = ts_data_seasonal_train
     X_test, y_test = ts_data_seasonal_test
 
-    fh_ = forecasting.ForecastingHorizon(y_test.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     a_clf.fit(y=y)
@@ -341,7 +341,7 @@ def test_fit_predict_date_index_named_out_of_sample(
     X, y = ts_data_seasonal_train
     X_test, y_test = ts_data_seasonal_test
 
-    fh_ = forecasting.ForecastingHorizon(y_test.index, is_relative=False)
+    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
 
     a_clf = sktime_arima.AutoARIMA()
     if X_none:
@@ -362,3 +362,24 @@ def test_fit_predict_date_index_named_out_of_sample(
         y_pred = m_clf.predict(X=X_test, y=y_test)
 
     assert (y_pred_sk.to_period("D") == y_pred).all()
+
+
+@pytest.mark.parametrize("freq_num", ["1", "2"])
+@pytest.mark.parametrize("freq_str", ["S", "T", "H", "D", "M", "Y"])
+def test_different_time_units_out_of_sample(freq_str, freq_num):
+    datetime_ = pd.date_range("1/1/1870", periods=20, freq=freq_num+freq_str)
+
+    X = pd.DataFrame(range(20), index=datetime_)
+    y = pd.Series(np.sin(np.linspace(-8 * np.pi, 8 * np.pi, 20)), index=datetime_)
+
+    fh_ = forecasting.ForecastingHorizon([i + 1 for i in range(len(y[15:]))], is_relative=True)
+
+    a_clf = sktime_arima.AutoARIMA(sp=4)
+    clf = a_clf.fit(X=X[:15], y=y[:15])
+    y_pred_sk = clf.predict(fh=fh_, X=X[15:])
+
+    m_clf = ARIMARegressor(sp=4, d=None)
+    m_clf.fit(X=X[:15], y=y[:15])
+    y_pred = m_clf.predict(X=X[15:], y=y[15:])
+
+    pd.testing.assert_series_equal(y_pred_sk.to_period(freq_num+freq_str), y_pred)

--- a/evalml/tests/component_tests/test_arima_regressor.py
+++ b/evalml/tests/component_tests/test_arima_regressor.py
@@ -121,7 +121,9 @@ def test_fit_predict_ts_with_only_datetime_column_in_X(
     assert isinstance(X.index, pd.DatetimeIndex)
     assert isinstance(y.index, pd.DatetimeIndex)
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y_test))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(y=y)
@@ -133,7 +135,7 @@ def test_fit_predict_ts_with_only_datetime_column_in_X(
     m_clf.fit(X=X, y=y)
     y_pred = m_clf.predict(X=X_test)
 
-    assert (y_pred_sk.to_period("D") == y_pred).all()
+    assert (y_pred_sk == y_pred).all()
 
 
 def test_fit_predict_ts_with_X_and_y_index_out_of_sample(
@@ -144,7 +146,9 @@ def test_fit_predict_ts_with_X_and_y_index_out_of_sample(
     assert isinstance(X.index, pd.DatetimeIndex)
     assert isinstance(y.index, pd.DatetimeIndex)
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y_test))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -154,7 +158,7 @@ def test_fit_predict_ts_with_X_and_y_index_out_of_sample(
     m_clf.fit(X=X, y=y)
     y_pred = m_clf.predict(X=X_test)
 
-    assert (y_pred_sk.to_period("D") == y_pred).all()
+    assert (y_pred_sk == y_pred).all()
 
 
 @patch(
@@ -175,7 +179,9 @@ def test_fit_predict_ts_with_X_and_y_index(
     mock_get_dates.return_value = (X.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -205,7 +211,9 @@ def test_fit_predict_ts_with_X_not_y_index(
     mock_get_dates.return_value = (X.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -236,7 +244,9 @@ def test_fit_predict_ts_with_y_not_X_index(
     mock_get_dates.return_value = (y.index, X)
     mock_format_dates.return_value = (X, y, None)
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     clf = a_clf.fit(X=X, y=y)
@@ -321,7 +331,9 @@ def test_fit_predict_ts_no_X_out_of_sample(
     X, y = ts_data_seasonal_train
     X_test, y_test = ts_data_seasonal_test
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y_test))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     a_clf.fit(y=y)
@@ -331,7 +343,7 @@ def test_fit_predict_ts_no_X_out_of_sample(
     m_clf.fit(X=None, y=y)
     y_pred = m_clf.predict(X=None, y=y_test)
 
-    assert (y_pred_sk.to_period("D") == y_pred).all()
+    assert (y_pred_sk == y_pred).all()
 
 
 @pytest.mark.parametrize("X_none", [True, False])
@@ -341,7 +353,9 @@ def test_fit_predict_date_index_named_out_of_sample(
     X, y = ts_data_seasonal_train
     X_test, y_test = ts_data_seasonal_test
 
-    fh_ = forecasting.ForecastingHorizon([i+1 for i in range(len(y_test))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y_test))], is_relative=True
+    )
 
     a_clf = sktime_arima.AutoARIMA()
     if X_none:
@@ -361,25 +375,27 @@ def test_fit_predict_date_index_named_out_of_sample(
         m_clf.fit(X=X, y=y)
         y_pred = m_clf.predict(X=X_test, y=y_test)
 
-    assert (y_pred_sk.to_period("D") == y_pred).all()
+    assert (y_pred_sk == y_pred).all()
 
 
 @pytest.mark.parametrize("freq_num", ["1", "2"])
 @pytest.mark.parametrize("freq_str", ["S", "T", "H", "D", "M", "Y"])
 def test_different_time_units_out_of_sample(freq_str, freq_num):
-    datetime_ = pd.date_range("1/1/1870", periods=20, freq=freq_num+freq_str)
+    datetime_ = pd.date_range("1/1/1870", periods=20, freq=freq_num + freq_str)
 
     X = pd.DataFrame(range(20), index=datetime_)
     y = pd.Series(np.sin(np.linspace(-8 * np.pi, 8 * np.pi, 20)), index=datetime_)
 
-    fh_ = forecasting.ForecastingHorizon([i + 1 for i in range(len(y[15:]))], is_relative=True)
+    fh_ = forecasting.ForecastingHorizon(
+        [i + 1 for i in range(len(y[15:]))], is_relative=True
+    )
 
-    a_clf = sktime_arima.AutoARIMA(sp=4)
+    a_clf = sktime_arima.AutoARIMA(start_p=2, start_q=2, max_p=2, max_q=2)
     clf = a_clf.fit(X=X[:15], y=y[:15])
     y_pred_sk = clf.predict(fh=fh_, X=X[15:])
 
-    m_clf = ARIMARegressor(sp=4, d=None)
+    m_clf = ARIMARegressor(start_p=2, start_q=2, max_p=2, max_q=2, d=None)
     m_clf.fit(X=X[:15], y=y[:15])
     y_pred = m_clf.predict(X=X[15:], y=y[15:])
 
-    pd.testing.assert_series_equal(y_pred_sk.to_period(freq_num+freq_str), y_pred)
+    pd.testing.assert_series_equal(y_pred_sk, y_pred)

--- a/evalml/tests/component_tests/test_estimators.py
+++ b/evalml/tests/component_tests/test_estimators.py
@@ -199,10 +199,7 @@ def test_estimator_predict_output_type(X_y_binary, helper_functions):
             predict_output = component.predict(X)
             assert isinstance(predict_output, pd.Series)
             assert len(predict_output) == len(y)
-            if component_class.name == "ARIMA Regressor":
-                assert predict_output.name == "predicted_mean"
-            else:
-                assert predict_output.name is None
+            assert predict_output.name is None
 
             if not (
                 (ProblemTypes.BINARY in component_class.supported_problem_types)


### PR DESCRIPTION
Fixes: #2592 

The original issue was filed under the assumption that `sktime` would not be able to support certain time units, such as those that had a frequency other than 1, such as 2 days, 4 minutes, 3 months, etc. This manifests when exogenous variables (features) are included in `fit` and `predict`. This problem doesn't seem to persist when the `is_relative` parameter in `ForecastingHorizon` is set to `True`. By setting this to `True`, predictions will be made on a set of absolute indices starting from after the last date used when fitting the estimator, as opposed to being made on specific dates.

```
time_index_1 = pd.date_range("1/1/21", periods=100, freq="3T")
X = pd.DataFrame(range(100), index=time_index_1)
y = pd.Series(y_values, index=time_index_1)
```

With the flag is set to `False`
```
# The actual dates have to be passed in to the ForecastingHorizon for when predictions need to be made
fh_ = ForecastingHorizon(X.index[75:], is_relative=False)
a_clf = AutoARIMA(suppress_warnings=True)
clf = a_clf.fit(y=y[:75])
y_pred_sk = clf.predict(fh=fh_)
print(y_pred_sk)
---------------------------------------------------
2021-03-17    0.371662
2021-03-18    0.776146
...
2021-04-09   -0.486227
2021-04-10   -0.000040
```

This does not work when features are passed
```
fh_ = ForecastingHorizon(X.index[75:], is_relative=False)
a_clf = AutoARIMA(suppress_warnings=True)
clf = a_clf.fit(X=X[:75], y=y[:75])
y_pred_sk = clf.predict(fh=fh_, X=X[75:])
print(y_pred_sk)
---------------------------------------------------
668         X = self._check_exog(X)  # type: np.ndarray
669         if X is not None and X.shape[0] != n_periods:
--> 670             raise ValueError('X array dims (n_rows) != n_periods')
671 
672         # f = self.arima_res_.forecast(steps=n_periods, exog=X)

ValueError: X array dims (n_rows) != n_periods
```

With the flag is set to `True`
```
# Only the "periods" or "absolute indices" after the last date provided when fitting the model are needed
fh_ = ForecastingHorizon([i+1 for i in range(len(X.index[75:]))], is_relative=True)
a_clf = AutoARIMA(suppress_warnings=True)
clf = a_clf.fit(y=y[:75])
y_pred_sk = clf.predict(fh=fh_)
print(y_pred_sk)
---------------------------------------------------
2021-03-17    0.371662
2021-03-18    0.776146
...
2021-04-09   -0.486227
2021-04-10   -0.000040
```

This works even when features are passed
```
fh_ = ForecastingHorizon([i+1 for i in range(len(X.index[75:]))], is_relative=True)
a_clf = AutoARIMA(suppress_warnings=True)
clf = a_clf.fit(X=X[:75], y=y[:75])
y_pred_sk = clf.predict(fh=fh_, X=X[75:])
print(y_pred_sk)
---------------------------------------------------
2021-01-01 03:45:00    0.369964
2021-01-01 03:48:00    0.768921
...
2021-01-01 04:54:00   -0.458856
2021-01-01 04:57:00   -0.012400
```

More information can be found [here](https://www.sktime.org/en/latest/examples/01_forecasting.html#section_1_2_2).