### PR TITLE
Stored `predict_proba` results in `.x` for intermediate estimators in ComponentGraph 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -41,6 +41,7 @@ Release Notes
         * Renamed SMOTE samplers to SMOTE oversampler :pr:`2595`
         * Changed ``partial_dependence`` and ``graph_partial_dependence`` to raise a ``PartialDependenceError`` instead of ``ValueError``. This is not a breaking change because ``PartialDependenceError`` is a subclass of ``ValueError`` :pr:`2604`
         * Cleaned up code duplication in ``ComponentGraph`` :pr:`2612`
+        * Stored predict_proba results in .x for intermediate estimators in ComponentGraph :pr:`2629`
     * Documentation Changes
         * To avoid local docs build error, only add warning disable and download headers on ReadTheDocs builds, not locally :pr:`2617`
     * Testing Changes

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -306,10 +306,16 @@ class ComponentGraph:
                 elif component_name != self.compute_order[-1]:
                     try:
                         output = component_instance.predict_proba(x_inputs)
-                        if len(output.columns) == 2:
-                            # If it is a binary problem, drop the first column since both columns are colinear
-                            output.drop(0, axis=1)
-                        output.ww.rename({col: str(col) + '_' + component_name for col in output.columns}, inplace=True)
+                        if isinstance(output, pd.DataFrame):
+                            if len(output.columns) == 2:
+                                # If it is a binary problem, drop the first column since both columns are colinear
+                                output = output.ww.drop(output.columns[0])
+                            output = output.ww.rename(
+                                {
+                                    col: f"{str(col)}_{component_name}.x"
+                                    for col in output.columns
+                                }
+                            )
                     except MethodPropertyNotFoundError:
                         output = component_instance.predict(x_inputs)
                 else:

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -312,7 +312,7 @@ class ComponentGraph:
                                 output = output.ww.drop(output.columns[0])
                             output = output.ww.rename(
                                 {
-                                    col: f"{str(col)}_{component_name}.x"
+                                    col: f"Col {str(col)} {component_name}.x"
                                     for col in output.columns
                                 }
                             )

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -542,16 +542,19 @@ def test_compute_final_component_features(
     X, y = X_y_binary
     mock_imputer.return_value = pd.DataFrame(X)
     mock_ohe.return_value = pd.DataFrame(X)
-    mock_en_predict_proba.return_value = pd.DataFrame((
-        {0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])}
-    ))
+    mock_en_predict_proba.return_value = pd.DataFrame(
+        ({0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])})
+    )
     mock_en_predict_proba.return_value.ww.init()
-    mock_rf_predict_proba.return_value = pd.DataFrame((
-        {0: np.ones(X.shape[0]), 1: np.zeros(X.shape[0])}
-    ))
+    mock_rf_predict_proba.return_value = pd.DataFrame(
+        ({0: np.ones(X.shape[0]), 1: np.zeros(X.shape[0])})
+    )
     mock_rf_predict_proba.return_value.ww.init()
     X_expected = pd.DataFrame(
-        {"1_Random Forest.x": np.zeros(X.shape[0]), "1_Elastic Net.x": np.ones(X.shape[0])}
+        {
+            "Col 1 Random Forest.x": np.zeros(X.shape[0]),
+            "Col 1 Elastic Net.x": np.ones(X.shape[0]),
+        }
     )
     component_graph = ComponentGraph(example_graph).instantiate({})
     component_graph.fit(X, y)
@@ -825,8 +828,8 @@ def test_input_feature_names(example_graph):
         "column_1_c",
     ]
     assert input_feature_names["Logistic Regression"] == [
-        "1_Random Forest.x",
-        "1_Elastic Net.x",
+        "Col 1 Random Forest.x",
+        "Col 1 Elastic Net.x",
     ]
 
 
@@ -893,8 +896,8 @@ def test_custom_input_feature_types(example_graph):
         "column_2_5",
     ]
     assert input_feature_names["Logistic Regression"] == [
-        "1_Random Forest.x",
-        "1_Elastic Net.x",
+        "Col 1 Random Forest.x",
+        "Col 1 Elastic Net.x",
     ]
 
 
