### PR TITLE
Set eval_metric for xgboost

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Added label encoder to ``XGBoostClassifier`` to remove the warning :pr:`2701`
+        * Set ``eval_metric`` to ``logloss`` for ``XGBoostClassifier`` :pr:`2741`
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
@@ -67,6 +67,7 @@ class XGBoostClassifier(Estimator):
         min_child_weight=1,
         n_estimators=100,
         random_seed=0,
+        eval_metric="logloss",
         n_jobs=-1,
         **kwargs,
     ):
@@ -76,6 +77,7 @@ class XGBoostClassifier(Estimator):
             "min_child_weight": min_child_weight,
             "n_estimators": n_estimators,
             "n_jobs": n_jobs,
+            "eval_metric": eval_metric,
         }
         parameters.update(kwargs)
         if "use_label_encoder" in parameters:

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -415,6 +415,7 @@ def test_describe_component():
                 "min_child_weight": 1,
                 "n_estimators": 75,
                 "n_jobs": -1,
+                "eval_metric": "logloss",
             },
         }
         assert xgb_regressor.describe(return_dict=True) == {

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -13,6 +13,17 @@ from evalml.utils import SEED_BOUNDS, get_random_state
 xgb = importorskip("xgboost", reason="Skipping test because xgboost not installed")
 
 
+@pytest.mark.parametrize("metric", ["error", "logloss"])
+def test_xgboost_classifier_default_evaluation_metric(metric):
+    xgb = XGBoostClassifier(eval_metric=metric)
+    assert xgb.parameters["eval_metric"] == metric
+    assert xgb._component_obj.get_params()["eval_metric"] == metric
+
+    xgb = XGBoostClassifier()
+    assert xgb.parameters["eval_metric"] == "logloss"
+    assert xgb._component_obj.get_params()["eval_metric"] == "logloss"
+
+
 def test_xgboost_classifier_random_seed_bounds_seed(X_y_binary):
     """ensure xgboost's RNG doesn't fail for the min/max bounds we support on user-inputted random seeds"""
     X, y = X_y_binary


### PR DESCRIPTION
### Pull Request Description

Fixes #2570 

Perf tests [here](https://alteryx.atlassian.net/wiki/spaces/PS/pages/1012860317/XGBoostClassifier+eval+metric+comparison)

I didn't see any difference in performance with changing the value of `eval_metric` so just picking `logloss` (new default).

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
