### PR TITLE
Revert "Automated Latest Dependency Updates"

### DIFF
--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,4 +1,4 @@
-catboost==1.0.0
+catboost==0.26.1
 click==8.0.1
 cloudpickle==2.0.0
 colorama==0.4.4


### PR DESCRIPTION
Reverts alteryx/evalml#2862 to remove the new Catboost version as main was frozen when perf tests were run.  Just don't want to risk an accidental regression!  