### PR TITLE
Add ability for users to define which class is "positive" for label encoder in binary classification case

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Added an algorithm to ``DelayedFeatureTransformer`` to select better lags :pr:`3005`
         * Added test to ensure pickling pipelines preserves thresholds :pr:`3027`
         * Added AutoML function to access ensemble pipeline's input pipelines IDs :pr:`3011`
+        * Added ability to define which class is "positive" for label encoder in binary classification case :pr:`3033`
     * Fixes
         * Fixed bug where ``Oversampler`` didn't consider boolean columns to be categorical :pr:`2980`
         * Fixed permutation importance failing when target is categorical :pr:`3017`

--- a/evalml/model_understanding/decision_boundary.py
+++ b/evalml/model_understanding/decision_boundary.py
@@ -187,8 +187,8 @@ def find_confusion_matrix_per_thresholds(
     pos_preds.index = y.index.tolist()
     neg_class, pos_class = 0, 1
     if pipeline._encoder is not None:
-        pos_class = pipeline._encoder._component_obj.classes_[1]
-        neg_class = pipeline._encoder._component_obj.classes_[0]
+        pos_class = pipeline._encoder.inverse_mapping[1]
+        neg_class = pipeline._encoder.inverse_mapping[0]
     true_pos = y[y == pos_class]
     true_neg = y[y == neg_class]
 

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -86,7 +86,7 @@ class LabelEncoder(Transformer):
                 f"y contains previously unseen labels: {y_unique_values.difference(self.mapping.keys())}"
             )
         y_t = y_ww.map(self.mapping)
-        return X, ww.init_series(y_t)
+        return X, ww.init_series(y_t, logical_type="integer")
 
     def fit_transform(self, X, y):
         """Fit and transform data using the label encoder.

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -12,6 +12,7 @@ class LabelEncoder(Transformer):
     """A transformer that encodes target labels using values between 0 and num_classes - 1.
 
     Args:
+        positive_label (int, str): The label for the class that should be treated as positive (1) for binary classification problems. Ignored for multiclass problems. Defaults to None.
         random_seed (int): Seed for the random number generator. Defaults to 0. Ignored.
     """
 
@@ -22,8 +23,8 @@ class LabelEncoder(Transformer):
     modifies_features = False
     modifies_target = True
 
-    def __init__(self, random_seed=0, **kwargs):
-        parameters = {}
+    def __init__(self, positive_label=None, random_seed=0, **kwargs):
+        parameters = {"positive_label": positive_label}
         parameters.update(kwargs)
 
         label_encoder_obj = SKLabelEncoder()
@@ -48,7 +49,31 @@ class LabelEncoder(Transformer):
         """
         if y is None:
             raise ValueError("y cannot be None!")
-        self._component_obj.fit(y)
+        if self.parameters["positive_label"] is None:
+            self._component_obj.fit(y)
+        else:
+            # assert that binary problem. otherwise, raise valueerror.
+            self.classes_ = set(pd.Series(y).unique())
+            if len(self.classes_) != 2:
+                raise ValueError(
+                    "positive_label should only be set for binary classification targets. Otherwise, positive_label should be None."
+                )
+            try:
+                self.classes_.remove(self.parameters["positive_label"])
+            except KeyError:
+                # positive label not found, user error
+                raise ValueError(
+                    f"positive_label was set to `{self.parameters['positive_label']}` but was not found in the input target data."
+                )
+
+            negative_label = self.classes_.pop()
+            self.mapping = {negative_label: 0, self.parameters["positive_label"]: 1}
+            self.inverse_mapping = {
+                0: negative_label,
+                1: self.parameters["positive_label"],
+            }
+            # check that positive_label in unique_vals, otherwise raise error.
+
         return self
 
     def transform(self, X, y=None):
@@ -67,9 +92,13 @@ class LabelEncoder(Transformer):
         if y is None:
             return X, y
         y_ww = infer_feature_types(y)
