### PR TITLE
Revert sktime minimum requirement to 0.7.0

### DIFF
--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -2,7 +2,7 @@ name: Nightly unit tests, windows
 
 on:
   schedule:
-      - cron: '0 3 * * *'
+      - cron: '0 7 * * *'
 
 jobs:
   win_unit_tests:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Release Notes
         * Deleted ``EmptyDataChecks`` class :pr:`2794`
     * Documentation Changes
     * Testing Changes
+        * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -102,12 +102,10 @@ def test_polynomial_detrender_needs_monotonic_index(ts_data):
     X, y = ts_data
     detrender = PolynomialDetrender(degree=2)
 
-    with pytest.raises(
-        ValueError,
-        match="The \\(time\\) index of input must be sorted monotonically increasing",
-    ):
+    with pytest.raises(ValueError) as exec_info:
         y_shuffled = y.sample(frac=1, replace=False)
         detrender.fit_transform(X, y_shuffled)
+        assert "monotonically" in str(exec_info.value)
 
     with pytest.raises(
         NotImplementedError,

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -105,7 +105,7 @@ def test_polynomial_detrender_needs_monotonic_index(ts_data):
     with pytest.raises(ValueError) as exec_info:
         y_shuffled = y.sample(frac=1, replace=False)
         detrender.fit_transform(X, y_shuffled)
-        assert "monotonically" in str(exec_info.value)
+    assert "monotonically" in str(exec_info.value)
 
     with pytest.raises(
         NotImplementedError,

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -11,4 +11,4 @@ category_encoders==2.2.2
 statsmodels==0.12.2
 imbalanced-learn==0.8.0
 pmdarima==1.8.0
-sktime==0.8.0
+sktime==0.7.0


### PR DESCRIPTION
### Pull Request Description
Change sktime minimum requirement to 0.7.0 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
