### PR TITLE
Display original feature values in explain predictions

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added label encoder to ``XGBoostClassifier`` to remove the warning :pr:`2701`
         * Set ``eval_metric`` to ``logloss`` for ``XGBoostClassifier`` :pr:`2741`
         * Added support for ``woodwork`` versions ``0.7.0`` and ``0.7.1`` :pr:`2743`
+        * Changed ``explain_predictions`` functions to display original feature values :pr:`2759`
     * Fixes
         * Fixed bug where ``_catch_warnings`` assumed all warnings were ``PipelineNotUsed`` :pr:`2753`
         * Fixed bug where ``Imputer.transform`` would erase ww typing information prior to handing data to the ``SimpleImputer`` :pr:`2752`

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -53,12 +53,12 @@ def _make_rows(
         display_text = symbol * min(int(abs(value) // 0.2) + 1, 5)
 
         # At this point, the feature is either in the original data or the data
-        # the final estimator sees. So if it is not a pipeline feature, it is
-        # an original feature
-        if feature_name in pipeline_features.columns:
-            feature_value = pipeline_features[feature_name].iloc[0]
-        else:
+        # the final estimator sees, or both. We use the original feature value if possible
+        is_original_feature = feature_name in original_features.columns
+        if is_original_feature:
             feature_value = original_features[feature_name].iloc[0]
+        else:
+            feature_value = pipeline_features[feature_name].iloc[0]
 
         if convert_numeric_to_string:
             if pd.api.types.is_number(feature_value) and not pd.api.types.is_bool(

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1782,3 +1782,111 @@ def test_explain_predictions_url_email(df_with_url_and_email):
         .isnull()
         .any()
     )
+
+
+@pytest.mark.parametrize("pipeline_class,estimator", pipeline_test_cases)
+def test_explain_predictions_report_shows_original_value_if_possible(
+    pipeline_class, estimator, fraud_100
+):
+    X, y = fraud_100
+    X.ww.set_types({"country": "NaturalLanguage"})
+    component_graph = [
+        "Imputer",
+        "DateTime Featurization Component",
+        "Text Featurization Component",
+        "One Hot Encoder",
+        "Standard Scaler",
+        estimator,
+    ]
+    parameters = {
+        estimator: {"n_jobs": 1},
+    }
+    pipeline = pipeline_class(component_graph=component_graph, parameters=parameters)
+
+    y = transform_y_for_problem_type(pipeline.problem_type, y)
+
+    pipeline.fit(X, y)
+
+    report = explain_predictions(
+        pipeline, X, y, indices_to_explain=[0], output_format="dict", top_k_features=20
+    )
+    expected_feature_values = set(X.ww.iloc[0, :].tolist())
+    for explanation in report["explanations"][0]["explanations"]:
+        assert set(explanation["feature_names"]) == set(X.columns)
+        assert set(explanation["feature_values"]) == expected_feature_values
+
+    X_null = X.ww.copy()
+    X_null.loc[0, "lat"] = None
+    X_null.ww.init(schema=X.ww.schema)
+
+    report = explain_predictions(
+        pipeline,
+        X_null,
+        y,
+        indices_to_explain=[0],
+        output_format="dict",
+        top_k_features=20,
+    )
+    for explanation in report["explanations"][0]["explanations"]:
+        assert set(explanation["feature_names"]) == set(X.columns)
+        for feature_name, feature_value in zip(
+            explanation["feature_names"], explanation["feature_values"]
+        ):
+            if feature_name == "lat":
+                assert np.isnan(feature_value)
+
+
+def test_explain_predictions_best_worst_report_shows_original_value_if_possible(
+    fraud_100,
+):
+    X, y = fraud_100
+    X.ww.set_types({"country": "NaturalLanguage"})
+    component_graph = [
+        "Imputer",
+        "DateTime Featurization Component",
+        "Text Featurization Component",
+        "One Hot Encoder",
+        "Standard Scaler",
+        "Random Forest Classifier",
+    ]
+    parameters = {
+        "Random Forest Classifier": {"n_jobs": 1},
+    }
+    pipeline = BinaryClassificationPipeline(
+        component_graph=component_graph, parameters=parameters
+    )
+
+    y = transform_y_for_problem_type(pipeline.problem_type, y)
+
+    pipeline.fit(X, y)
+    report = explain_predictions_best_worst(
+        pipeline, X, y, num_to_explain=1, output_format="dict", top_k_features=20
+    )
+
+    for index, explanation in enumerate(report["explanations"]):
+        for exp in explanation["explanations"]:
+            assert set(exp["feature_names"]) == set(X.columns)
+            assert set(exp["feature_values"]) == set(
+                X.ww.iloc[explanation["predicted_values"]["index_id"], :]
+            )
+
+    X_null = X.ww.copy()
+    X_null.loc[0:2, "lat"] = None
+    X_null.ww.init(schema=X.ww.schema)
+
+    report = explain_predictions_best_worst(
+        pipeline,
+        X_null.ww.iloc[:2],
+        y.ww.iloc[:2],
+        num_to_explain=1,
+        output_format="dict",
+        top_k_features=20,
+    )
+    for explanation in report["explanations"]:
+        for exp in explanation["explanations"]:
+            assert set(exp["feature_names"]) == set(X.columns)
+            for feature_name, feature_value in zip(
+                exp["feature_names"], exp["feature_values"]
+            ):
+                if feature_name == "lat":
+                    assert np.isnan(feature_value)


### PR DESCRIPTION
### Pull Request Description
Fixes #1359 

Users really wanted us to display the original feature value even when there was a standard scaler, so decided to do this in this sprint because it's a small change. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
