### PR TITLE
Pin woodwork==0.8.0

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -12,7 +12,7 @@ psutil>=5.6.6
 requirements-parser>=0.2.0
 shap>=0.36.0
 texttable>=1.6.2
-woodwork>=0.8.0,<=0.8.1
+woodwork==0.8.0
 dask>=2.12.0
 featuretools>=0.26.1
 nlp-primitives>=1.1.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,6 +21,7 @@ Release Notes
         * Deleted ``EmptyDataChecks`` class :pr:`2794`
         * Removed data check for checking log distributions in ``make_pipeline`` :pr:`2806`
         * Changed the minimum ``woodwork`` version to 0.8.0 :pr:`2783`
+        * Pinned ``woodwork`` version to 0.8.0 :pr:`2832`
     * Documentation Changes
     * Testing Changes
         * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -29,5 +29,5 @@ shap==0.39.0
 sktime==0.8.0
 statsmodels==0.12.2
 texttable==1.6.4
-woodwork==0.8.1
+woodwork==0.8.0
 xgboost==1.4.2


### PR DESCRIPTION
Closes #2831. Once this issue is merged, we can file a separate issue to unpin our Woodwork dependency :)