### PR TITLE
Release v0.35.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,6 @@
 Release Notes
 -------------
-**Future Releases**
+**v0.35.0 Oct. 14, 2021**
     * Enhancements
         * Added human-readable pipeline explanations to model understanding :pr:`2861`
         * Updated to support Featuretools 1.0.0 and nlp-primitives 2.0.0 :pr:`2848`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.34.0',
+    version='0.35.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.35.0 Oct. 14, 2021
### Enhancements
- Added human-readable pipeline explanations to model understanding #2861
- Updated to support Featuretools 1.0.0 and nlp-primitives 2.0.0 #2848
### Fixes
- Fixed bug where ``long`` mode for the top level search method was not respected #2875
- Pinned ``cmdstan`` to ``0.28.0`` in ``cmdstan-builder`` to prevent future breaking of support for Prophet #2880
- Added ``Jarque-Bera`` to the ``TargetDistributionDataCheck`` #2891
### Changes
- Updated pipelines to use a label encoder component instead of doing encoding on the pipeline level #2821
- Deleted scikit-learn ensembler #2819
- Refactored pipeline building logic out of ``AutoMLSearch`` and into ``IterativeAlgorithm`` #2854
- Refactored names for methods in ``ComponentGraph`` and ``PipelineBase`` #2902
### Documentation Changes
- Updated ``install.ipynb`` to reflect flexibility for ``cmdstan`` version installation #2880
- Updated the conda section of our contributing guide #2899
### Testing Changes
- Updated ``test_all_estimators`` to account for Prophet being allowed for Python 3.9 #2892
- Updated linux tests to use ``cmdstan-builder==0.0.8`` #2880
### Breaking Changes
- Updated pipelines to use a label encoder component instead of doing encoding on the pipeline level. This means that pipelines will no longer automatically encode non-numerical targets. Please use a label encoder if working with classification problems and non-numeric targets. #2821
- Deleted scikit-learn ensembler #2819
- ``IterativeAlgorithm`` now requires X, y, problem_type as required arguments as well as sampler_name, allowed_model_families, allowed_component_graphs, max_batches, and verbose as optional arguments #2854
- Changed method names of ``fit_features`` and ``compute_final_component_features`` to ``fit_and_transform_all_but_final`` and ``transform_all_but_final`` in ``ComponentGraph``, and ``compute_estimator_features`` to ``transform_all_but_final`` in pipeline classes #2902