### PR TITLE
Remove LinearRegressor from default AutoMLSearch estimators

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,12 +5,14 @@ Release Notes
         * Removed SVM "linear" and "precomputed" kernel hyperparameter options, and improved default parameters :pr:`2651`
     * Fixes
     * Changes
+        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
     * Documentation Changes
     * Testing Changes
 
 .. warning::
 
     **Breaking Changes**
+        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
     
 
 **v0.31.0 Aug. 19, 2021**
@@ -25,7 +27,6 @@ Release Notes
         * Refactored time series pipeline code using a time series pipeline base class :pr:`2649`
         * Renamed ``dask_tests`` to ``parallel_tests`` :pr:`2657`
         * Removed commented out code in ``pipeline_meta.py`` :pr:`2659`
-        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
     * Documentation Changes
         * Add complete install command to README and Install section :pr:`2627`
     * Testing Changes
@@ -34,7 +35,6 @@ Release Notes
 
     **Breaking Changes**
         * ``TimeSeriesRegressionPipeline`` no longer inherits from ``TimeSeriesRegressionPipeline`` :pr:`2649`
-        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
 
 
 **v0.30.2 Aug. 16, 2021**

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Refactored time series pipeline code using a time series pipeline base class :pr:`2649`
         * Renamed ``dask_tests`` to ``parallel_tests`` :pr:`2657`
         * Removed commented out code in ``pipeline_meta.py`` :pr:`2659`
+        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
     * Documentation Changes
         * Add complete install command to README and Install section :pr:`2627`
     * Testing Changes
@@ -33,6 +34,7 @@ Release Notes
 
     **Breaking Changes**
         * ``TimeSeriesRegressionPipeline`` no longer inherits from ``TimeSeriesRegressionPipeline`` :pr:`2649`
+        * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
 
 
 **v0.30.2 Aug. 16, 2021**

--- a/evalml/automl/automl_algorithm/evalml_algorithm.py
+++ b/evalml/automl/automl_algorithm/evalml_algorithm.py
@@ -129,7 +129,7 @@ class EvalMLAlgorithm(AutoMLAlgorithm):
     def _naive_estimators(self):
         if is_regression(self.problem_type):
             naive_estimators = [
-                "Linear Regressor",
+                "Elastic Net Regressor",
                 "Random Forest Regressor",
             ]
         else:

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -284,7 +284,7 @@ def test_pipeline_limits(
     out = caplog.text
     assert "Using default limit of max_batches=1." in out
     assert "Searching up to 1 batches for a total of" in out
-    assert len(automl.results["pipeline_results"]) > 5
+    assert len(automl.results["pipeline_results"]) > 4
 
     caplog.clear()
     automl = AutoMLSearch(

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -682,7 +682,6 @@ def test_iterative_algorithm_first_batch_order(
         assert (
             estimators_in_first_batch
             == [
-                "Linear Regressor",
                 "Elastic Net Regressor",
                 "Decision Tree Regressor",
                 "Extra Trees Regressor",

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -413,7 +413,7 @@ def test_get_estimators(has_minimal_dependencies):
             == 2
         )
         assert len(get_estimators(problem_type=ProblemTypes.MULTICLASS)) == 5
-        assert len(get_estimators(problem_type=ProblemTypes.REGRESSION)) == 5
+        assert len(get_estimators(problem_type=ProblemTypes.REGRESSION)) == 4
     else:
         assert len(get_estimators(problem_type=ProblemTypes.BINARY)) == 8
         assert (
@@ -426,7 +426,7 @@ def test_get_estimators(has_minimal_dependencies):
             == 2
         )
         assert len(get_estimators(problem_type=ProblemTypes.MULTICLASS)) == 8
-        assert len(get_estimators(problem_type=ProblemTypes.REGRESSION)) == 8
+        assert len(get_estimators(problem_type=ProblemTypes.REGRESSION)) == 7
 
     assert len(get_estimators(problem_type=ProblemTypes.BINARY, model_families=[])) == 0
     assert (

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -121,12 +121,12 @@ def test_all_estimators(
     has_minimal_dependencies, is_running_py_39_or_above, is_using_conda
 ):
     if has_minimal_dependencies:
-        assert len((_all_estimators_used_in_search())) == 10
+        assert len((_all_estimators_used_in_search())) == 9
     else:
         if is_using_conda:
-            n_estimators = 16
+            n_estimators = 15
         else:
-            n_estimators = 16 if is_running_py_39_or_above else 17
+            n_estimators = 15 if is_running_py_39_or_above else 16
         assert len(_all_estimators_used_in_search()) == n_estimators
 
 

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -182,6 +182,7 @@ _not_used_in_automl = {
     "SVMClassifier",
     "SVMRegressor",
     "ProphetRegressor",
+    "LinearRegressor",
 }
 
 


### PR DESCRIPTION
### Pull Request Description
Fixes #2589 

Rationale [here](https://alteryx.atlassian.net/wiki/spaces/PS/pages/986153264/Investigating+Looking+Glass+Failures+on+regress.csv?focusedCommentId=987758749)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
