### PR TITLE
Check conda versions match pip versions

### DIFF
--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -7,7 +7,7 @@ import os
 CONDA_RECIPE = "/Users/freddy.boulton/sources/personal/evalml-core-feedstock/recipe/meta.yaml"
 EVALML_PATH = "/Users/freddy.boulton/sources/evalml/"
 
-IGNORE_PACKAGES = {"python", "pmdarima"}
+IGNORE_PACKAGES = {"python", "pmdarima", "pyzmq"}
 CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib',
                      'python-graphviz': 'graphviz'}
 

--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -4,9 +4,6 @@ import requirements
 import pathlib
 import os
 
-CONDA_RECIPE = "/Users/freddy.boulton/sources/personal/evalml-core-feedstock/recipe/meta.yaml"
-EVALML_PATH = "/Users/freddy.boulton/sources/evalml/"
-
 IGNORE_PACKAGES = {"python", "pmdarima", "pyzmq"}
 CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib',
                      'python-graphviz': 'graphviz'}

--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -8,7 +8,8 @@ CONDA_RECIPE = "/Users/freddy.boulton/sources/personal/evalml-core-feedstock/rec
 EVALML_PATH = "/Users/freddy.boulton/sources/evalml/"
 
 IGNORE_PACKAGES = {"python", "pmdarima"}
-CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib'}
+CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib',
+                     'python-graphviz': 'graphviz'}
 
 
 @contextmanager

--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -7,7 +7,7 @@ import os
 CONDA_RECIPE = "/Users/freddy.boulton/sources/personal/evalml-core-feedstock/recipe/meta.yaml"
 EVALML_PATH = "/Users/freddy.boulton/sources/evalml/"
 
-IGNORE_PACKAGES = {"python"}
+IGNORE_PACKAGES = {"python", "pmdarima"}
 CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib'}
 
 

--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -26,7 +26,8 @@ def standardize_format(packages):
             continue
         name = CONDA_TO_PIP_NAME.get(package.name, package.name)
         if package.specs:
-            standardized = f"{name}{''.join(package.specs[0])}"
+            all_specs = ",".join([''.join(spec) for spec in package.specs])
+            standardized = f"{name}{all_specs}"
         else:
             standardized = name
         standardized_package_specifiers.append(standardized)

--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -1,0 +1,74 @@
+import yaml
+from contextlib import contextmanager
+import requirements
+import pathlib
+import os
+
+CONDA_RECIPE = "/Users/freddy.boulton/sources/personal/evalml-core-feedstock/recipe/meta.yaml"
+EVALML_PATH = "/Users/freddy.boulton/sources/evalml/"
+
+IGNORE_PACKAGES = {"python"}
+CONDA_TO_PIP_NAME = {"python-kaleido": "kaleido", 'py-xgboost': 'xgboost', 'matplotlib-base': 'matplotlib'}
+
+
+@contextmanager
+def read_conda_yaml(path):
+    with open(path, "rb") as config_file:
+        # Toss out the first line that declares the version since its not supported YAML syntax
+        next(config_file)
+        yield yaml.safe_load(config_file)
+
+
+def standardize_format(packages):
+    standardized_package_specifiers = []
+    for package in packages:
+        if package.name in IGNORE_PACKAGES:
+            continue
+        name = CONDA_TO_PIP_NAME.get(package.name, package.name)
+        if package.specs:
+            standardized = f"{name}{''.join(package.specs[0])}"
+        else:
+            standardized = name
+        standardized_package_specifiers.append(standardized)
+    return standardized_package_specifiers
+
+
+def get_evalml_pip_requirements(evalml_path):
+    core_reqs = open(pathlib.Path(evalml_path, "core-requirements.txt")).readlines()
+    extra_reqs = open(pathlib.Path(evalml_path, "requirements.txt")).readlines()
+    extra_reqs = [req for req in extra_reqs if "-r core-requirements.txt" not in req]
+    all_reqs = core_reqs + extra_reqs
+    return standardize_format(requirements.parse("".join(all_reqs)))
+
+
+def get_evalml_conda_requirements(conda_recipe):
+    with read_conda_yaml(conda_recipe) as recipe:
+        core_reqs = recipe['outputs'][0]['requirements']['run']
+        extra_reqs = recipe['outputs'][1]['requirements']['run']
+        extra_reqs = [package for package in extra_reqs if "evalml-core" not in package]
+        all_reqs = core_reqs + extra_reqs
+    return standardize_format(requirements.parse("\n".join(all_reqs)))
+
+
+def check_versions():
+    conda_recipe_file_path = pathlib.Path(os.getcwd(), 'evalml-core-feedstock', 'recipe', 'meta.yaml')
+    pip_requirements_path = pathlib.Path(os.getcwd())
+    conda_versions = sorted(get_evalml_conda_requirements(conda_recipe_file_path))
+    pip_versions = sorted(get_evalml_pip_requirements(pip_requirements_path))
+    if conda_versions != pip_versions:
+        conda_not_in_pip = set(conda_versions).difference(pip_versions)
+        conda_not_in_pip = ["\t" + version for version in conda_not_in_pip]
+        conda_not_in_pip = "\n".join(conda_not_in_pip)
+
+        pip_not_in_conda = set(pip_versions).difference(conda_versions)
+        pip_not_in_conda = ["\t" + version for version in pip_not_in_conda]
+        pip_not_in_conda = "\n".join(pip_not_in_conda)
+
+        raise SystemExit(
+            f"The following package versions are different in conda from pip:\n {conda_not_in_pip}\n"
+            f"The following package versions are different in pip from conda:\n {pip_not_in_conda}\n"
+        )
+
+
+if __name__ == "__main__":
+    check_versions()

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -35,7 +35,7 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
-          git clone -b latest_release_changes_fixed --single-branch https://github.com/conda-forge/evalml-core-feedstock
+          git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
           pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
     paths:
