### PR TITLE
Pass X_train and y_train to graph_prediction_vs_actual_over_time

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,9 @@ Release Notes
         * Set ``eval_metric`` to ``logloss`` for ``XGBoostClassifier`` :pr:`2741`
         * Added support for ``woodwork`` versions ``0.7.0`` and ``0.7.1`` :pr:`2743`
         * Changed ``explain_predictions`` functions to display original feature values :pr:`2759`
+        * Added ``X_train`` and ``y_train`` to ``graph_prediction_vs_actual_over_time`` and ``get_prediction_vs_actual_over_time_data`` :pr:`2762`
+        * Added ``forecast_horizon`` as a required parameter to time series pipelines and ``AutoMLSearch`` :pr:`2697`
+        * Added ``predict_in_sample`` and ``predict_proba_in_sample`` methods to time series pipelines to predict on data where the target is known, e.g. cross-validation :pr:`2697`
     * Fixes
         * Fixed bug where ``_catch_warnings`` assumed all warnings were ``PipelineNotUsed`` :pr:`2753`
         * Fixed bug where ``Imputer.transform`` would erase ww typing information prior to handing data to the ``SimpleImputer`` :pr:`2752`
@@ -15,9 +18,14 @@ Release Notes
         * Deleted ``drop_nan_target_rows`` utility method :pr:`2737`
         * Removed default logging setup and debugging log file :pr:`2645`
         * Changed the default n_jobs value for ``XGBoostClassifier`` and ``XGBoostRegressor`` to 12 :pr:`2757`
+        * Changed ``TimeSeriesBaselineEstimator`` to only work on a time series pipeline with a ``DelayedFeaturesTransformer`` :pr:`2697`
+        * Added ``X_train`` and ``y_train`` as optional parameters to pipeline ``predict``, ``predict_proba``. Only used for time series pipelines :pr:`2697`
+        * Added ``training_data`` and ``training_target`` as optional parameters to ``explain_predictions`` and ``explain_predictions_best_worst`` to support time series pipelines :pr:`2697`
+        * Changed time series pipeline predictions to no longer output series/dataframes padded with NaNs. A prediction will be returned for every row in the `X` input :pr:`2697`
     * Documentation Changes
         * Specified installation steps for Prophet :pr:`2713`
-        * Added documentation for data exploration on data check actions :pr:`2696` 
+        * Added documentation for data exploration on data check actions :pr:`2696`
+        * Added a user guide entry for time series modelling :pr:`2697`
     * Testing Changes
         * Fixed flaky ``TargetDistributionDataCheck`` test for very_lognormal distribution :pr:`2748`
 
@@ -25,6 +33,11 @@ Release Notes
 
     **Breaking Changes**
         * Removed default logging setup and debugging log file :pr:`2645`
+        * Added ``X_train`` and ``y_train`` to ``graph_prediction_vs_actual_over_time`` and ``get_prediction_vs_actual_over_time_data`` :pr:`2762`
+        * Added ``forecast_horizon`` as a required parameter to time series pipelines and ``AutoMLSearch`` :pr:`2697`
+        * Changed ``TimeSeriesBaselineEstimator`` to only work on a time series pipeline with a ``DelayedFeaturesTransformer`` :pr:`2697`
+        * Added ``X_train`` and ``y_train`` as required parameters for ``predict`` and ``predict_proba`` in time series pipelines :pr:`2697`
+        * Added ``training_data`` and ``training_target`` as required parameters to ``explain_predictions`` and ``explain_predictions_best_worst`` for time series pipelines :pr:`2697`
 
 **v0.32.0 Aug. 31, 2021**
     * Enhancements
@@ -37,8 +50,6 @@ Release Notes
         * Updated pipeline ``graph()`` to distingush X and y edges :pr:`2654`
         * Added ``DropRowsTransformer`` component :pr:`2692`
         * Added ``DROP_ROWS`` to ``_make_component_list_from_actions`` and clean up metadata :pr:`2694`
-        * Added ``forecast_horizon`` as a required parameter to time series pipelines and ``AutoMLSearch`` :pr:`2697`
-        * Added ``predict_in_sample`` and ``predict_proba_in_sample`` methods to time series pipelines to predict on data where the target is known, e.g. cross-validation :pr:`2697`
     * Fixes
         * Updated Oversampler logic to select best SMOTE based on component input instead of pipeline input :pr:`2695`
         * Added ability to explicitly close DaskEngine resources to improve runtime and reduce Dask warnings :pr:`2667`
