### PR TITLE
Simplify `graph_json` output and fix bugs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,10 @@ Release Notes
     * Enhancements
         * Added ``NumWords`` and ``NumCharacters`` primitives to ``TextFeaturizer`` and renamed ``TextFeaturizer` to ``NaturalLanguageFeaturizer`` :pr:`3030`
     * Fixes
+        * Fixed bug where ensembling components could not get converted to JSON format :pr:`3049`
+        * Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format :pr:`3049`
     * Changes
+        * Updated the ``Pipeline.graph_json`` function to return a dictionary of "from" and "to" edges instead of tuples :pr:`3049`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,7 +7,6 @@ Release Notes
         * Fixed bug where ensembling components could not get converted to JSON format :pr:`3049`
         * Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format :pr:`3049`
     * Changes
-        * Updated the ``Pipeline.graph_json`` function to return a dictionary of "from" and "to" edges instead of tuples :pr:`3049`
     * Documentation Changes
     * Testing Changes
 
@@ -15,6 +14,7 @@ Release Notes
 
     **Breaking Changes**
         * Renamed ``TextFeaturizer` to ``NaturalLanguageFeaturizer`` :pr:`3030`
+        * Updated the ``Pipeline.graph_json`` function to return a dictionary of "from" and "to" edges instead of tuples :pr:`3049`
 
 
 **v0.37.0 Nov. 9, 2021**

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -450,8 +450,8 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
                     param_dict[f"{param}_name"] = val.name
                     param_dict[f"{param}_parameters"] = val.parameters
                 else:
-                    if np.issubdtype(type(val), np.number):
-                        val = val.item()
+                    if isinstance(val, np.int64):
+                        val = int(val)
                     param_dict[param] = val
             nodes[comp_] = {"Parameters": param_dict, "Name": att_.name}
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -450,7 +450,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
                     param_dict[f"{param}_name"] = val.name
                     param_dict[f"{param}_parameters"] = val.parameters
                 else:
-                    if isinstance(val, np.int64):
+                    if np.issubdtype(type(val), np.number):
                         val = int(val)
                     param_dict[param] = val
             nodes[comp_] = {"Parameters": param_dict, "Name": att_.name}

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -10,11 +10,12 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 
 import cloudpickle
+import numpy as np
 import pandas as pd
 
 from .components import (
-    ComponentBase,
     PCA,
+    ComponentBase,
     DFSTransformer,
     Estimator,
     LinearDiscriminantAnalysis,
@@ -449,6 +450,8 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
                     param_dict[f"{param}_name"] = val.name
                     param_dict[f"{param}_parameters"] = val.parameters
                 else:
+                    if isinstance(val, np.int64):
+                        val = int(val)
                     param_dict[param] = val
             nodes[comp_] = {"Parameters": param_dict, "Name": att_.name}
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -444,26 +444,30 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             for comp_, att_ in self.component_graph.component_instances.items()
         }
 
