### PR TITLE
Release v0.34.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.34.0 Sep. 30, 2021**
+    * Enhancements
         * Updated to work with Woodwork 0.8.1 :pr:`2783`
         * Added validation that ``training_data`` and ``training_target`` are not ``None`` in prediction explanations :pr:`2787`
         * Added support for training-only components in pipelines and component graphs :pr:`2776`
@@ -32,7 +44,6 @@ Release Notes
         * Removed ``model_family`` attribute from ``ComponentBase`` and transformers :pr:`2828`
         * Limited ``scikit-learn`` until new features and errors can be addressed :pr:`2842`
         * Show DeprecationWarning when Sklearn Ensemblers are called :pr:`2859`
-    * Documentation Changes
     * Testing Changes
         * Updated matched assertion message regarding monotonic indices in polynomial detrender tests :pr:`2811`
         * Added a test to make sure pip versions match conda versions :pr:`2851`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -22,4 +22,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.33.0',
+    version='0.34.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.34.0 Oct. 1, 2021
### Enhancements
- Updated to work with Woodwork 0.8.1 #2783
- Added validation that ``training_data`` and ``training_target`` are not ``None`` in prediction explanations #2787
- Added support for training-only components in pipelines and component graphs #2776
- Added default argument for the parameters value for ``ComponentGraph.instantiate`` #2796
- Added ``TIME_SERIES_REGRESSION`` to ``LightGBMRegressor's`` supported problem types #2793
- Added validation to holdout data passed to ``predict`` and ``predict_proba`` for time series #2804
- Added information about which row indices are outliers in ``OutliersDataCheck`` #2818
- Added verbose flag to top level ``search()`` method #2813
- Added support for linting jupyter notebooks and clearing the executed cells and empty cells #2829 #2837
- Added "DROP_ROWS" action to output of ``OutliersDataCheck.validate()`` #2820
- Added the ability of ``AutoMLSearch`` to accept a ``SequentialEngine`` instance as engine input #2838
- Added new label encoder component to EvalML #2853
- Added our own partial dependence implementation #2834
### Fixes
- Fixed bug where ``calculate_permutation_importance`` was not calculating the right value for pipelines with target transformers #2782
- Fixed bug where transformed target values were not used in ``fit`` for time series pipelines #2780
- Fixed bug where ``score_pipelines`` method of ``AutoMLSearch`` would not work for time series problems #2786
- Removed ``TargetTransformer`` class #2833
- Added tests to verify ``ComponentGraph`` support by pipelines #2830
- Fixed incorrect parameter for baseline regression pipeline in ``AutoMLSearch`` #2847
### Changes
- Changed woodwork initialization to use partial schemas #2774
- Made ``Transformer.transform()`` an abstract method #2744
- Deleted ``EmptyDataChecks`` class #2794
- Removed data check for checking log distributions in ``make_pipeline`` #2806
- Changed the minimum ``woodwork`` version to 0.8.0 #2783
- Pinned ``woodwork`` version to 0.8.0 #2832
- Removed ``model_family`` attribute from ``ComponentBase`` and transformers #2828
- Limited ``scikit-learn`` until new features and errors can be addressed #2842
- Show DeprecationWarning when Sklearn Ensemblers are called #2859
### Testing Changes
- Updated matched assertion message regarding monotonic indices in polynomial detrender tests #2811
- Added a test to make sure pip versions match conda versions #2851
### Breaking Changes
- Made ``Transformer.transform()`` an abstract method #2744
- Deleted ``EmptyDataChecks`` class #2794
- Removed data check for checking log distributions in ``make_pipeline`` #2806