### PR TITLE
Add lint to fix jupyter executed cells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ clean:
 lint:
 	isort --check-only evalml
 	python docs/notebook_version_standardizer.py check-versions
+	python docs/notebook_version_standardizer.py check-execution
 	black evalml -t py39 --check
 	pydocstyle evalml/ --convention=google --add-ignore=D107 --add-select=D400 --match-dir='^(?!(tests)).*'
 	flake8 evalml

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -58,7 +58,7 @@ def _fix_execution_and_output(notebook):
     with open(notebook, "r") as f:
         source = json.load(f)
         for cells in source["cells"]:
-            if cells["cell_type"] == "code" and cells["execution_count"] != 'null':
+            if cells["cell_type"] == "code" and cells["execution_count"] != None:
                 cells["execution_count"] = None
                 cells["outputs"] = []
         source["metadata"]["kernelspec"]["display_name"] = "Python 3"

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -138,9 +138,9 @@ def check_execution():
     executed_notebooks = _get_notebooks_with_executions(notebooks)
     if executed_notebooks:
         executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
-        different_versions = "\n".join(executed_notebooks)
+        executed_notebooks = "\n".join(executed_notebooks)
         raise SystemExit(
-            f"The following notebooks have executed outputs:\n {different_versions}\n"
+            f"The following notebooks have executed outputs:\n {executed_notebooks}\n"
             "Please run make lint-fix to fix this."
         )
 

--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -45,6 +45,40 @@ def _standardize_versions(notebooks, desired_version="3.8.6"):
         _standardize_python_version(notebook, desired_version)
 
 
+def _check_execution_and_output(notebook):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        for cells in source["cells"]:
+            if cells["cell_type"] == "code" and cells["execution_count"] != None:
+                return False
+    return True
+
+
+def _fix_execution_and_output(notebook):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        for cells in source["cells"]:
+            if cells["cell_type"] == "code" and cells["execution_count"] != 'null':
+                cells["execution_count"] = None
+                cells["outputs"] = []
+        source["metadata"]["kernelspec"]["display_name"] = "Python 3"
+        source["metadata"]["kernelspec"]["name"] = "python3"
+    json.dump(source, open(notebook, "w"), indent=1)
+
+
+def _get_notebooks_with_executions(notebooks):
+    executed = []
+    for notebook in notebooks:
+        if not _check_execution_and_output(notebook):
+            executed.append(notebook)
+    return executed
+
+
+def _standardize_outputs(notebooks):
+    for notebook in notebooks:
+        _fix_execution_and_output(notebook)
+
+
 @click.group()
 def cli():
     """no-op"""
@@ -81,12 +115,33 @@ def standardize(desired_version):
     different_versions = _get_notebooks_with_different_versions(
         notebooks, desired_version
     )
+    executed_notebooks = _get_notebooks_with_executions(notebooks)
     if different_versions:
         _standardize_versions(different_versions, desired_version)
         different_versions = ["\t" + notebook for notebook in different_versions]
         different_versions = "\n".join(different_versions)
         click.echo(
             f"Set the notebook version to {desired_version} for:\n {different_versions}"
+        )
+    if executed_notebooks:
+        _standardize_outputs(executed_notebooks)
+        executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
+        executed_notebooks = "\n".join(executed_notebooks)
+        click.echo(
+            f"Removed the outputs for:\n {executed_notebooks}"
+        )
+
+
+@cli.command()
+def check_execution():
+    notebooks = _get_ipython_notebooks(DOCS_PATH)
+    executed_notebooks = _get_notebooks_with_executions(notebooks)
+    if executed_notebooks:
+        executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
+        different_versions = "\n".join(executed_notebooks)
+        raise SystemExit(
+            f"The following notebooks have executed outputs:\n {different_versions}\n"
+            "Please run make lint-fix to fix this."
         )
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series :pr:`2804`
         * Added information about which row indices are outliers in ``OutliersDataCheck`` :pr:`2818`
         * Added verbose flag to top level ``search()`` method :pr:`2813`
+        * Added spport for linting jupyter notebooks and clearing the executed cells :pr:`2829`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`
         * Fixed bug where transformed target values were not used in ``fit`` for time series pipelines :pr:`2780`


### PR DESCRIPTION
fix #2566 

Example usage:
Running 2 different notebooks in different directories:
![diff --git adocssourcedemosfraud ipynb bdocssourcedemosfraud ipynb](https://user-images.githubusercontent.com/22552445/134414222-55634f5b-0caa-48cd-bb94-73a8d75da2cf.png)
![diff git adocssourceuser_guidedata_actions ipynb bdocssourceuser_data_nsn](https://user-images.githubusercontent.com/22552445/134414237-11b81cc9-8bfc-4405-9d62-06ab7459def8.png)

# lint output
![make lint](https://user-images.githubusercontent.com/22552445/134414256-31238a7d-fceb-4dee-93c9-0741e367eb65.png)

# post lint-fix
![Removed the outputs for](https://user-images.githubusercontent.com/22552445/134414263-461b86d5-7a2f-41dc-b110-7f621ebf79b6.png)

The notebooks then become cleaned and are no longer different from the originals
