### PR TITLE
Switch order of boolean checks in infer_feature_types

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
         * Updated the high variance check in AutoMLSearch to be robust to a variety of objectives and cv scores :pr:`2622`
         * Use Woodwork's outlier detection for the ``OutliersDataCheck`` :pr:`2637`
         * Added ability to utilize instantiated components when creating a pipeline :pr:`2643`
+        * Sped up the all Nan and unknown check in ``infer_feature_types`` :pr:`2661`
     * Fixes
     * Changes
         * Deleted ``_put_into_original_order`` helper function :pr:`2639`

--- a/evalml/utils/woodwork_utils.py
+++ b/evalml/utils/woodwork_utils.py
@@ -66,7 +66,7 @@ def infer_feature_types(data, feature_types=None):
 
     def convert_all_nan_unknown_to_double(data):
         def is_column_pd_na(data, col):
-            return all(data[col].isna())
+            return data[col].isna().all()
 
         def is_column_unknown(data, col):
             return isinstance(data.ww.logical_types[col], Unknown)
@@ -75,7 +75,7 @@ def infer_feature_types(data, feature_types=None):
             all_null_unk_cols = [
                 col
                 for col in data.columns
-                if (is_column_pd_na(data, col) and is_column_unknown(data, col))
+                if (is_column_unknown(data, col) and is_column_pd_na(data, col))
             ]
             if len(all_null_unk_cols):
                 for col in all_null_unk_cols:


### PR DESCRIPTION
### Pull Request Description
Fixes #2642 

I was able to track the regression down to `infer_feature_types` like @chukarsten  and I suspected.

Steps to identify problem:

1. Profile this script locally for both v0.30.0 and main
```python
import pandas as pd
from evalml.automl import AutoMLSearch
from evalml.preprocessing import split_data

X = pd.read_csv("/Users/freddy.boulton/Downloads/KDDCup09_churn.csv")
y = X.pop("CHURN")

X_train, X_validation, y_train, y_validation = split_data(X, y, problem_type="binary",test_size=0.5, random_seed=0)
automl = AutoMLSearch(X_train, y_train, "binary")
automl.search()
```

2. Visualize with snakeviz. I saw that main took 5 minutes 3 seconds while v0.30.0 took 4 minutes 30 seconds. There's pretty much an exact 30 second increase in total time spent in `infer_feature_types` corresponding to `is_pd_na`

### main
![image](https://user-images.githubusercontent.com/41651716/130109358-a4335d2c-476f-48c0-a837-ca4a85f0ea06.png)

### 0.30.0
![image](https://user-images.githubusercontent.com/41651716/130109406-5fdae165-eab6-491b-b239-eb37b7f04a64.png)

3. We need to perform `is_pd_na` but the trick is to only do it when the column is `Unknown`, that's the only case we care about. In python, the booleans are evaluated from left to right so we'll put the `is_column_unknown` check first since that one is near instant. Example:

![Screen Shot 2021-08-19 at 12 00 41 PM](https://user-images.githubusercontent.com/41651716/130109924-9fc1df5c-4474-4dab-b050-a35da6828262.png)

4. With the new order, `infer_feature_types` now only takes 10 seconds longer compared to 0.30.0. This is coming from running `convert_all_nan_unknown_to_double` and checking if the columns are Unknown. 

![image](https://user-images.githubusercontent.com/41651716/130110293-85c868e5-397a-47bf-ab1c-2b3994372f80.png)


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
