### PR TITLE
Only add docs build files if ipython 'startup' profile exists

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -53,6 +53,8 @@ Note that if you're on Mac, there are a few extra steps you'll want to keep trac
   open build/html/index.html
   ```
 
+Note that if you're building docs locally, the warning suppression code at `docs/source/disable-warnings.py` will not run, meaning you'll see python warnings appear in the docs where applicable. To supporess this, add `warnings.filterwarnings('ignore') to `docs/source/conf.py`.
+
 #### 3. Submit your Pull Request
 
 * Once your changes are ready to be submitted, make sure to push your changes to GitHub before creating a pull request. Create a pull request, and our continuous integration will run automatically.

--- a/contributing.md
+++ b/contributing.md
@@ -53,7 +53,7 @@ Note that if you're on Mac, there are a few extra steps you'll want to keep trac
   open build/html/index.html
   ```
 
-Note that if you're building docs locally, the warning suppression code at `docs/source/disable-warnings.py` will not run, meaning you'll see python warnings appear in the docs where applicable. To supporess this, add `warnings.filterwarnings('ignore')` to `docs/source/conf.py`.
+Note that if you're building docs locally, the warning suppression code at `docs/source/disable-warnings.py` will not run, meaning you'll see python warnings appear in the docs where applicable. To suppress this, add `warnings.filterwarnings('ignore')` to `docs/source/conf.py`.
 
 #### 3. Submit your Pull Request
 

--- a/contributing.md
+++ b/contributing.md
@@ -53,7 +53,7 @@ Note that if you're on Mac, there are a few extra steps you'll want to keep trac
   open build/html/index.html
   ```
 
-Note that if you're building docs locally, the warning suppression code at `docs/source/disable-warnings.py` will not run, meaning you'll see python warnings appear in the docs where applicable. To supporess this, add `warnings.filterwarnings('ignore') to `docs/source/conf.py`.
+Note that if you're building docs locally, the warning suppression code at `docs/source/disable-warnings.py` will not run, meaning you'll see python warnings appear in the docs where applicable. To supporess this, add `warnings.filterwarnings('ignore')` to `docs/source/conf.py`.
 
 #### 3. Submit your Pull Request
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -279,9 +279,11 @@ class PatchedPythonDomain(PythonDomain):
 
 def setup(app):
     p = Path("/home/docs/.ipython/profile_default/startup")
-    p.mkdir(parents=True, exist_ok=True)
-    shutil.copy("disable-warnings.py", "/home/docs/.ipython/profile_default/startup/")
-    shutil.copy("set-headers.py", "/home/docs/.ipython/profile_default/startup")
+    if p.exists():
+        print(f'Adding disable-warnings.py and set-headers.py to {str(p)}')
+        p.mkdir(parents=True, exist_ok=True)
+        shutil.copy("disable-warnings.py", "/home/docs/.ipython/profile_default/startup/")
+        shutil.copy("set-headers.py", "/home/docs/.ipython/profile_default/startup")
     app.add_domain(PatchedPythonDomain, override=True)
     app.add_javascript(
        "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
         * Renamed SMOTE samplers to SMOTE oversampler :pr:`2595`
         * Changed ``partial_dependence`` and ``graph_partial_dependence`` to raise a ``PartialDependenceError`` instead of ``ValueError``. This is not a breaking change because ``PartialDependenceError`` is a subclass of ``ValueError`` :pr:`2604`
     * Documentation Changes
+        * To avoid local docs build error, only add warning disable and download headers on ReadTheDocs builds, not locally :pr:`2617`
     * Testing Changes
         * Changed the lint CI job to only check against python 3.9 via the `-t` flag :pr:`2586`
         * Installed Prophet in linux nightlies test and fixed ``test_all_components`` :pr:`2598`


### PR DESCRIPTION
Fixes #2567 

This will be true on the RTD builder, but false locally. This does mean warnings will show up in the docs for local builds, but I think its better than local docs build simply failing with a path error.