### PR TITLE
Release v0.32.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,17 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.32.0 Aug. 31, 2021**
+    * Enhancements
         * Allow string for ``engine`` parameter for ``AutoMLSearch``:pr:`2667`
         * Add ``ProphetRegressor`` to AutoML :pr:`2619`
         * Integrated ``DefaultAlgorithm`` into ``AutoMLSearch`` :pr:`2634`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -21,4 +21,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.31.0',
+    version='0.32.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.32.0 Aug. 31, 2021
### Enhancements
- Allow string for ``engine`` parameter for ``AutoMLSearch``#2667
- Add ``ProphetRegressor`` to AutoML #2619
- Integrated ``DefaultAlgorithm`` into ``AutoMLSearch`` #2634
- Removed SVM "linear" and "precomputed" kernel hyperparameter options, and improved default parameters #2651
- Updated ``ComponentGraph`` initalization to raise ``ValueError`` when user attempts to use ``.y`` for a component that does not produce a tuple output #2662
- Updated to support Woodwork 0.6.0 #2690
- Updated pipeline ``graph()`` to distingush X and y edges #2654
- Added ``DropRowsTransformer`` component #2692
- Added ``DROP_ROWS`` to ``_make_component_list_from_actions`` and clean up metadata #2694
### Fixes
- Updated Oversampler logic to select best SMOTE based on component input instead of pipeline input #2695
- Added ability to explicitly close DaskEngine resources to improve runtime and reduce Dask warnings #2667
- Fixed partial dependence bug for ensemble pipelines #2714
- Updated ``TargetLeakageDataCheck`` to maintain user-selected logical types #2711
### Changes
- Replaced ``SMOTEOversampler``, ``SMOTENOversampler`` and ``SMOTENCOversampler`` with consolidated ``Oversampler`` component #2695
- Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance #2660
### Documentation Changes
- Updated documentation to make parallelization of AutoML clearer #2667
### Testing Changes
- Removes the process-level parallelism from the ``test_cancel_job`` test #2666
- Installed numba 0.53 in windows CI to prevent problems installing version 0.54 #2710
### Breaking Changes
- Renamed the current top level ``search`` method to ``search_iterative`` and defined a new ``search`` method for the ``DefaultAlgorithm`` #2634
- Replaced ``SMOTEOversampler``, ``SMOTENOversampler`` and ``SMOTENCOversampler`` with consolidated ``Oversampler`` component #2695
- Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance #2660
