### PR TITLE
Fix cost benefit matrix doc formatting

### DIFF
--- a/docs/source/demos/cost_benefit_matrix.ipynb
+++ b/docs/source/demos/cost_benefit_matrix.ipynb
@@ -83,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, let's say that correctly identifying customers who will churn (true positive case) will give us a net profit of \\$400, because it allows us to intervene, incentivize the customer to stay, and sign a new contract. Incorrectly classifying customers who were not going to churn as customers who will churn (false positive case) will cost \\$100 to represent the marketing and effort used to try to retain the user. Not identifying customers who will churn (false negative case) will cost us \\$200 to represent the lost in revenue from losing a customer. Finally, correctly identifying customers who will not churn (true negative case) will not cost us anything (\\$0), as nothing needs to be done for that customer."
+    "In this example, let's say that correctly identifying customers who will churn (true positive case) will give us a net profit of \\\\$400, because it allows us to intervene, incentivize the customer to stay, and sign a new contract. Incorrectly classifying customers who were not going to churn as customers who will churn (false positive case) will cost \\\\$100 to represent the marketing and effort used to try to retain the user. Not identifying customers who will churn (false negative case) will cost us \\\\$200 to represent the lost in revenue from losing a customer. Finally, correctly identifying customers who will not churn (true negative case) will not cost us anything (\\\\$0), as nothing needs to be done for that customer."
    ]
   },
   {

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Fixed bug where ``Oversampler`` didn't consider boolean columns to be categorical :pr:`2980`
     * Changes
     * Documentation Changes
+        * Fixed cost benefit matrix demo formatting :pr:`2990`
     * Testing Changes
 
 .. warning::


### PR DESCRIPTION
Closes #2988

Docs here: https://feature-labs-inc-evalml--2990.com.readthedocs.build/en/2990/demos/cost_benefit_matrix.html
Docs on main: https://evalml.alteryx.com/en/stable/demos/cost_benefit_matrix.html

On this branch:
![image](https://user-images.githubusercontent.com/5422235/139467852-21af6163-2dca-40ed-9b3c-287a742dfb94.png)


On main:
![image](https://user-images.githubusercontent.com/5422235/139467813-a06f84c3-520e-492a-9a7a-973b97d08a02.png)


