### PR TITLE
Fix PolynomialDetrender test

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,7 +31,7 @@ Release Notes
     * Documentation Changes
         * Added docstring linting packages ``pydocstyle`` and ``darglint`` to `make-lint` command :pr:`2670`
     * Testing Changes
-        * Fixed regex error for non-monotonically increasing ``PolynomialDetrender`` test :pr:``
+        * Fixed regex error for non-monotonically increasing ``PolynomialDetrender`` test :pr:`2809`
 
 .. warning::
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -31,6 +31,7 @@ Release Notes
     * Documentation Changes
         * Added docstring linting packages ``pydocstyle`` and ``darglint`` to `make-lint` command :pr:`2670`
     * Testing Changes
+        * Fixed regex error for non-monotonically increasing ``PolynomialDetrender`` test :pr:``
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -104,7 +104,7 @@ def test_polynomial_detrender_needs_monotonic_index(ts_data):
 
     with pytest.raises(
         ValueError,
-        match="The \\(time\\) index must be sorted \\(monotonically increasing\\)",
+        match="The \\(time\\) index of input must be sorted monotonically increasing",
     ):
         y_shuffled = y.sample(frac=1, replace=False)
         detrender.fit_transform(X, y_shuffled)


### PR DESCRIPTION
Fixes failing `git-test-other` in nightlies.

As part of `sktime`'s upgrade to 0.8.0 and its new support for multivariate forecasters, a simple wording change was made to a `ValueError` exception.
