### PR TITLE
Limit scikit-learn until errors and new features can be addressed

### DIFF
--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.20.0
 numba==0.53
 pandas>=1.2.5
 scipy>=1.5.0
-scikit-learn>=0.24.0
+scikit-learn>=0.24.0,<1.0
 scikit-optimize>=0.8.1
 pyzmq>=20.0.0
 colorama>=0.4.4

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,7 @@ Release Notes
         * Changed the minimum ``woodwork`` version to 0.8.0 :pr:`2783`
         * Pinned ``woodwork`` version to 0.8.0 :pr:`2832`
         * Removed ``model_family`` attribute from ``ComponentBase`` and transformers :pr:`2828`
+        * Limited ``scikit-learn`` until new features and errors can be addressed :pr:`2842`
     * Documentation Changes
     * Testing Changes
         * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`


### PR DESCRIPTION
Fixes: #2841 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
