### PR TITLE
Incorrect parameter for baseline regression pipeline in AutoMLSearch

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,6 +18,7 @@ Release Notes
         * Fixed bug where ``score_pipelines`` method of ``AutoMLSearch`` would not work for time series problems :pr:`2786`
         * Removed ``TargetTransformer`` class :pr:`2833`
         * Added tests to verify ``ComponentGraph`` support by pipelines :pr:`2830`
+        * Fixed incorrect parameter for baseline regression pipeline in ``AutoMLSearch`` :pr:`2847`
     * Changes
         * Changed woodwork initialization to use partial schemas :pr:`2774`
         * Made ``Transformer.transform()`` an abstract method :pr:`2744`

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1213,7 +1213,7 @@ class AutoMLSearch:
             baseline = RegressionPipeline(
                 component_graph=["Baseline Regressor"],
                 custom_name="Mean Baseline Regression Pipeline",
-                parameters={"Baseline Classifier": {"strategy": "mean"}},
+                parameters={"Baseline Regressor": {"strategy": "mean"}},
             )
         else:
             gap = self.problem_configuration["gap"]

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5290,28 +5290,25 @@ def test_baseline_pipeline_properly_initalized(
         X, y = X_y_binary
         score_value = {"Log Loss Binary": 1.0}
         expected_pipeline = BinaryClassificationPipeline(
-            component_graph={"Baseline Classifier": ["Baseline Classifier", "X", "y"]},
-            parameters={"Baseline Classifier": {"strategy": "mode"}},
+            component_graph=["Baseline Classifier"],
             custom_name="Mode Baseline Binary Classification Pipeline",
-            random_seed=0,
+            parameters={"Baseline Classifier": {"strategy": "mode"}},
         )
     elif automl_type == ProblemTypes.MULTICLASS:
         X, y = X_y_multi
         score_value = {"Log Loss Multiclass": 1.0}
         expected_pipeline = MulticlassClassificationPipeline(
-            component_graph={"Baseline Classifier": ["Baseline Classifier", "X", "y"]},
-            parameters={"Baseline Classifier": {"strategy": "mode"}},
+            component_graph=["Baseline Classifier"],
             custom_name="Mode Baseline Multiclass Classification Pipeline",
-            random_seed=0,
+            parameters={"Baseline Classifier": {"strategy": "mode"}},
         )
     elif automl_type == ProblemTypes.REGRESSION:
         X, y = X_y_regression
         score_value = {"R2": 1.0}
         expected_pipeline = RegressionPipeline(
-            component_graph={"Baseline Regressor": ["Baseline Regressor", "X", "y"]},
-            parameters={"Baseline Regressor": {"strategy": "mean"}},
+            component_graph=["Baseline Regressor"],
             custom_name="Mean Baseline Regression Pipeline",
-            random_seed=0,
+            parameters={"Baseline Regressor": {"strategy": "mean"}},
         )
 
     automl = AutoMLSearch(


### PR DESCRIPTION
Right now, `_get_baseline_pipeline` sets the parameter for a baseline classifier component in a baseline regression pipeline. This is incorrect!
```
        elif self.problem_type == ProblemTypes.REGRESSION:
            baseline = RegressionPipeline(
                component_graph=["Baseline Regressor"],
                custom_name="Mean Baseline Regression Pipeline",
                parameters={"Baseline Classifier": {"strategy": "mean"}},
            )
```

This PR updates this to "Baseline Regressor".