### PR TITLE
Add validation for train_data and train_target in prediction explanations

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,7 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+        * Added validation that ``training_data`` and ``training_target`` are not ``None`` in prediction explanations :pr:`2787`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`
         * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`

--- a/evalml/model_understanding/prediction_explanations/explainers.py
+++ b/evalml/model_understanding/prediction_explanations/explainers.py
@@ -86,6 +86,13 @@ def explain_predictions(
         raise ValueError(
             f"Explained indices should be between 0 and {len(input_features) - 1}"
         )
+    if is_time_series(pipeline.problem_type) and (
+        training_target is None or training_data is None
+    ):
+        raise ValueError(
+            "Prediction explanations for time series pipelines requires that training_target and "
+            "training_data are not None"
+        )
 
     pipeline_features = pipeline.compute_estimator_features(
         input_features, y, training_data, training_target
@@ -213,6 +220,13 @@ def explain_predictions_best_worst(
     _update_progress(
         start_time, timer(), ExplainPredictionsStage.PREDICT_STAGE, callback
     )
+    if is_time_series(pipeline.problem_type) and (
+        training_target is None or training_data is None
+    ):
+        raise ValueError(
+            "Prediction explanations for time series pipelines requires that training_target and "
+            "training_data are not None"
+        )
 
     try:
         if is_regression(pipeline.problem_type):

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -123,6 +123,49 @@ def test_explain_predictions_value_errors():
         )
 
 
+@pytest.mark.parametrize("training_target", [None, pd.Series([1, 2, 3])])
+@pytest.mark.parametrize("training_data", [None, pd.DataFrame({"a": [1, 2, 3]})])
+@pytest.mark.parametrize(
+    "problem_type",
+    [
+        ProblemTypes.TIME_SERIES_BINARY,
+        ProblemTypes.TIME_SERIES_REGRESSION,
+        ProblemTypes.TIME_SERIES_MULTICLASS,
+    ],
+)
+def test_time_series_training_target_and_training_data_are_not_None(
+    training_target, training_data, problem_type
+):
+    mock_ts_pipeline = MagicMock(problem_type=problem_type)
+
+    if training_data is not None and training_target is not None:
+        pytest.xfail("No exception raised in this  case")
+
+    with pytest.raises(
+        ValueError, match="training_target and training_data are not None"
+    ):
+        explain_predictions(
+            mock_ts_pipeline,
+            pd.DataFrame({"a": [0, 1, 2, 3, 4]}),
+            y=pd.Series([1, 2, 3, 4, 5]),
+            indices_to_explain=[2],
+            training_data=training_data,
+            training_target=training_target,
+        )
+
+    with pytest.raises(
+        ValueError, match="training_target and training_data are not None"
+    ):
+        explain_predictions_best_worst(
+            mock_ts_pipeline,
+            pd.DataFrame({"a": [0, 1, 2, 3, 4]}),
+            y_true=pd.Series([1, 2, 3, 4, 5]),
+            num_to_explain=1,
+            training_data=training_data,
+            training_target=training_target,
+        )
+
+
 def test_output_format_checked():
     input_features, y_true = pd.DataFrame(data=[range(15)]), pd.Series(range(15))
     with pytest.raises(

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -139,7 +139,7 @@ def test_time_series_training_target_and_training_data_are_not_None(
     mock_ts_pipeline = MagicMock(problem_type=problem_type)
 
     if training_data is not None and training_target is not None:
-        pytest.xfail("No exception raised in this  case")
+        pytest.xfail("No exception raised in this case")
 
     with pytest.raises(
         ValueError, match="training_target and training_data are not None"


### PR DESCRIPTION
### Pull Request Description
Fixes #2738


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
