### PR TITLE
Added ability to utilize instantiated components when creating a pipeline

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Use Woodwork's outlier detection for the ``OutliersDataCheck`` :pr:`2637`
+        * Added ability to utilize instantiated components when creating a pipeline :pr:`2643`
     * Fixes
     * Changes
         * Deleted ``_put_into_original_order`` helper function :pr:`2639`

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -148,7 +148,7 @@ class ComponentGraph:
                     )
                     raise ValueError(err) from e
                 component_instances[component_name] = new_component
-            elif hasattr(component_class, "_is_fitted") and component_class._is_fitted:
+            elif isinstance(component_class, ComponentBase):
                 component_instances[component_name] = component_class
         self.component_instances = component_instances
         return self

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -121,7 +121,8 @@ class ComponentGraph:
 
         Arguments:
             parameters (dict): Dictionary with component names as keys and dictionary of that component's parameters as values.
-                               An empty dictionary {} or None implies using all default values for component parameters.
+                               An empty dictionary {} or None implies using all default values for component parameters. If a component
+                               in the component graph is already instantiated, it will not use any of its parameters defined in this dictionary.
         """
         if self._is_instantiated:
             raise ValueError(

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -13,8 +13,12 @@ from evalml.exceptions.exceptions import (
     ParameterNotUsedWarning,
 )
 from evalml.pipelines.components import ComponentBase, Estimator, Transformer
-from evalml.pipelines.components.transformers.samplers.base_sampler import BaseSampler
-from evalml.pipelines.components.transformers.transformer import TargetTransformer
+from evalml.pipelines.components.transformers.samplers.base_sampler import (
+    BaseSampler,
+)
+from evalml.pipelines.components.transformers.transformer import (
+    TargetTransformer,
+)
 from evalml.pipelines.components.utils import handle_component_class
 from evalml.utils import get_logger, import_or_raise, infer_feature_types
 
@@ -144,7 +148,7 @@ class ComponentGraph:
                     )
                     raise ValueError(err) from e
                 component_instances[component_name] = new_component
-            elif hasattr(component_class, '_is_fitted') and component_class._is_fitted:
+            elif hasattr(component_class, "_is_fitted") and component_class._is_fitted:
                 component_instances[component_name] = component_class
         self.component_instances = component_instances
         return self

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -99,8 +99,8 @@ def handle_component_class(component_class):
     """Standardizes input from a string name to a ComponentBase subclass if necessary.
 
     If a str is provided, will attempt to look up a ComponentBase class by that name and
-    return a new instance. Otherwise if a ComponentBase subclass is provided, will return that
-    without modification.
+    return a new instance. Otherwise if a ComponentBase subclass or Component instance is provided,
+    will return that without modification.
 
     Arguments:
         component (str, ComponentBase): input to be standardized
@@ -108,7 +108,7 @@ def handle_component_class(component_class):
     Returns:
         ComponentBase
     """
-    if inspect.isclass(component_class) and issubclass(component_class, ComponentBase):
+    if isinstance(component_class, ComponentBase) or (inspect.isclass(component_class) and issubclass(component_class, ComponentBase)):
         return component_class
     if not isinstance(component_class, str):
         raise ValueError(

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -108,7 +108,9 @@ def handle_component_class(component_class):
     Returns:
         ComponentBase
     """
-    if isinstance(component_class, ComponentBase) or (inspect.isclass(component_class) and issubclass(component_class, ComponentBase)):
+    if isinstance(component_class, ComponentBase) or (
+        inspect.isclass(component_class) and issubclass(component_class, ComponentBase)
+    ):
         return component_class
     if not isinstance(component_class, str):
         raise ValueError(

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -143,6 +143,18 @@ def test_init_str_components():
     assert comp_graph.compute_order == expected_order
 
 
+def test_init_instantiated():
+    graph = {
+        "Imputer": [
+            Imputer(numeric_impute_strategy="constant", numeric_fill_value=0),
+            "X",
+            "y",
+        ]
+    }
+    cg = ComponentGraph(graph)
+    assert graph['Imputer'][0] == cg.get_component('Imputer')
+
+
 def test_invalid_init():
     invalid_graph = {"Imputer": [Imputer, "X", "y"], "OHE": OneHotEncoder}
     with pytest.raises(
@@ -152,7 +164,7 @@ def test_invalid_init():
 
     graph = {
         "Imputer": [
-            Imputer(numeric_impute_strategy="constant", numeric_fill_value=0),
+            None,
             "X",
             "y",
         ]

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -152,7 +152,7 @@ def test_init_instantiated():
         ]
     }
     cg = ComponentGraph(graph)
-    assert graph['Imputer'][0] == cg.get_component('Imputer')
+    assert graph["Imputer"][0] == cg.get_component("Imputer")
 
 
 def test_invalid_init():

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -151,9 +151,14 @@ def test_init_instantiated():
             "y",
         ]
     }
-    cg = ComponentGraph(graph)
-    cg.instantiate({"Imputer": {}})
-    assert graph["Imputer"][0] == cg.get_component("Imputer")
+    component_graph = ComponentGraph(graph)
+    component_graph.instantiate(
+        {"Imputer": {"numeric_fill_value": 10, "categorical_fill_value": "Fill"}}
+    )
+    cg_imputer = component_graph.get_component("Imputer")
+    assert graph["Imputer"][0] == cg_imputer
+    assert cg_imputer.parameters["numeric_fill_value"] == 0
+    assert cg_imputer.parameters["categorical_fill_value"] is None
 
 
 def test_invalid_init():

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -152,6 +152,7 @@ def test_init_instantiated():
         ]
     }
     cg = ComponentGraph(graph)
+    cg.instantiate({"Imputer": {}})
     assert graph["Imputer"][0] == cg.get_component("Imputer")
 
 


### PR DESCRIPTION
As part of #2587, we will need to be able to create new pipelines using already trained components. When creating new pipelines ensemble pipelines, the AutoML algorithm will be choosing from the best previously trained pipelines to create one large ensembling pipeline. Rather than creating an entirely new ensembling pipeline with the best parameters and retraining the entire pipeline, we can just utilize the pre-trained components and train only the final estimator. 

This PR adds support for using already instantiated components when creating a new pipeline. When an instantiated component is passed through a dictionary, the existing object is used rather than the current behavior of raising an error.