@@ -1063,8 +1066,8 @@ def test_component_graph_dataset_with_different_types():
             )
         )
         assert input_feature_names["Logistic Regression"] == [
-            "1_Random Forest.x",
-            "1_Elastic Net.x",
+            "Col 1 Random Forest.x",
+            "Col 1 Elastic Net.x",
         ]
 
     check_feature_names(component_graph.input_feature_names)

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -412,7 +412,8 @@ def test_fit_component_graph(
 ):
     X, y = X_y_binary
     mock_fit_transform.return_value = pd.DataFrame(X)
-    mock_predict_proba.return_value = pd.Series(y)
+    mock_predict_proba.return_value = pd.DataFrame(y)
+    mock_predict_proba.return_value.ww.init()
     component_graph = ComponentGraph(example_graph).instantiate({})
     component_graph.fit(X, y)
 
@@ -458,7 +459,8 @@ def test_component_graph_fit_features(
     mock_X_t = pd.DataFrame(np.ones(pd.DataFrame(X).shape))
     mock_fit_transform.return_value = mock_X_t
     mock_fit.return_value = Estimator
-    mock_predict_proba.return_value = pd.Series(y)
+    mock_predict_proba.return_value = pd.DataFrame(y)
+    mock_predict_proba.return_value.ww.init()
 
     component_graph.fit_features(X, y)
 
@@ -472,7 +474,8 @@ def test_component_graph_fit_features(
 @patch("evalml.pipelines.components.Estimator.predict")
 def test_predict(mock_predict, mock_predict_proba, mock_fit, example_graph, X_y_binary):
     X, y = X_y_binary
-    mock_predict_proba.return_value = pd.Series(y)
+    mock_predict_proba.return_value = pd.DataFrame(y)
+    mock_predict_proba.return_value.ww.init()
     mock_predict.return_value = pd.Series(y)
     component_graph = ComponentGraph(example_graph).instantiate({})
     component_graph.fit(X, y)
@@ -493,7 +496,8 @@ def test_predict_repeat_estimator(
     mock_predict, mock_predict_proba, mock_fit, X_y_binary
 ):
     X, y = X_y_binary
-    mock_predict_proba.return_value = pd.Series(y)
+    mock_predict_proba.return_value = pd.DataFrame(y)
+    mock_predict_proba.return_value.ww.init()
     mock_predict.return_value = pd.Series(y)
     graph = {
         "Imputer": [Imputer, "X", "y"],
@@ -538,10 +542,16 @@ def test_compute_final_component_features(
     X, y = X_y_binary
     mock_imputer.return_value = pd.DataFrame(X)
     mock_ohe.return_value = pd.DataFrame(X)
-    mock_en_predict_proba.return_value = pd.Series(np.ones(X.shape[0]))
-    mock_rf_predict_proba.return_value = pd.Series(np.zeros(X.shape[0]))
+    mock_en_predict_proba.return_value = pd.DataFrame((
+        {0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])}
+    ))
+    mock_en_predict_proba.return_value.ww.init()
+    mock_rf_predict_proba.return_value = pd.DataFrame((
+        {0: np.ones(X.shape[0]), 1: np.zeros(X.shape[0])}
+    ))
+    mock_rf_predict_proba.return_value.ww.init()
     X_expected = pd.DataFrame(
-        {"Random Forest.x": np.zeros(X.shape[0]), "Elastic Net.x": np.ones(X.shape[0])}
+        {"1_Random Forest.x": np.zeros(X.shape[0]), "1_Elastic Net.x": np.ones(X.shape[0])}
     )
     component_graph = ComponentGraph(example_graph).instantiate({})
     component_graph.fit(X, y)

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -888,8 +888,8 @@ def test_compute_estimator_features_nonlinear(
 
     X_expected_df = pd.DataFrame(
         {
-            "1_Random Forest.x": np.ones(X.shape[0]),
-            "1_Elastic Net.x": np.zeros(X.shape[0]),
+            "Col 1 Random Forest.x": np.ones(X.shape[0]),
+            "Col 1 Elastic Net.x": np.zeros(X.shape[0]),
         }
     )
 
@@ -1183,8 +1183,8 @@ def test_nonlinear_feature_importance_has_feature_names(
     assert len(clf.feature_importance) == 2
     assert not clf.feature_importance.isnull().all().all()
     assert sorted(clf.feature_importance["feature"]) == [
-        "1_Elastic Net.x",
-        "1_Random Forest.x",
+        "Col 1 Elastic Net.x",
+        "Col 1 Random Forest.x",
     ]
 
 

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -855,11 +855,15 @@ def test_compute_estimator_features(
 
 @patch("evalml.pipelines.components.Imputer.transform")
 @patch("evalml.pipelines.components.OneHotEncoder.transform")
+@patch("evalml.pipelines.components.RandomForestClassifier.predict_proba")
+@patch("evalml.pipelines.components.ElasticNetClassifier.predict_proba")
 @patch("evalml.pipelines.components.RandomForestClassifier.predict")
 @patch("evalml.pipelines.components.ElasticNetClassifier.predict")
 def test_compute_estimator_features_nonlinear(
     mock_en_predict,
     mock_rf_predict,
+    mock_en_predict_proba,
+    mock_rf_predict_proba,
     mock_ohe,
     mock_imputer,
     X_y_binary,
@@ -870,8 +874,23 @@ def test_compute_estimator_features_nonlinear(
     mock_ohe.return_value = pd.DataFrame(X)
     mock_en_predict.return_value = pd.Series(np.ones(X.shape[0]))
     mock_rf_predict.return_value = pd.Series(np.zeros(X.shape[0]))
+
+    mock_en_predict_proba_df = pd.DataFrame(
+        {0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])}
+    )
+    mock_en_predict_proba_df.ww.init()
+    mock_en_predict_proba.return_value = mock_en_predict_proba_df
+    mock_rf_predict_proba_df = pd.DataFrame(
+        {0: np.ones(X.shape[0]), 1: np.zeros(X.shape[0])}
+    )
+    mock_rf_predict_proba_df.ww.init()
+    mock_rf_predict_proba.return_value = mock_rf_predict_proba_df
+
     X_expected_df = pd.DataFrame(
-        {"Random Forest.x": np.zeros(X.shape[0]), "Elastic Net.x": np.ones(X.shape[0])}
+        {
+            "1_Random Forest.x": np.zeros(X.shape[0]),
+            "1_Elastic Net.x": np.ones(X.shape[0]),
+        }
     )
 
     pipeline = nonlinear_binary_pipeline_class({})
@@ -881,8 +900,8 @@ def test_compute_estimator_features_nonlinear(
     assert_frame_equal(X_expected_df, X_t)
     assert mock_imputer.call_count == 2
     assert mock_ohe.call_count == 4
-    assert mock_en_predict.call_count == 2
-    assert mock_rf_predict.call_count == 2
+    assert mock_en_predict_proba.call_count == 2
+    assert mock_rf_predict_proba.call_count == 2
 
 
 def test_no_default_parameters():
@@ -1164,8 +1183,8 @@ def test_nonlinear_feature_importance_has_feature_names(
     assert len(clf.feature_importance) == 2
     assert not clf.feature_importance.isnull().all().all()
     assert sorted(clf.feature_importance["feature"]) == [
-        "Elastic Net.x",
-        "Random Forest.x",
+        "1_Elastic Net.x",
+        "1_Random Forest.x",
     ]
 
 

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -876,20 +876,20 @@ def test_compute_estimator_features_nonlinear(
     mock_rf_predict.return_value = pd.Series(np.zeros(X.shape[0]))
 
     mock_en_predict_proba_df = pd.DataFrame(
-        {0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])}
-    )
-    mock_en_predict_proba_df.ww.init()
-    mock_en_predict_proba.return_value = mock_en_predict_proba_df
-    mock_rf_predict_proba_df = pd.DataFrame(
         {0: np.ones(X.shape[0]), 1: np.zeros(X.shape[0])}
     )
+    mock_en_predict_proba_df.ww.init()
+    mock_rf_predict_proba_df = pd.DataFrame(
+        {0: np.zeros(X.shape[0]), 1: np.ones(X.shape[0])}
+    )
     mock_rf_predict_proba_df.ww.init()
+    mock_en_predict_proba.return_value = mock_en_predict_proba_df
     mock_rf_predict_proba.return_value = mock_rf_predict_proba_df
 
     X_expected_df = pd.DataFrame(
         {
-            "1_Random Forest.x": np.zeros(X.shape[0]),
-            "1_Elastic Net.x": np.ones(X.shape[0]),
+            "1_Random Forest.x": np.ones(X.shape[0]),
+            "1_Elastic Net.x": np.zeros(X.shape[0]),
         }
     )
 


### PR DESCRIPTION
As part of the component graph changes necessary to support building our new ensembler (#1930), this PR stores the prediction probabilities (when available) for non-final estimators in a component graph. If `predict_proba` is not available or if the final estimator in a component graph is being evaluated, then `predict` is used.