### PR TITLE
Show DeprecationWarning when Sklearn Ensemblers are called

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -30,6 +30,7 @@ Release Notes
         * Pinned ``woodwork`` version to 0.8.0 :pr:`2832`
         * Removed ``model_family`` attribute from ``ComponentBase`` and transformers :pr:`2828`
         * Limited ``scikit-learn`` until new features and errors can be addressed :pr:`2842`
+        * Show DeprecationWarning when Sklearn Ensemblers are called :pr:`2859`
     * Documentation Changes
     * Testing Changes
         * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`

--- a/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
+++ b/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
@@ -1,5 +1,5 @@
 """Stacked Ensemble Base Class."""
-import warnings
+import logging
 
 from evalml.exceptions import EnsembleMissingPipelinesError
 from evalml.model_family import ModelFamily
@@ -52,7 +52,7 @@ class SklearnStackedEnsembleBase(Estimator):
         random_seed=0,
         **kwargs,
     ):
-        warnings.warn(
+        logging.getLogger(__name__).warn(
             "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead.",
             DeprecationWarning,
         )

--- a/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
+++ b/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
@@ -1,4 +1,6 @@
 """Stacked Ensemble Base Class."""
+import warnings
+
 from evalml.exceptions import EnsembleMissingPipelinesError
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components import Estimator
@@ -50,6 +52,10 @@ class SklearnStackedEnsembleBase(Estimator):
         random_seed=0,
         **kwargs,
     ):
+        warnings.warn(
+            "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead.",
+            DeprecationWarning,
+        )
         if not input_pipelines:
             raise EnsembleMissingPipelinesError(
                 "`input_pipelines` must not be None or an empty list."

--- a/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
+++ b/evalml/pipelines/components/ensemble/sklearn_stacked_ensemble_base.py
@@ -1,5 +1,5 @@
 """Stacked Ensemble Base Class."""
-import logging
+import warnings
 
 from evalml.exceptions import EnsembleMissingPipelinesError
 from evalml.model_family import ModelFamily
@@ -52,10 +52,6 @@ class SklearnStackedEnsembleBase(Estimator):
         random_seed=0,
         **kwargs,
     ):
-        logging.getLogger(__name__).warn(
-            "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead.",
-            DeprecationWarning,
-        )
         if not input_pipelines:
             raise EnsembleMissingPipelinesError(
                 "`input_pipelines` must not be None or an empty list."
@@ -102,6 +98,10 @@ class SklearnStackedEnsembleBase(Estimator):
             parameters=parameters,
             component_obj=self._stacking_estimator_class(**sklearn_parameters),
             random_seed=random_seed,
+        )
+        warnings.warn(
+            "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead.",
+            DeprecationWarning,
         )
 
     @property

--- a/evalml/tests/component_tests/test_sklearn_stacked_ensemble_classifier.py
+++ b/evalml/tests/component_tests/test_sklearn_stacked_ensemble_classifier.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -229,3 +230,16 @@ def test_sklearn_stacked_feature_importance(
         NotImplementedError, match="feature_importance is not implemented"
     ):
         clf.feature_importance
+
+
+def test_sklearn_stacked_deprecation_warning(logistic_regression_binary_pipeline_class):
+    input_pipelines = [logistic_regression_binary_pipeline_class(parameters={})]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        SklearnStackedEnsembleClassifier(input_pipelines=input_pipelines)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert (
+            str(w[0].message)
+            == "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead."
+        )

--- a/evalml/tests/component_tests/test_sklearn_stacked_ensemble_regressor.py
+++ b/evalml/tests/component_tests/test_sklearn_stacked_ensemble_regressor.py
@@ -197,7 +197,7 @@ def test_sklearn_stacked_feature_importance(
         clf.feature_importance
 
 
-def test_component_graph_from_list_deprecation_warning(
+def test_sklearn_stacked_deprecation_warning(
     linear_regression_pipeline_class,
 ):
     input_pipelines = [linear_regression_pipeline_class(parameters={})]

--- a/evalml/tests/component_tests/test_sklearn_stacked_ensemble_regressor.py
+++ b/evalml/tests/component_tests/test_sklearn_stacked_ensemble_regressor.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -194,3 +195,18 @@ def test_sklearn_stacked_feature_importance(
         NotImplementedError, match="feature_importance is not implemented"
     ):
         clf.feature_importance
+
+
+def test_component_graph_from_list_deprecation_warning(
+    linear_regression_pipeline_class,
+):
+    input_pipelines = [linear_regression_pipeline_class(parameters={})]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        SklearnStackedEnsembleRegressor(input_pipelines=input_pipelines)
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert (
+            str(w[0].message)
+            == "Scikit-learn based ensemblers will be completely removed in the next release. Utilize the new `StackedEnsembleRegressor` or `StackedEnsembleClassifier` ensembler instead."
+        )


### PR DESCRIPTION
When a sklearn ensembler is instantiated, show a warning that it will removed in the next release. 