### PR TITLE
Release v0.33.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,18 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.33.0 Sep. 10, 2021**
+    * Enhancements
+    * Fixes
         * Fixed bug where warnings during ``make_pipeline`` were not being raised to the user :pr:`2765`
     * Changes
         * Refactored and removed ``SamplerBase`` class :pr:`2775`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,7 +12,7 @@ Release Notes
     **Breaking Changes**
 
 
-**v0.33.0 Sep. 10, 2021**
+**v0.33.0 Sep. 15, 2021**
     * Enhancements
     * Fixes
         * Fixed bug where warnings during ``make_pipeline`` were not being raised to the user :pr:`2765`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.32.1"
+__version__ = "0.33.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.32.1',
+    version='0.33.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.33.0 Sep. 14, 2021
### Fixes
- Fixed bug where warnings during ``make_pipeline`` were not being raised to the user #2765
### Changes
- Refactored and removed ``SamplerBase`` class #2775
### Documentation Changes
- Added docstring linting packages ``pydocstyle`` and ``darglint`` to `make-lint` command #2670