-        y_t = self._component_obj.transform(y_ww)
-        y_t = pd.Series(y_t, index=y_ww.index)
-        return X, ww.init_series(y_t)
+        if self.parameters["positive_label"] is None:
+            y_t = self._component_obj.transform(y_ww)
+            y_t = pd.Series(y_t, index=y_ww.index)
+            return X, ww.init_series(y_t)
+        else:
+            y_t = y.map(self.mapping)
+            return X, ww.init_series(y_t)
 
     def fit_transform(self, X, y):
         """Fit and transform data using the label encoder.
@@ -98,6 +127,10 @@ class LabelEncoder(Transformer):
         if y is None:
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
-        y_it = self._component_obj.inverse_transform(y)
-        y_it = infer_feature_types(pd.Series(y_it, index=y_ww.index))
+        if self.parameters["positive_label"] is None:
+
+            y_it = self._component_obj.inverse_transform(y)
+            y_it = infer_feature_types(pd.Series(y_it, index=y_ww.index))
+        else:
+            y_it = infer_feature_types(y_ww.map(self.inverse_mapping))
         return y_it

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -91,7 +91,6 @@ class LabelEncoder(Transformer):
         if self.parameters["positive_label"] is None:
             y_t = self._component_obj.transform(y_ww)
             y_t = pd.Series(y_t, index=y_ww.index)
-            return X, ww.init_series(y_t)
         else:
             y_unique_values = set(pd.Series(y).unique())
             if y_unique_values != self.mapping.keys():
@@ -99,7 +98,7 @@ class LabelEncoder(Transformer):
                     f"y contains previously unseen labels: {y_unique_values.difference(self.mapping.keys())}"
                 )
             y_t = y.map(self.mapping)
-            return X, ww.init_series(y_t)
+        return X, ww.init_series(y_t)
 
     def fit_transform(self, X, y):
         """Fit and transform data using the label encoder.
@@ -129,7 +128,6 @@ class LabelEncoder(Transformer):
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
         if self.parameters["positive_label"] is None:
-
             y_it = self._component_obj.inverse_transform(y)
             y_it = infer_feature_types(pd.Series(y_it, index=y_ww.index))
         else:

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -52,28 +52,24 @@ class LabelEncoder(Transformer):
         if self.parameters["positive_label"] is None:
             self._component_obj.fit(y)
         else:
-            # assert that binary problem. otherwise, raise valueerror.
-            self.classes_ = set(pd.Series(y).unique())
+            classes_ = set(pd.Series(y).unique())
             if len(self.classes_) != 2:
                 raise ValueError(
                     "positive_label should only be set for binary classification targets. Otherwise, positive_label should be None."
                 )
             try:
-                self.classes_.remove(self.parameters["positive_label"])
+                classes_.remove(self.parameters["positive_label"])
             except KeyError:
-                # positive label not found, user error
                 raise ValueError(
                     f"positive_label was set to `{self.parameters['positive_label']}` but was not found in the input target data."
                 )
 
-            negative_label = self.classes_.pop()
+            negative_label = classes_.pop()
             self.mapping = {negative_label: 0, self.parameters["positive_label"]: 1}
             self.inverse_mapping = {
                 0: negative_label,
                 1: self.parameters["positive_label"],
             }
-            # check that positive_label in unique_vals, otherwise raise error.
-
         return self
 
     def transform(self, X, y=None):
@@ -97,6 +93,11 @@ class LabelEncoder(Transformer):
             y_t = pd.Series(y_t, index=y_ww.index)
             return X, ww.init_series(y_t)
         else:
+            y_unique_values = set(pd.Series(y).unique())
+            if y_unique_values != self.mapping.keys():
+                raise ValueError(
+                    f"y contains previously unseen labels: {y_unique_values.difference(self.mapping.keys())}"
+                )
             y_t = y.map(self.mapping)
             return X, ww.init_series(y_t)
 

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -53,7 +53,7 @@ class LabelEncoder(Transformer):
             self._component_obj.fit(y)
         else:
             classes_ = set(pd.Series(y).unique())
-            if len(self.classes_) != 2:
+            if len(classes_) != 2:
                 raise ValueError(
                     "positive_label should only be set for binary classification targets. Otherwise, positive_label should be None."
                 )

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -86,7 +86,7 @@ class LabelEncoder(Transformer):
                 f"y contains previously unseen labels: {y_unique_values.difference(self.mapping.keys())}"
             )
         y_t = y_ww.map(self.mapping)
-        return X, ww.init_series(y_t, logical_type="integer")
+        return X, ww.init_series(y_t)
 
     def fit_transform(self, X, y):
         """Fit and transform data using the label encoder.

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -81,7 +81,7 @@ class LabelEncoder(Transformer):
             return X, y
         y_ww = infer_feature_types(y)
         y_unique_values = set(y_ww.unique())
-        if y_unique_values != self.mapping.keys():
+        if y_unique_values.difference(self.mapping.keys()):
             raise ValueError(
                 f"y contains previously unseen labels: {y_unique_values.difference(self.mapping.keys())}"
             )

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -46,8 +46,8 @@ class LabelEncoder(Transformer):
         """
         if y is None:
             raise ValueError("y cannot be None!")