-#      - 'requirements.txt'
-#      - 'core-requirements.txt'
-#      - 'evalml/tests/dependency_update_check/*.txt'
+      - 'requirements.txt'
+      - 'core-requirements.txt'
+      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   build_conda_pkg:

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
     paths:
-      - 'requirements.txt'
-      - 'core-requirements.txt'
-      - 'evalml/tests/dependency_update_check/*.txt'
+#      - 'requirements.txt'
+#      - 'core-requirements.txt'
+#      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   build_conda_pkg:
@@ -35,7 +35,7 @@ jobs:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
-          git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
+          git clone -b latest_release_changes_fixed --single-branch https://github.com/conda-forge/evalml-core-feedstock
           pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -6,10 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
-#    paths:
-#      - 'requirements.txt'
-#      - 'core-requirements.txt'
-#      - 'evalml/tests/dependency_update_check/*.txt'
+    paths:
+      - 'requirements.txt'
+      - 'core-requirements.txt'
+      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   check_versions:

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -29,11 +29,10 @@ jobs:
           pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate
-          make installdeps-test
+          pip install PyYAML==5.4
       - name: Clone Feedstock & Check Versions
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
-          pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate
           mkdir evalml-core-feedstock/evalml

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -29,7 +29,7 @@ jobs:
           pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate
-          pip install PyYAML==5.4
+          pip install PyYAML==5.4 requirements
       - name: Clone Feedstock & Check Versions
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -1,4 +1,4 @@
-name: Build conda package
+name: Check conda versions
 
 on:
   push:

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     types: [ opened, synchronize ]
     paths:
-#      - 'requirements.txt'
-#      - 'core-requirements.txt'
-#      - 'evalml/tests/dependency_update_check/*.txt'
+      - 'requirements.txt'
+      - 'core-requirements.txt'
+      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   check_versions:

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -29,7 +29,7 @@ jobs:
           pip install virtualenv
           virtualenv test_python -q
           source test_python/bin/activate
-          pip install PyYAML==5.4 requirements
+          pip install -r test-requirements.txt
       - name: Clone Feedstock & Check Versions
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -30,6 +30,7 @@ jobs:
           virtualenv test_python -q
           source test_python/bin/activate
           pip install -r test-requirements.txt
