### PR TITLE
Return transformed target in ComponentGraph.fit_features

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Fixed bug where warnings during ``make_pipeline`` were not being raised to the user :pr:`2765`
+        * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`
     * Changes
         * Refactored and removed ``SamplerBase`` class :pr:`2775`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`
+        * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -17,7 +18,6 @@ Release Notes
     * Enhancements
     * Fixes
         * Fixed bug where warnings during ``make_pipeline`` were not being raised to the user :pr:`2765`
-        * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`
     * Changes
         * Refactored and removed ``SamplerBase`` class :pr:`2775`
     * Documentation Changes

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -203,7 +203,7 @@ class ComponentGraph:
             y (pd.Series): The target training data of length [n_samples].
 
         Returns:
-            pd.DataFrame: Transformed values.
+            Tuple: pd.DataFrame, pd.Series: Transformed features and target.
         """
         return self._fit_transform_features_helper(True, X, y)
 
@@ -217,7 +217,8 @@ class ComponentGraph:
         Returns:
             pd.DataFrame: Transformed values.
         """
-        return self._fit_transform_features_helper(False, X, y)
+        features, _ = self._fit_transform_features_helper(False, X, y)
+        return features
 
     def _fit_transform_features_helper(self, needs_fitting, X, y=None):
         """Transform all components save the final one, and returns the data that should be fed to the final component, usually an estimator.
@@ -228,23 +229,23 @@ class ComponentGraph:
             y (pd.Series): The target training data of length [n_samples]. Defaults to None.
 
         Returns:
-            pd.DataFrame: Transformed values.
+           Tuple: pd.DataFrame, pd.Series: Transformed features and target.
         """
         if len(self.compute_order) <= 1:
             X = infer_feature_types(X)
             self.input_feature_names.update({self.compute_order[0]: list(X.columns)})
-            return X
+            return X, y
         component_outputs = self._compute_features(
             self.compute_order[:-1], X, y=y, fit=needs_fitting
         )
-        x_inputs, _ = self._consolidate_inputs_for_component(
+        x_inputs, y_output = self._consolidate_inputs_for_component(
             component_outputs, self.compute_order[-1], X, y
         )
         if needs_fitting:
             self.input_feature_names.update(
                 {self.compute_order[-1]: list(x_inputs.columns)}
             )
-        return x_inputs
+        return x_inputs, y_output
 
     def _consolidate_inputs_for_component(
         self, component_outputs, component, X, y=None

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -203,7 +203,7 @@ class ComponentGraph:
             y (pd.Series): The target training data of length [n_samples].
 
         Returns:
-            Tuple: pd.DataFrame, pd.Series: Transformed features and target.
+            Tuple (pd.DataFrame, pd.Series): Transformed features and target.
         """
         return self._fit_transform_features_helper(True, X, y)
 

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -230,13 +230,13 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
 
     def _fit(self, X, y):
         self.input_target_name = y.name
-        X_t = self.component_graph.fit_features(X, y)
-        X_t, y_shifted = drop_rows_with_nans(X_t, y)
+        X_t, y_t = self.component_graph.fit_features(X, y)
+        X_t, y_shifted = drop_rows_with_nans(X_t, y_t)
 
         if self.estimator is not None:
             self.estimator.fit(X_t, y_shifted)
         else:
-            self.component_graph.get_last_component().fit(X_t, y)
+            self.component_graph.get_last_component().fit(X_t, y_shifted)
 
         self.input_feature_names = self.component_graph.input_feature_names
 


### PR DESCRIPTION
### Pull Request Description
Fixes #2703 

I realized it's easier to update `fit_features` as opposed to `compute_estimator_features`. It's also a smaller change this way. 

This can go in the release in two weeks. Just opening up for review.


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