@@ -47,14 +58,9 @@ Release Notes
     * Changes
         * Replaced ``SMOTEOversampler``, ``SMOTENOversampler`` and ``SMOTENCOversampler`` with consolidated ``Oversampler`` component :pr:`2695`
         * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
-        * Changed ``TimeSeriesBaselineEstimator`` to only work on a time series pipeline with a ``DelayedFeaturesTransformer`` :pr:`2697`
-        * Added ``X_train`` and ``y_train`` as optional parameters to pipeline ``predict``, ``predict_proba``. Only used for time series pipelines :pr:`2697`
-        * Added ``training_data`` and ``training_target`` as optional parameters to ``explain_predictions`` and ``explain_predictions_best_worst`` to support time series pipelines :pr:`2697`
-        * Changed time series pipeline predictions to no longer output series/dataframes padded with NaNs. A prediction will be returned for every row in the `X` input :pr:`2697`
     * Documentation Changes
         * Added user guide documentation for using ``ComponentGraph`` and added ``ComponentGraph`` to API reference :pr:`2673`
         * Updated documentation to make parallelization of AutoML clearer :pr:`2667`
-        * Added a user guide entry for time series modelling :pr:`2697`
     * Testing Changes
         * Removes the process-level parallelism from the ``test_cancel_job`` test :pr:`2666`
         * Installed numba 0.53 in windows CI to prevent problems installing version 0.54 :pr:`2710`
@@ -65,11 +71,6 @@ Release Notes
         * Renamed the current top level ``search`` method to ``search_iterative`` and defined a new ``search`` method for the ``DefaultAlgorithm`` :pr:`2634`
         * Replaced ``SMOTEOversampler``, ``SMOTENOversampler`` and ``SMOTENCOversampler`` with consolidated ``Oversampler`` component :pr:`2695`
         * Removed ``LinearRegressor`` from the list of default ``AutoMLSearch`` estimators due to poor performance :pr:`2660`
-        * Added ``forecast_horizon`` as a required parameter to time series pipelines and ``AutoMLSearch`` :pr:`2697`
-        * Changed ``TimeSeriesBaselineEstimator`` to only work on a time series pipeline with a ``DelayedFeaturesTransformer`` :pr:`2697`
-        * Added ``X_train`` and ``y_train`` as required parameters for ``predict`` and ``predict_proba`` in time series pipelines :pr:`2697`
-        * Added ``training_data`` and ``training_target`` as required parameters to ``explain_predictions`` and ``explain_predictions_best_worst`` for time series pipelines :pr:`2697`
-    
 
 **v0.31.0 Aug. 19, 2021**
     * Enhancements