-        x_edges = self.component_graph._get_edges(
+        x_edges_list = self.component_graph._get_edges(
             self.component_graph.component_dict, "features"
         )
-        y_edges = self.component_graph._get_edges(
+        y_edges_list = self.component_graph._get_edges(
             self.component_graph.component_dict, "target"
         )
+        x_edges = [{"from": edge[0], "to": edge[1]} for edge in x_edges_list]
+        y_edges = [{"from": edge[0], "to": edge[1]} for edge in y_edges_list]
+
         for (
             component_name,
             component_info,
         ) in self.component_graph.component_dict.items():
             for parent in component_info[1:]:
                 if parent == "X":
-                    x_edges.append(("X", component_name))
+                    x_edges.append({"from": "X", "to": component_name})
                 elif parent == "y":
-                    y_edges.append(("y", component_name))
-        nodes.update({"X": "X", "y": "y"})
+                    y_edges.append({"from": "y", "to": component_name})
+        nodes["X"] = {"Parameters": {}, "Name": "X"}
+        nodes["y"] = {"Parameters": {}, "Name": "y"}
         graph_as_json = {"Nodes": nodes, "x_edges": x_edges, "y_edges": y_edges}
 
         for x_edge in graph_as_json["x_edges"]:
-            if x_edge[0] == "X":
+            if x_edge["from"] == "X":
                 graph_as_json["x_edges"].remove(x_edge)
                 graph_as_json["x_edges"].insert(0, x_edge)
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -434,7 +434,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         y_edges specifies from which component target data is being passed.
         This can be used to build graphs across a variety of visualization tools.
         Template:
-        {"Nodes": {"component_name": {"Name": class_name, "Attributes": parameters_attributes}, ...}},
+        {"Nodes": {"component_name": {"Name": class_name, "Parameters": parameters_attributes}, ...}},
         "x_edges": [[from_component_name, to_component_name], [from_component_name, to_component_name], ...],
         "y_edges": [[from_component_name, to_component_name], [from_component_name, to_component_name], ...]}
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -440,7 +440,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
             dag_json (str): A serialized JSON representation of a DAG structure.
         """
         nodes = {
-            comp_: {"Attributes": att_.parameters, "Name": att_.name}
+            comp_: {"Parameters": att_.parameters, "Name": att_.name}
             for comp_, att_ in self.component_graph.component_instances.items()
         }
 

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -451,7 +451,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
                     param_dict[f"{param}_parameters"] = val.parameters
                 else:
                     if np.issubdtype(type(val), np.number):
-                        val = int(val)
+                        val = val.item()
                     param_dict[param] = val
             nodes[comp_] = {"Parameters": param_dict, "Name": att_.name}
 

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5226,7 +5226,7 @@ def test_graph_automl(X_y_multi):
     for node_, params_ in automl_parameters_.items():
         for key_, val_ in params_.items():
             assert (
-                dag_json["Nodes"][node_]["Attributes"][key_]
+                dag_json["Nodes"][node_]["Parameters"][key_]
                 == automl_parameters_[node_][key_]
             )
 

--- a/evalml/tests/pipeline_tests/test_graphs.py
+++ b/evalml/tests/pipeline_tests/test_graphs.py
@@ -297,7 +297,9 @@ def test_ensemble_as_json():
             "Decision Tree Pipeline - Label Encoder.y",
         ],
     }
-    parameters = {'Random Forest Pipeline - Random Forest Classifier': {'max_depth': np.int64(7)}}
+    parameters = {
+        "Random Forest Pipeline - Random Forest Classifier": {"max_depth": np.int64(7)}
+    }
     pipeline = BinaryClassificationPipeline(component_graph, parameters=parameters)
     dag_str = pipeline.graph_json()
     dag_json = json.loads(dag_str)

--- a/evalml/tests/pipeline_tests/test_graphs.py
+++ b/evalml/tests/pipeline_tests/test_graphs.py
@@ -227,32 +227,34 @@ def test_component_as_json(
     assert isinstance(dag_str, str)
     dag_json = json.loads(dag_str)
     assert isinstance(dag_json, dict)
-    assert dag_json["x_edges"][0][0] == "X"
+    assert dag_json["x_edges"][0]["from"] == "X"
     assert len(expected_nodes.keys()) == len(dag_json["Nodes"].keys()) - 2
     assert dag_json["Nodes"].keys() - expected_nodes.keys() == {"X", "y"}
-    x_edges_set = set()
-    y_edges_set = set()
+    x_edges_expected = []
+    y_edges_expected = []
     for node_, graph_ in expected_nodes.items():
         assert node_ in dag_json["Nodes"]
         comp_name = graph_[0].name if graph_type == "list" else graph_[0]
         assert comp_name == dag_json["Nodes"][node_]["Name"]
         for comp_ in graph_[1:]:
             if comp_ == "X":
-                x_edges_set.add(("X", node_))
+                x_edges_expected.append({"from": "X", "to": node_})
             elif comp_.endswith(".x"):
-                x_edges_set.add((comp_[:-2], node_))
+                x_edges_expected.append({"from": comp_[:-2], "to": node_})
             elif comp_ == "y":
-                y_edges_set.add(("y", node_))
+                y_edges_expected.append({"from": "y", "to": node_})
             else:
-                y_edges_set.add((comp_[:-2], node_))
+                y_edges_expected.append({"from": comp_[:-2], "to": node_})
     for node_, params_ in pipeline_parameters.items():
         for key_, val_ in params_.items():
             assert (
                 dag_json["Nodes"][node_]["Parameters"][key_]
                 == pipeline_parameters[node_][key_]
             )
-    assert x_edges_set == set(tuple(edge_) for edge_ in dag_json["x_edges"])
-    assert y_edges_set == set(tuple(edge_) for edge_ in dag_json["y_edges"])
+    assert len(x_edges_expected) == len(dag_json["x_edges"])
+    assert [edge in dag_json["x_edges"] for edge in x_edges_expected]
+    assert len(y_edges_expected) == len(dag_json["y_edges"])
+    assert [edge in dag_json["y_edges"] for edge in y_edges_expected]
 
 
 def test_ensemble_as_json():

--- a/evalml/tests/pipeline_tests/test_graphs.py
+++ b/evalml/tests/pipeline_tests/test_graphs.py
@@ -297,7 +297,9 @@ def test_ensemble_as_json():
             "Decision Tree Pipeline - Label Encoder.y",
         ],
     }
-    pipeline = BinaryClassificationPipeline(component_graph)
-    dag_json = pipeline.graph_json()
+    parameters = {'Random Forest Pipeline - Random Forest Classifier': {'max_depth': np.int64(7)}}
+    pipeline = BinaryClassificationPipeline(component_graph, parameters=parameters)
+    dag_str = pipeline.graph_json()
+    dag_json = json.loads(dag_str)
 
-    assert dag_json["Nodes"].keys() == component_graph.keys()
+    assert list(dag_json["Nodes"].keys()) == list(component_graph.keys()) + ["X", "y"]


### PR DESCRIPTION
Closes #3038 

Also fixes two bugs that prevented some pipelines from getting JSON serialized:
- Ensemble components store an entire estimator object as the "final_estimator" parameter. This code saves that estimator as "final_estimator_name" and "final_estimator_parameters" instead.
- JSON cannot serialize the `np.int64` datatype, which is the type returned by `Integer` ranges for hyperparameter searches. This can be changed within the `Integer()` call, but that was too many places across the code base for this PR, so I left the fix within `graph_json` itself. In the future, however, it might be better practice to move over to having `Integer` generate `int` types instead of `np.int64`.