### PR TITLE
Fixing flaky TargetDistributionDataCheck test

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
     * Documentation Changes
         * Added documentation for data exploration on data check actions :pr:`2696` 
     * Testing Changes
-        * Fixed flaky ``TargetDistributionDataCheck`` test for very_lognormal distribution :pr:``
+        * Fixed flaky ``TargetDistributionDataCheck`` test for very_lognormal distribution :pr:`2748`
 
 .. warning::
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
     * Documentation Changes
         * Added documentation for data exploration on data check actions :pr:`2696` 
     * Testing Changes
+        * Fixed flaky ``TargetDistributionDataCheck`` test for very_lognormal distribution :pr:``
 
 .. warning::
 

--- a/evalml/data_checks/target_distribution_data_check.py
+++ b/evalml/data_checks/target_distribution_data_check.py
@@ -98,7 +98,7 @@ class TargetDistributionDataCheck(DataCheck):
 
         if log_detected:
             details = {
-                "shapiro-statistic/pvalue": f"{round(shapiro_test_og.statistic, 2)}/{round(shapiro_test_og.pvalue, 3)}"
+                "shapiro-statistic/pvalue": f"{round(shapiro_test_og.statistic, 1)}/{round(shapiro_test_og.pvalue, 3)}"
             }
             results["warnings"].append(
                 DataCheckWarning(

--- a/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
+++ b/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
@@ -114,7 +114,7 @@ def test_target_distribution_data_check_warning_action(
         shapiro_test_og = shapiro(y)
 
         details = {
-            "shapiro-statistic/pvalue": f"{round(shapiro_test_og.statistic, 2)}/{round(shapiro_test_og.pvalue, 3)}"
+            "shapiro-statistic/pvalue": f"{round(shapiro_test_og.statistic, 1)}/{round(shapiro_test_og.pvalue, 3)}"
         }
         assert target_dist_ == {
             "warnings": [


### PR DESCRIPTION
Fixes #2581 

New test rounds the Shapiro value to the tenths place. Confirmed that the old test ran into a rounding issue once every few thousand runs. This test passed after 30,000 runs so I'm assuming the problem should be fixed.

This fix is fine for now until we can address #2749 