+          pip install requirements-parser>=0.2.0
       - name: Clone Feedstock & Check Versions
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -6,10 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - 'requirements.txt'
-      - 'core-requirements.txt'
-      - 'evalml/tests/dependency_update_check/*.txt'
+#    paths:
+#      - 'requirements.txt'
+#      - 'core-requirements.txt'
+#      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   check_versions:
@@ -36,6 +36,4 @@ jobs:
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
           virtualenv test_python -q
           source test_python/bin/activate
-          mkdir evalml-core-feedstock/evalml
-          cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/
           python .github/conda_version_check.py

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -1,0 +1,41 @@
+name: Build conda package
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ opened, synchronize ]
+    paths:
+#      - 'requirements.txt'
+#      - 'core-requirements.txt'
+#      - 'evalml/tests/dependency_update_check/*.txt'
+
+jobs:
+  build_conda_pkg:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Install Dependencies
+        run: |
+          pip install virtualenv
+          virtualenv test_python -q
+          source test_python/bin/activate
+          make installdeps-test
+      - name: Clone Feedstock, Copy to Container, and Run Update
+        run: |
+          git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
+          pip install virtualenv
+          virtualenv test_python -q
+          source test_python/bin/activate
+          mkdir evalml-core-feedstock/evalml
+          cp -r `ls -A | grep -v "evalml-core-feedstock"` ./evalml-core-feedstock/evalml/
+          python .github/conda_version_check.py

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -33,7 +33,7 @@ jobs:
           pip install requirements-parser>=0.2.0
       - name: Clone Feedstock & Check Versions
         run: |
-          git clone -b latest_release_changes_fixed --single-branch https://github.com/conda-forge/evalml-core-feedstock
+          git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
           virtualenv test_python -q
           source test_python/bin/activate
           mkdir evalml-core-feedstock/evalml

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -30,7 +30,7 @@ jobs:
           virtualenv test_python -q
           source test_python/bin/activate
           make installdeps-test
-      - name: Clone Feedstock, Copy to Container, and Run Update
+      - name: Clone Feedstock & Check Versions
         run: |
           git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
           pip install virtualenv

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -12,7 +12,7 @@ on:
 #      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
-  build_conda_pkg:
+  check_versions:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.8

--- a/.github/workflows/check_conda_pkg_versions.yml
+++ b/.github/workflows/check_conda_pkg_versions.yml
@@ -33,7 +33,7 @@ jobs:
           pip install requirements-parser>=0.2.0
       - name: Clone Feedstock & Check Versions
         run: |
-          git clone -b latest_release_changes --single-branch https://github.com/conda-forge/evalml-core-feedstock
+          git clone -b latest_release_changes_fixed --single-branch https://github.com/conda-forge/evalml-core-feedstock
           virtualenv test_python -q
           source test_python/bin/activate
           mkdir evalml-core-feedstock/evalml

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -32,6 +32,7 @@ Release Notes
     * Documentation Changes
     * Testing Changes
         * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`
+        * Added a test to make sure pip versions match conda versions :pr:`2851`
 
 .. warning::
 


### PR DESCRIPTION
### Pull Request Description

Add a CI job to check that the versions listed in our requirements files (used to install via pip) match the versions listed in our conda recipe (used to install via conda).

This is important because these should be equal to avoid the conda recipe getting stale. XGBoost is a good example of this. In pip, we list `>=1.4.2` but in conda, we have [`<1.3.0`](https://github.com/conda-forge/evalml-core-feedstock/blob/master/recipe/meta.yaml#L70). 

The goal is to check that our pip dependencies match the conda dependencies in `latest_release_changes` whenever we update one of our dependencies.

We check `latest_release_changes` instead of `master` because the `latest_release_changes` branch keeps track of all the changes we need to make prior to making the next conda release.

When we go do the next conda release in the feedstock, [CI will run](https://github.com/conda-forge/evalml-core-feedstock/pull/79) to check that the PR has the same dependencies as `latest_release_changes`

### Example where the check failed
https://github.com/alteryx/evalml/runs/3735325116?check_suite_focus=true

### Example where the check passed
https://github.com/alteryx/evalml/runs/3735846986?check_suite_focus=true

### Example of build_conda_pkg passing
https://github.com/alteryx/evalml/runs/3735847310?check_suite_focus=true

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
