### PR TITLE
Fix Imputer so that it does not erase ww info during transform

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Set ``eval_metric`` to ``logloss`` for ``XGBoostClassifier`` :pr:`2741`
         * Added support for ``woodwork`` versions ``0.7.0`` and ``0.7.1`` :pr:`2743`
     * Fixes
+        * Fixed bug where ``Imputer.transform`` would erase ww typing information prior to handing data to the ``SimpleImputer`` :pr:`2752`
     * Changes
     * Documentation Changes
         * Specified installation steps for Prophet :pr:`2713`

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -123,15 +123,17 @@ class Imputer(Transformer):
             df = pd.DataFrame(index=X.index)
             return _retain_custom_types_and_initalize_woodwork(original_ltypes, df)
 
-        X.drop(self._all_null_cols, inplace=True, axis=1, errors="ignore")
+        X_no_all_null = X.ww.drop(self._all_null_cols)
 
         if self._numeric_cols is not None and len(self._numeric_cols) > 0:
-            X_numeric = X[self._numeric_cols.tolist()]
+            X_numeric = X.ww[self._numeric_cols.tolist()]
             imputed = self._numeric_imputer.transform(X_numeric)
-            X[X_numeric.columns] = imputed
+            X_no_all_null[X_numeric.columns] = imputed
 
         if self._categorical_cols is not None and len(self._categorical_cols) > 0:
-            X_categorical = X[self._categorical_cols.tolist()]
+            X_categorical = X.ww[self._categorical_cols.tolist()]
             imputed = self._categorical_imputer.transform(X_categorical)
-            X[X_categorical.columns] = imputed
-        return _retain_custom_types_and_initalize_woodwork(original_ltypes, X)
+            X_no_all_null[X_categorical.columns] = imputed
+        return _retain_custom_types_and_initalize_woodwork(
+            original_ltypes, X_no_all_null
+        )


### PR DESCRIPTION
### Pull Request Description
Fixes #2751 


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
