### PR TITLE
Add pipeline threshold to confusion matrix returns

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
         * Added in error message when fit and predict/predict_proba data types are different :pr:`3036`
         * Fixed bug where ensembling components could not get converted to JSON format :pr:`3049`
         * Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format :pr:`3049`
-        * Included confusion matrix at the pipeline threshold for ``find_confusion_matrix_per_threshold`` :pr:``
+        * Included confusion matrix at the pipeline threshold for ``find_confusion_matrix_per_threshold`` :pr:`3080`
     * Changes
         * Delete ``predict_uses_y`` estimator attribute :pr:`3069`
     * Documentation Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Added in error message when fit and predict/predict_proba data types are different :pr:`3036`
         * Fixed bug where ensembling components could not get converted to JSON format :pr:`3049`
         * Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format :pr:`3049`
+        * Included confusion matrix at the pipeline threshold for ``find_confusion_matrix_per_threshold`` :pr:``
     * Changes
         * Delete ``predict_uses_y`` estimator attribute :pr:`3069`
     * Documentation Changes

--- a/evalml/model_understanding/decision_boundary.py
+++ b/evalml/model_understanding/decision_boundary.py
@@ -181,7 +181,7 @@ def find_confusion_matrix_per_thresholds(
         raise ValueError("Expected a fitted binary classification pipeline")
     X = infer_feature_types(X)
     y = infer_feature_types(y)
-
+    pipeline_thresh = 0.5 if pipeline.threshold is None else pipeline.threshold
     proba = pipeline.predict_proba(X)
     pos_preds = proba.iloc[:, -1]
     pos_preds.index = y.index.tolist()
@@ -201,6 +201,9 @@ def find_confusion_matrix_per_thresholds(
         bins = [i / n_bins for i in range(n_bins + 1)]
     else:
         bins = np.histogram_bin_edges(pos_preds, bins="fd", range=(0, 1))
+    if pipeline_thresh not in bins:
+        bins = np.sort(np.append(bins, pipeline_thresh))
+
     pos_skew, _ = np.histogram(true_pos_preds, bins=bins)
     neg_skew, _ = np.histogram(true_neg_preds, bins=bins)
     data_ranges = _find_data_between_ranges(pos_preds, bins, top_k)

--- a/evalml/tests/model_understanding_tests/test_decision_boundary.py
+++ b/evalml/tests/model_understanding_tests/test_decision_boundary.py
@@ -15,6 +15,7 @@ from evalml.model_understanding.decision_boundary import (
     _precision,
     _recall,
 )
+from evalml.objectives import AccuracyBinary, BalancedAccuracyBinary, Precision, F1
 
 
 @pytest.mark.parametrize(
@@ -403,3 +404,15 @@ def test_find_confusion_matrix_json(
     object_dict = result["objectives"]
     assert object_dict == obj_dict
     pd.testing.assert_frame_equal(res_df, df)
+
+
+@pytest.mark.parametrize("threshold,expected_len", [(0.5, 20), (None, 20), (0.6789012, 21)])
+def test_find_confusion_matrix_pipeline_threshold(threshold, expected_len, logistic_regression_binary_pipeline_class, X_y_binary):
+    bcp = logistic_regression_binary_pipeline_class({})
+    X, y = X_y_binary
+    bcp.fit(X, y)
+    bcp.threshold = threshold
+    res_df, _ = find_confusion_matrix_per_thresholds(bcp, X, y, n_bins=20)
+    assert len(res_df) == expected_len
+    if threshold is not None:
+        assert threshold in res_df.index

--- a/evalml/tests/model_understanding_tests/test_decision_boundary.py
+++ b/evalml/tests/model_understanding_tests/test_decision_boundary.py
@@ -15,12 +15,6 @@ from evalml.model_understanding.decision_boundary import (
     _precision,
     _recall,
 )
-from evalml.objectives import (
-    F1,
-    AccuracyBinary,
-    BalancedAccuracyBinary,
-    Precision,
-)
 
 
 @pytest.mark.parametrize(

--- a/evalml/tests/model_understanding_tests/test_decision_boundary.py
+++ b/evalml/tests/model_understanding_tests/test_decision_boundary.py
@@ -15,7 +15,12 @@ from evalml.model_understanding.decision_boundary import (
     _precision,
     _recall,
 )
-from evalml.objectives import AccuracyBinary, BalancedAccuracyBinary, Precision, F1
+from evalml.objectives import (
+    F1,
+    AccuracyBinary,
+    BalancedAccuracyBinary,
+    Precision,
+)
 
 
 @pytest.mark.parametrize(
@@ -406,8 +411,12 @@ def test_find_confusion_matrix_json(
     pd.testing.assert_frame_equal(res_df, df)
 
 
-@pytest.mark.parametrize("threshold,expected_len", [(0.5, 20), (None, 20), (0.6789012, 21)])
-def test_find_confusion_matrix_pipeline_threshold(threshold, expected_len, logistic_regression_binary_pipeline_class, X_y_binary):
+@pytest.mark.parametrize(
+    "threshold,expected_len", [(0.5, 20), (None, 20), (0.6789012, 21)]
+)
+def test_find_confusion_matrix_pipeline_threshold(
+    threshold, expected_len, logistic_regression_binary_pipeline_class, X_y_binary
+):
     bcp = logistic_regression_binary_pipeline_class({})
     X, y = X_y_binary
     bcp.fit(X, y)


### PR DESCRIPTION
fix #3079 

There are 2 potential issues that I want to raise, although they are not severe enough to block this PR from being merged. 
First is the aesthetic of the index when it is very granular, as can be seen here:
![image](https://user-images.githubusercontent.com/22552445/142505853-fae4c34d-6630-426e-8522-1c5978c586d3.png)
Note that the threshold is `0.99999...`, but looking at the dataframe, it just shows as `1.0`, which could be confusing for OS users. By grabbing the index itself,, we can see the actual value. We could stringify the index to have them appear, but this might be annoying for our internal use:
![image](https://user-images.githubusercontent.com/22552445/142506096-053a1629-282e-46c4-93d4-4cd302fe0203.png)

The other is when our optimized pipeline threshold doesn't match the best threshold chosen through this method. This can be seen in the problem above, but also can be seen here:
![image](https://user-images.githubusercontent.com/22552445/142506203-cc104f2c-7fb3-4de1-9855-5dff7dd6958d.png)

Above, the pipeline is optimized using `accuracy binary`, and we see the pipeline threshold `0.360321` actually has a worse performance value compared to `0.5` with accuracy, which is the ideal value `find_confusion_matrix_per_thresholds` finds. The differences here are likely how we're finding the optimal threshold, with our `optimize_thresholds` using gradient descent, and our current method using a simple linear scan. Is this disparity an issue for our users? Discussing with @freddyaboulton, it could be confusing when our optimal thresholds don't match up. However, what would be the best approach to fix this, if necessary?

Again, these two issues shouldn't block the merge of this PR, but are both things I wanted to bring up for discussion.