### PR TITLE
Add time series regression to LightGBMRegressor supported problem types

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Added validation that ``training_data`` and ``training_target`` are not ``None`` in prediction explanations :pr:`2787`
         * Added support for training-only components in pipelines and component graphs :pr:`2776`
         * Added default argument for the parameters value for ``ComponentGraph.instantiate`` :pr:`2796`
+        * Added ``TIME_SERIES_REGRESSION`` to ``LightGBMRegressor's`` supported problem types :pr:`2793`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`
         * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`

--- a/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/lightgbm_regressor.py
@@ -64,7 +64,10 @@ class LightGBMRegressor(Estimator):
     }"""
     model_family = ModelFamily.LIGHTGBM
     """ModelFamily.LIGHTGBM"""
-    supported_problem_types = [ProblemTypes.REGRESSION]
+    supported_problem_types = [
+        ProblemTypes.REGRESSION,
+        ProblemTypes.TIME_SERIES_REGRESSION,
+    ]
     """[ProblemTypes.REGRESSION]"""
 
     SEED_MIN = 0

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -19,7 +19,10 @@ def test_model_family():
 
 
 def test_problem_types():
-    assert set(LightGBMRegressor.supported_problem_types) == {ProblemTypes.REGRESSION}
+    assert set(LightGBMRegressor.supported_problem_types) == {
+        ProblemTypes.REGRESSION,
+        ProblemTypes.TIME_SERIES_REGRESSION,
+    }
 
 
 def test_lightgbm_regressor_random_seed_bounds_seed(X_y_regression):


### PR DESCRIPTION
### Pull Request Description
Fixes #2760 

Performance tests here: https://alteryx.atlassian.net/wiki/spaces/PS/pages/1046872126/Adding+LightGBM+regressor+to+time+series+estimators+used+in+AutoMLSearch

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