--- a/docs/source/user_guide/timeseries.ipynb
+++ b/docs/source/user_guide/timeseries.ipynb
@@ -274,41 +274,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = pd.DataFrame({\"dates\": X_test.Date,\n",
-    "                     \"prediction\": pl.predict_in_sample(X_test, y_test, X_train, y_train),\n",
-    "                     \"target\": y_test})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data = [\n",
-    "    go.Scatter(\n",
-    "        x=data[\"dates\"],\n",
-    "        y=data[\"target\"],\n",
-    "        mode=\"lines+markers\",\n",
-    "        name=\"Target\",\n",
-    "        line=dict(color=\"#1f77b4\"),\n",
-    "    ),\n",
-    "    go.Scatter(\n",
-    "        x=data[\"dates\"],\n",
-    "        y=data[\"prediction\"],\n",
-    "        mode=\"lines+markers\",\n",
-    "        name=\"Prediction\",\n",
-    "        line=dict(color=\"#d62728\"),\n",
-    "    ),\n",
-    "]\n",
-    "# Let plotly pick the best date format.\n",
-    "layout = go.Layout(\n",
-    "    title={\"text\": \"Prediction vs Target over time\"},\n",
-    "    xaxis={\"title\": \"Time\"},\n",
-    "    yaxis={\"title\": \"Target Values and Predictions\"},\n",
-    ")\n",
+    "from evalml.model_understanding import graph_prediction_vs_actual_over_time\n",
     "\n",
-    "go.Figure(data=data, layout=layout)"
+    "fig = graph_prediction_vs_actual_over_time(pl, X_test, y_test, X_train, y_train, dates=X_test['Date'])\n",
+    "fig"
    ]
   },
   {

--- a/evalml/model_understanding/graphs.py
+++ b/evalml/model_understanding/graphs.py
@@ -1427,13 +1427,15 @@ def visualize_decision_tree(
     return source_obj
 
 
-def get_prediction_vs_actual_over_time_data(pipeline, X, y, dates):
+def get_prediction_vs_actual_over_time_data(pipeline, X, y, X_train, y_train, dates):
     """Get the data needed for the prediction_vs_actual_over_time plot.
 
     Arguments:
         pipeline (TimeSeriesRegressionPipeline): Fitted time series regression pipeline.
         X (pd.DataFrame): Features used to generate new predictions.
         y (pd.Series): Target values to compare predictions against.
+        X_train (pd.DataFrame): Data the pipeline was trained on.
+        y_train (pd.Series): Target values for training data.
         dates (pd.Series): Dates corresponding to target values and predictions.
 
     Returns:
@@ -1441,8 +1443,7 @@ def get_prediction_vs_actual_over_time_data(pipeline, X, y, dates):
     """
 
     dates = infer_feature_types(dates)
-    y = infer_feature_types(y)
-    prediction = pipeline.predict(X, y)
+    prediction = pipeline.predict_in_sample(X, y, X_train=X_train, y_train=y_train)
 
     return pd.DataFrame(
         {
@@ -1453,13 +1454,15 @@ def get_prediction_vs_actual_over_time_data(pipeline, X, y, dates):
     )
 
 
-def graph_prediction_vs_actual_over_time(pipeline, X, y, dates):
+def graph_prediction_vs_actual_over_time(pipeline, X, y, X_train, y_train, dates):
     """Plot the target values and predictions against time on the x-axis.
 
     Arguments:
         pipeline (TimeSeriesRegressionPipeline): Fitted time series regression pipeline.
         X (pd.DataFrame): Features used to generate new predictions.
         y (pd.Series): Target values to compare predictions against.
+        X_train (pd.DataFrame): Data the pipeline was trained on.
+        y_train (pd.Series): Target values for training data.
         dates (pd.Series): Dates corresponding to target values and predictions.
 
     Returns:
@@ -1475,7 +1478,9 @@ def graph_prediction_vs_actual_over_time(pipeline, X, y, dates):
             f"Received {str(pipeline.problem_type)}."
         )
 
-    data = get_prediction_vs_actual_over_time_data(pipeline, X, y, dates)
+    data = get_prediction_vs_actual_over_time_data(
+        pipeline, X, y, X_train, y_train, dates
+    )
 
     data = [
         _go.Scatter(

--- a/evalml/tests/model_understanding_tests/test_graphs.py
+++ b/evalml/tests/model_understanding_tests/test_graphs.py
@@ -43,6 +43,7 @@ from evalml.pipelines import (
     LinearRegressor,
     MulticlassClassificationPipeline,
     RegressionPipeline,
+    TimeSeriesRegressionPipeline,
 )
 from evalml.problem_types import ProblemTypes
 from evalml.utils import get_random_state, infer_feature_types
@@ -994,46 +995,56 @@ def test_graph_prediction_vs_actual(data_type):
     assert fig_dict["data"][2]["name"] == ">= outlier_threshold"
 
 
-@patch("evalml.pipelines.ClassificationPipeline.predict")
-@pytest.mark.parametrize("data_type", ["pd", "ww"])
-def test_get_prediction_vs_actual_over_time_data(
-    mock_predict, data_type, logistic_regression_binary_pipeline_class, make_data_type
-):
-    mock_predict.return_value = pd.Series([0] * 20)
-    X = make_data_type(data_type, pd.DataFrame())
-    y = make_data_type(data_type, pd.Series([0] * 20))
-    dates = make_data_type(
-        data_type, pd.Series(pd.date_range("2000-05-19", periods=20, freq="D"))
+def test_get_prediction_vs_actual_over_time_data(ts_data):
+    X, y = ts_data
+    X_train, y_train = X.iloc[:15], y.iloc[:15]
+    X_test, y_test = X.iloc[15:], y.iloc[15:]
+
+    pipeline = TimeSeriesRegressionPipeline(
+        ["Elastic Net Regressor"],
+        parameters={
+            "pipeline": {
+                "gap": 0,
+                "max_delay": 2,
+                "forecast_horizon": 1,
+                "date_index": None,
+            }
+        },
     )
 
-    pipeline = logistic_regression_binary_pipeline_class(parameters={})
-    results = get_prediction_vs_actual_over_time_data(pipeline, X, y, dates)
+    pipeline.fit(X_train, y_train)
+    results = get_prediction_vs_actual_over_time_data(
+        pipeline, X_test, y_test, X_train, y_train, pd.Series(X_test.index)
+    )
     assert isinstance(results, pd.DataFrame)
     assert list(results.columns) == ["dates", "target", "prediction"]
 
 
-def test_graph_prediction_vs_actual_over_time():
+def test_graph_prediction_vs_actual_over_time(ts_data):
     go = pytest.importorskip(
         "plotly.graph_objects",
         reason="Skipping plotting test because plotly not installed",
     )
 
-    class MockPipeline:
-        problem_type = ProblemTypes.TIME_SERIES_REGRESSION
+    X, y = ts_data
+    X_train, y_train = X.iloc[:15], y.iloc[:15]
+    X_test, y_test = X.iloc[15:], y.iloc[15:]
 
-        def predict(self, X, y):
-            y = infer_feature_types(y)
-            preds = y + 10
-            preds.index = range(100, 161)
-            return preds
+    pipeline = TimeSeriesRegressionPipeline(
+        ["Elastic Net Regressor"],
+        parameters={
+            "pipeline": {
+                "gap": 0,
+                "max_delay": 2,
+                "forecast_horizon": 1,
+                "date_index": None,
+            }
+        },
+    )
+    pipeline.fit(X_train, y_train)
 
-    y = pd.Series(np.arange(61), index=range(200, 261))
-    dates = pd.Series(pd.date_range("2020-03-01", "2020-04-30"))
-    pipeline = MockPipeline()
-
-    # For this test it doesn't matter what the features are
     fig = graph_prediction_vs_actual_over_time(
-        pipeline, X=pd.DataFrame(), y=y, dates=dates
+        pipeline, X_test, y_test, X_train, y_train, pd.Series(X_test.index)
     )
 
     assert isinstance(fig, go.Figure)
@@ -1045,12 +1056,12 @@ def test_graph_prediction_vs_actual_over_time():
     )
     assert len(fig_dict["data"]) == 2
     assert fig_dict["data"][0]["line"]["color"] == "#1f77b4"
-    assert len(fig_dict["data"][0]["x"]) == 61
+    assert len(fig_dict["data"][0]["x"]) == X_test.shape[0]
     assert not np.isnan(fig_dict["data"][0]["y"]).all()
-    assert len(fig_dict["data"][0]["y"]) == 61
+    assert len(fig_dict["data"][0]["y"]) == X_test.shape[0]
     assert fig_dict["data"][1]["line"]["color"] == "#d62728"
-    assert len(fig_dict["data"][1]["x"]) == 61
-    assert len(fig_dict["data"][1]["y"]) == 61
+    assert len(fig_dict["data"][1]["x"]) == X_test.shape[0]
+    assert len(fig_dict["data"][1]["y"]) == X_test.shape[0]
     assert not np.isnan(fig_dict["data"][1]["y"]).all()
 
 
@@ -1065,7 +1076,9 @@ def test_graph_prediction_vs_actual_over_time_value_error():
 
     error_msg = "graph_prediction_vs_actual_over_time only supports time series regression pipelines! Received regression."
     with pytest.raises(ValueError, match=error_msg):
-        graph_prediction_vs_actual_over_time(NotTSPipeline(), None, None, None)
+        graph_prediction_vs_actual_over_time(
+            NotTSPipeline(), None, None, None, None, None
+        )
 
 
 def test_decision_tree_data_from_estimator_not_fitted(tree_estimators):


### PR DESCRIPTION
### Pull Request Description
Fixes #2731 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