-
-        self.mapping = {val: i for i, val in enumerate(sorted(y.unique()))}
+        y_ww = infer_feature_types(y)
+        self.mapping = {val: i for i, val in enumerate(sorted(y_ww.unique()))}
         if self.parameters["positive_label"] is not None:
             if len(self.mapping) != 2:
                 raise ValueError(

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -149,7 +149,6 @@ class TimeSeriesClassificationPipeline(TimeSeriesPipelineBase, ClassificationPip
             y_predicted_proba = self.predict_proba_in_sample(X, y, X_train, y_train)
         if any(not o.score_needs_proba for o in objectives):
             y_predicted = self.predict_in_sample(X, y, X_train, y_train)
-            y_predicted = y_predicted.astype(int)
             y_predicted = self._encode_targets(y_predicted)
         return y_predicted, y_predicted_proba
 
@@ -261,6 +260,7 @@ class TimeSeriesBinaryClassificationPipeline(
             proba = proba.iloc[:, 1]
             if objective is None:
                 predictions = proba > self.threshold
+                predictions = predictions.astype(int)
             else:
                 predictions = objective.decision_function(
                     proba, threshold=self.threshold, X=X

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -107,7 +107,6 @@ class TimeSeriesClassificationPipeline(TimeSeriesPipelineBase, ClassificationPip
             raise ValueError(
                 "Cannot call predict_in_sample() on a component graph because the final component is not an Estimator."
             )
-
         features = self.transform_all_but_final(X, y, X_train, y_train)
         predictions = self._estimator_predict(features, y)
         predictions.index = y.index
@@ -150,6 +149,7 @@ class TimeSeriesClassificationPipeline(TimeSeriesPipelineBase, ClassificationPip
             y_predicted_proba = self.predict_proba_in_sample(X, y, X_train, y_train)
         if any(not o.score_needs_proba for o in objectives):
             y_predicted = self.predict_in_sample(X, y, X_train, y_train)
+            y_predicted = y_predicted.astype(int)
             y_predicted = self._encode_targets(y_predicted)
         return y_predicted, y_predicted_proba
 

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1428,7 +1428,8 @@ def test_describe_pipeline(return_dict, verbose, caplog, X_y_binary, AutoMLTestE
         )
         assert automl_dict["pipeline_summary"] == "Baseline Classifier w/ Label Encoder"
         assert automl_dict["parameters"] == {
-            "Baseline Classifier": {"strategy": "mode"}
+            "Label Encoder": {"positive_label": None},
+            "Baseline Classifier": {"strategy": "mode"},
         }
         assert automl_dict["mean_cv_score"] == 1.0
         assert not automl_dict["high_variance_cv"]

--- a/evalml/tests/component_tests/test_label_encoder.py
+++ b/evalml/tests/component_tests/test_label_encoder.py
@@ -125,3 +125,72 @@ def test_label_encoder_inverse_transform():
     y_expected = ww.init_series(pd.Series(["b", "a", "c", "b"]))
     y_inverse_transformed = encoder.inverse_transform(y_encoded)
     assert_series_equal(y_expected, y_inverse_transformed)
+
+
+def test_label_encoder_with_positive_label_multiclass_error():
+    y = pd.Series(["a", "b", "c", "a"])
+    encoder = LabelEncoder(positive_label="a")
+    with pytest.raises(
+        ValueError,
+        match="positive_label should only be set for binary classification targets",
+    ):
+        encoder.fit(None, y)
+
+
+def test_label_encoder_with_positive_label_missing_from_input():
+    y = pd.Series(["a", "b", "a"])
+    encoder = LabelEncoder(positive_label="z")
+    with pytest.raises(
+        ValueError,
+        match="positive_label was set to `z` but was not found in the input target data.",
+    ):
+        encoder.fit(None, y)
+
+
+@pytest.mark.parametrize(
+    "y, positive_label, y_encoded_expected",
+    [
+        (
+            pd.Series([True, False, False, True]),
+            False,
+            pd.Series([0, 1, 1, 0]),
+        ),  # boolean
+        (
+            pd.Series([True, False, False, True]),
+            True,
+            pd.Series([1, 0, 0, 1]),
+        ),  # boolean
+        (
+            pd.Series([0, 1, 1, 0]),
+            0,
+            pd.Series([1, 0, 0, 1]),
+        ),  # int, 0 / 1, encoding should flip
+        (
+            pd.Series([0, 1, 1, 0]),
+            1,
+            pd.Series([0, 1, 1, 0]),
+        ),  # int, 0 / 1, encoding should not change
+        (
+            pd.Series([6, 2, 2, 6]),
+            6,
+            pd.Series([1, 0, 0, 1]),
+        ),  # ints, not 0 / 1, encoding should not change
+        (
+            pd.Series([6, 2, 2, 6]),
+            2,
+            pd.Series([0, 1, 1, 0]),
+        ),  # ints, not 0 / 1, encoding should flip
+        (pd.Series(["b", "a", "a", "b"]), "a", pd.Series([0, 1, 1, 0])),  # categorical
+        (pd.Series(["b", "a", "a", "b"]), "b", pd.Series([1, 0, 0, 1])),  # categorical
+    ],
+)
+def test_label_encoder_with_positive_label(y, positive_label, y_encoded_expected):
+    encoder = LabelEncoder(positive_label=positive_label)
+    _, y_fit_transformed = encoder.fit_transform(None, y)
+
+    assert_series_equal(y_encoded_expected, y_fit_transformed)
+
+    y_inverse_transformed = encoder.inverse_transform(y_fit_transformed)
+    assert_series_equal(ww.init_series(y), y_inverse_transformed)
+
+    # transform array different from original --> can't map

--- a/evalml/tests/component_tests/test_label_encoder.py
+++ b/evalml/tests/component_tests/test_label_encoder.py
@@ -206,6 +206,18 @@ def test_label_encoder_with_positive_label_fit_different_from_transform():
         encoder.transform(None, pd.Series(["x", "y", "x"]))
 
 
+@pytest.mark.parametrize("use_positive_label", [True, False])
+def test_label_encoder_transform_does_not_have_all_labels(use_positive_label):
+    encoder = LabelEncoder(positive_label="a" if use_positive_label else None)
+    y = pd.Series(["a", "b", "b", "a"])
+    encoder.fit(None, y)
+    expected = (
+        pd.Series([1, 1, 1, 1]) if use_positive_label else pd.Series([0, 0, 0, 0])
+    )
+    _, y_transformed = encoder.transform(None, pd.Series(["a", "a", "a", "a"]))
+    assert_series_equal(expected, y_transformed)
+
+
 def test_label_encoder_with_positive_label_with_custom_indices():
     encoder = LabelEncoder(positive_label="a")
     y = pd.Series(["a", "b", "a"])

--- a/evalml/tests/component_tests/test_label_encoder.py
+++ b/evalml/tests/component_tests/test_label_encoder.py
@@ -12,7 +12,7 @@ from evalml.pipelines.components import LabelEncoder
 
 def test_label_encoder_init():
     encoder = LabelEncoder()
-    assert encoder.parameters == {}
+    assert encoder.parameters == {"positive_label": None}
     assert encoder.random_seed == 0
 
 
@@ -202,9 +202,7 @@ def test_label_encoder_with_positive_label_fit_different_from_transform():
     encoder = LabelEncoder(positive_label="a")
     y = pd.Series(["a", "b", "b", "a"])
     encoder.fit(None, y)
-    with pytest.raises(
-        ValueError, match="y contains previously unseen labels: {'x', 'y'}"
-    ):
+    with pytest.raises(ValueError, match="y contains previously unseen labels"):
         encoder.transform(None, pd.Series(["x", "y", "x"]))
 
 

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -312,7 +312,10 @@ def test_describe_pipeline(
                         "numeric_fill_value": None,
                     },
                 },
-                "Label Encoder": {"name": "Label Encoder", "parameters": {}},
+                "Label Encoder": {
+                    "name": "Label Encoder",
+                    "parameters": {"positive_label": None},
+                },
                 "One Hot Encoder": {
                     "name": "One Hot Encoder",
                     "parameters": {
@@ -447,6 +450,7 @@ def test_parameters(logistic_regression_binary_pipeline_class):
     }
     lrp = logistic_regression_binary_pipeline_class(parameters=parameters)
     expected_parameters = {
+        "Label Encoder": {"positive_label": None},
         "Imputer": {
             "categorical_impute_strategy": "most_frequent",
             "numeric_impute_strategy": "median",
@@ -1245,6 +1249,7 @@ def test_component_not_found():
 
 def test_get_default_parameters(logistic_regression_binary_pipeline_class):
     expected_defaults = {
+        "Label Encoder": {"positive_label": None},
         "Imputer": {
             "categorical_impute_strategy": "most_frequent",
             "numeric_impute_strategy": "mean",


### PR DESCRIPTION
Closes #2926.

General question: since we have specific behavior in the label encoder... should we just move away from using sklearn's and completely write our own? There isn't too much additional functionality we get from using sklearn's impl but we could end up with different stack traces depending on whether or not positive_label is defined (if defined, uses our stack traces and errors, if not, uses sklearn's).