### PR TITLE
Remove empty last cell in jupyter notebooks

### DIFF
--- a/docs/notebook_version_standardizer.py
+++ b/docs/notebook_version_standardizer.py
@@ -49,7 +49,7 @@ def _check_execution_and_output(notebook):
     with open(notebook, "r") as f:
         source = json.load(f)
         for cells in source["cells"]:
-            if cells["cell_type"] == "code" and cells["execution_count"] != None:
+            if cells["cell_type"] == "code" and (cells["execution_count"] is not None or cells['outputs']!= []):
                 return False
     return True
 
@@ -58,12 +58,12 @@ def _fix_execution_and_output(notebook):
     with open(notebook, "r") as f:
         source = json.load(f)
         for cells in source["cells"]:
-            if cells["cell_type"] == "code" and cells["execution_count"] != None:
+            if cells["cell_type"] == "code" and cells["execution_count"] is not None:
                 cells["execution_count"] = None
                 cells["outputs"] = []
         source["metadata"]["kernelspec"]["display_name"] = "Python 3"
         source["metadata"]["kernelspec"]["name"] = "python3"
-    json.dump(source, open(notebook, "w"), indent=1)
+    json.dump(source, open(notebook, "w"), ensure_ascii=False, indent=1)
 
 
 def _get_notebooks_with_executions(notebooks):
@@ -77,6 +77,35 @@ def _get_notebooks_with_executions(notebooks):
 def _standardize_outputs(notebooks):
     for notebook in notebooks:
         _fix_execution_and_output(notebook)
+
+
+def _check_delete_empty_cell(notebook, delete=True):
+    with open(notebook, "r") as f:
+        source = json.load(f)
+        cell = source["cells"][-1]
+        if cell["cell_type"] == "code" and cell["source"] == []:
+            # this is an empty cell, which we should delete
+            if delete:
+                source["cells"] = source["cells"][:-1]
+            else:
+                return False
+    if delete:
+        json.dump(source, open(notebook, "w"), ensure_ascii=False, indent=1)
+    else:
+        return True
+
+
+def _get_notebook_with_empty_last_cell(notebooks):
+    empty_last_cell = []
+    for notebook in notebooks:
+        if not _check_delete_empty_cell(notebook, delete=False):
+            empty_last_cell.append(notebook)
+    return empty_last_cell
+
+
+def _remove_notebook_empty_last_cell(notebooks):
+    for notebook in notebooks:
+        _check_delete_empty_cell(notebook, delete=True)
 
 
 @click.group()
@@ -116,6 +145,7 @@ def standardize(desired_version):
         notebooks, desired_version
     )
     executed_notebooks = _get_notebooks_with_executions(notebooks)
+    empty_cells = _get_notebook_with_empty_last_cell(notebooks)
     if different_versions:
         _standardize_versions(different_versions, desired_version)
         different_versions = ["\t" + notebook for notebook in different_versions]
@@ -130,17 +160,32 @@ def standardize(desired_version):
         click.echo(
             f"Removed the outputs for:\n {executed_notebooks}"
         )
+    if empty_cells:
+        _remove_notebook_empty_last_cell(empty_cells)
+        empty_cells = ["\t" + notebook for notebook in empty_cells]
+        empty_cells = "\n".join(empty_cells)
+        click.echo(
+            f"Removed the empty cells for:\n {empty_cells}"
+        )
 
 
 @cli.command()
 def check_execution():
     notebooks = _get_ipython_notebooks(DOCS_PATH)
     executed_notebooks = _get_notebooks_with_executions(notebooks)
+    empty_cells = _get_notebook_with_empty_last_cell(notebooks)
     if executed_notebooks:
         executed_notebooks = ["\t" + notebook for notebook in executed_notebooks]
         executed_notebooks = "\n".join(executed_notebooks)
         raise SystemExit(
             f"The following notebooks have executed outputs:\n {executed_notebooks}\n"
+            "Please run make lint-fix to fix this."
+        )
+    if empty_cells:
+        empty_cells = ["\t" + notebook for notebook in empty_cells]
+        empty_cells = "\n".join(empty_cells)
+        click.echo(
+            f"The following notebooks have empty cells at the end:\n {empty_cells}\n"
             "Please run make lint-fix to fix this."
         )
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Release Notes
         * Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series :pr:`2804`
         * Added information about which row indices are outliers in ``OutliersDataCheck`` :pr:`2818`
         * Added verbose flag to top level ``search()`` method :pr:`2813`
-        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr::`2837`
+        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr:`2837`
         * Added "DROP_ROWS" action to output of ``OutliersDataCheck.validate()`` :pr:`2820`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Release Notes
         * Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series :pr:`2804`
         * Added information about which row indices are outliers in ``OutliersDataCheck`` :pr:`2818`
         * Added verbose flag to top level ``search()`` method :pr:`2813`
-        * Added support for linting jupyter notebooks and clearing the executed cells :pr:`2829`
+        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr::``
         * Added "DROP_ROWS" action to output of ``OutliersDataCheck.validate()`` :pr:`2820`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Release Notes
         * Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series :pr:`2804`
         * Added information about which row indices are outliers in ``OutliersDataCheck`` :pr:`2818`
         * Added verbose flag to top level ``search()`` method :pr:`2813`
-        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr::``
+        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr::`2837`
         * Added "DROP_ROWS" action to output of ``OutliersDataCheck.validate()`` :pr:`2820`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,7 +10,7 @@ Release Notes
         * Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series :pr:`2804`
         * Added information about which row indices are outliers in ``OutliersDataCheck`` :pr:`2818`
         * Added verbose flag to top level ``search()`` method :pr:`2813`
-        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` pr:`2837`
+        * Added support for linting jupyter notebooks and clearing the executed cells and empty cells :pr:`2829` :pr:`2837`
         * Added "DROP_ROWS" action to output of ``OutliersDataCheck.validate()`` :pr:`2820`
     * Fixes
         * Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers :pr:`2782`


### PR DESCRIPTION
A quick change to also handle empty cells in jupyter notebooks in our docs.
Example usage can be seen [here](https://github.com/alteryx/woodwork/pull/1153#issuecomment-926084592) and
![image](https://user-images.githubusercontent.com/22552445/134572860-f3a6c29d-375c-4e4f-a91b-d33220ab83fa.png)
