### PR TITLE
Release v0.30.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,18 @@
 Release Notes
 -------------
-**Future Release**
+**Future Releases**
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.30.1 Aug. 12, 2021**
     * Enhancements
         * Added ``DatetimeFormatDataCheck`` for time series problems :pr:`2603`
         * Added ``ProphetRegressor`` to estimators :pr:`2242`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.30.0"
+__version__ = "0.30.1"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
 
 setup(
     name='evalml',
-    version='0.30.0',
+    version='0.30.1',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.30.1 Aug. 12, 2021
### Enhancements
- Added ``DatetimeFormatDataCheck`` for time series problems #2603
- Added ``ProphetRegressor`` to estimators #2242
- Updated ``ComponentGraph`` to handle not calling samplers' transform during predict, and updated samplers' transform methods s.t. ``fit_transform`` is equivalent to ``fit(X, y).transform(X, y)`` #2583
- Updated ``ComponentGraph`` ``_validate_component_dict`` logic to be stricter about input values #2599
- Patched bug in ``xgboost`` estimators where predicting on a feature matrix of only booleans would throw an exception. #2602
- Updated ``ARIMARegressor`` to use relative forecasting to predict values #2613
- Updated to support Woodwork 0.5.1 #2610
### Fixes
- Updated ``get_best_sampler_for_data`` to consider all non-numeric datatypes as categorical for SMOTE #2590
- Fixed inconsistent test results from `TargetDistributionDataCheck` #2608
### Changes
- Renamed SMOTE samplers to SMOTE oversampler #2595
- Changed ``partial_dependence`` and ``graph_partial_dependence`` to raise a ``PartialDependenceError`` instead of ``ValueError``. This is not a breaking change because ``PartialDependenceError`` is a subclass of ``ValueError`` #2604
- Cleaned up code duplication in ``ComponentGraph`` #2612
### Documentation Changes
- To avoid local docs build error, only add warning disable and download headers on ReadTheDocs builds, not locally #2617
### Testing Changes
- Changed the lint CI job to only check against python 3.9 via the `-t` flag #2586
- Installed Prophet in linux nightlies test and fixed ``test_all_components`` #2598
- Refactored and fixed all ``make_pipeline`` tests to assert correct order and address new Woodwork Unknown type inference #2572
- Removed ``component_graphs`` as a global variable in ``test_component_graphs.py`` #2609
### Breaking Changes
- Renamed SMOTE samplers to SMOTE oversampler. Please use ``SMOTEOversampler``, ``SMOTENCOversampler``, ``SMOTENOversampler`` instead of ``SMOTESampler``, ``SMOTENCSampler``, and ``SMOTENSampler`` #2595