### PR TITLE
Return details from `TargetDistributionDataCheck` as floats rather string

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format :pr:`3049`
     * Changes
         * Delete ``predict_uses_y`` estimator attribute :pr:`3069`
+        * Change ``DateTimeFeaturizer`` to use corresponding Featuretools primitives :pr:`3081`
     * Documentation Changes
         * Updated docs to use data check action methods rather than manually cleaning data :pr:`3050`
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -14,6 +14,7 @@ Release Notes
     * Changes
         * Delete ``predict_uses_y`` estimator attribute :pr:`3069`
         * Change ``DateTimeFeaturizer`` to use corresponding Featuretools primitives :pr:`3081`
+        * Updated ``TargetDistributionDataCheck`` to return metadata details as floats rather strings :pr:`3085`
     * Documentation Changes
         * Updated docs to use data check action methods rather than manually cleaning data :pr:`3050`
     * Testing Changes

--- a/evalml/data_checks/target_distribution_data_check.py
+++ b/evalml/data_checks/target_distribution_data_check.py
@@ -38,7 +38,7 @@ class TargetDistributionDataCheck(DataCheck):
             ...                   "data_check_name": "TargetDistributionDataCheck",
             ...                   "level": "warning",
             ...                   "code": "TARGET_LOGNORMAL_DISTRIBUTION",
-            ...                   "details": {"shapiro-statistic/pvalue": '0.8/0.045', "columns": None, "rows": None}}],
+            ...                   "details": {"normalization_method": "shapiro", "statistic": 0.8, "p-value": 0.045, "columns": None, "rows": None}}],
             ...     "actions": [{'code': 'TRANSFORM_TARGET',
             ...                  "data_check_name": "TargetDistributionDataCheck",
             ...                  'metadata': {'transformation_strategy': 'lognormal',
@@ -95,11 +95,16 @@ class TargetDistributionDataCheck(DataCheck):
             )
             return results
 
-        is_log_distribution, normalization_test_string, norm_test_og = _detect_log_distribution_helper(y)
+        (
+            is_log_distribution,
+            normalization_test_string,
+            norm_test_og,
+        ) = _detect_log_distribution_helper(y)
         if is_log_distribution:
             details = {
                 "normalization_method": normalization_test_string,
-                "pvalue": round(norm_test_og.statistic, 1)/round(norm_test_og.pvalue, 3)
+                "statistic": round(norm_test_og.statistic, 1),
+                "p-value": round(norm_test_og.pvalue, 3),
             }
             results["warnings"].append(
                 DataCheckWarning(
@@ -139,8 +144,8 @@ def _detect_log_distribution_helper(y):
     norm_test_og = normalization_test(y_new)
     norm_test_log = normalization_test(np.log(y_new))
 
-   # If the p-value of the log transformed target is greater than or equal to the p-value of the original target
+    # If the p-value of the log transformed target is greater than or equal to the p-value of the original target
     # with outliers dropped, then it would imply that the log transformed target has more of a normal distribution
     if norm_test_log.pvalue >= norm_test_og.pvalue:
-            return True, normalization_test_string, norm_test_og
+        return True, normalization_test_string, norm_test_og
     return False, normalization_test_string, norm_test_og

--- a/evalml/data_checks/target_distribution_data_check.py
+++ b/evalml/data_checks/target_distribution_data_check.py
@@ -129,6 +129,7 @@ class TargetDistributionDataCheck(DataCheck):
 
 
 def _detect_log_distribution_helper(y):
+    """Helper method to detect log distribution. Returns boolean, the normalization test used, and test statistics."""
     normalization_test = shapiro if len(y) <= 5000 else jarque_bera
     normalization_test_string = "shapiro" if len(y) <= 5000 else "jarque_bera"
     # Check if a normal distribution is detected with p-value above 0.05

--- a/evalml/data_checks/target_distribution_data_check.py
+++ b/evalml/data_checks/target_distribution_data_check.py
@@ -95,32 +95,11 @@ class TargetDistributionDataCheck(DataCheck):
             )
             return results
 
-        normalization_test = shapiro if len(y) <= 5000 else jarque_bera
-        normalization_test_string = "shapiro" if len(y) <= 5000 else "jarque_bera"
-        # Check if a normal distribution is detected with p-value above 0.05
-        if normalization_test(y).pvalue >= 0.05:
-            return results
-
-        y_new = round(y, 6)
-        if any(y <= 0):
-            y_new = y + abs(y.min()) + 1
-
-        y_new = y_new[
-            y_new < (y_new.mean() + 3 * round(y.std(), 3))
-        ]  # Drop values greater than 3 standard deviations
-        norm_test_og = normalization_test(y_new)
-        norm_test_log = normalization_test(np.log(y_new))
-
-        log_detected = False
-
-        # If the p-value of the log transformed target is greater than or equal to the p-value of the original target
-        # with outliers dropped, then it would imply that the log transformed target has more of a normal distribution
-        if norm_test_log.pvalue >= norm_test_og.pvalue:
-            log_detected = True
-
-        if log_detected:
+        is_log_distribution, normalization_test_string, norm_test_og = _detect_log_distribution_helper(y)
+        if is_log_distribution:
             details = {
-                f"{normalization_test_string}-statistic/pvalue": f"{round(norm_test_og.statistic, 1)}/{round(norm_test_og.pvalue, 3)}"
+                "normalization_method": normalization_test_string,
+                "pvalue": round(norm_test_og.statistic, 1)/round(norm_test_og.pvalue, 3)
             }
             results["warnings"].append(
                 DataCheckWarning(
@@ -142,3 +121,26 @@ class TargetDistributionDataCheck(DataCheck):
             )
 
         return results
+
+
+def _detect_log_distribution_helper(y):
+    normalization_test = shapiro if len(y) <= 5000 else jarque_bera
+    normalization_test_string = "shapiro" if len(y) <= 5000 else "jarque_bera"
+    # Check if a normal distribution is detected with p-value above 0.05
+    if normalization_test(y).pvalue >= 0.05:
+        return False, normalization_test_string, None
+
+    y_new = round(y, 6)
+    if any(y <= 0):
+        y_new = y + abs(y.min()) + 1
+    y_new = y_new[
+        y_new < (y_new.mean() + 3 * round(y.std(), 3))
+    ]  # Drop values greater than 3 standard deviations
+    norm_test_og = normalization_test(y_new)
+    norm_test_log = normalization_test(np.log(y_new))
+
+   # If the p-value of the log transformed target is greater than or equal to the p-value of the original target
+    # with outliers dropped, then it would imply that the log transformed target has more of a normal distribution
+    if norm_test_log.pvalue >= norm_test_og.pvalue:
+            return True, normalization_test_string, norm_test_og
+    return False, normalization_test_string, norm_test_og

--- a/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/datetime_featurizer.py
@@ -1,40 +1,40 @@
 """Transformer that can automatically extract features from datetime columns."""
 import numpy as np
+import pandas as pd
 import woodwork as ww
+from featuretools.primitives import Hour, Month, Weekday, Year
 
 from evalml.pipelines.components.transformers import Transformer
 from evalml.utils import infer_feature_types
 
 
 def _extract_year(col, encode_as_categories=False):
-    return col.dt.year, None
+    return Year()(col), None
 
 
-_month_to_int_mapping = {
-    "January": 0,
-    "February": 1,
-    "March": 2,
-    "April": 3,
-    "May": 4,
-    "June": 5,
-    "July": 6,
-    "August": 7,
-    "September": 8,
-    "October": 9,
-    "November": 10,
-    "December": 11,
+_int_to_month_mapping = {
+    0: "January",
+    1: "February",
+    2: "March",
+    3: "April",
+    4: "May",
+    5: "June",
+    6: "July",
+    7: "August",
+    8: "September",
+    9: "October",
+    10: "November",
+    11: "December",
 }
 
 
 def _extract_month(col, encode_as_categories=False):
-    months = col.dt.month_name()
-    months_unique = months.unique()
-    months_encoded = months.map(lambda m: _month_to_int_mapping.get(m, np.nan))
+    month = Month()
+    months = month(col) - 1
+    months_unique = pd.Series(months.unique())
     if encode_as_categories:
-        months_encoded = ww.init_series(months_encoded, logical_type="Categorical")
-    return months_encoded, {
-        m: _month_to_int_mapping.get(m, np.nan) for m in months_unique
-    }
+        months = ww.init_series(months, logical_type="Categorical")
+    return months, {_int_to_month_mapping.get(m, np.nan): m for m in months_unique}
 
 
 _day_to_int_mapping = {
@@ -48,17 +48,29 @@ _day_to_int_mapping = {
 }
 
 
+_int_to_day_mapping = {
+    0: "Sunday",
+    1: "Monday",
+    2: "Tuesday",
+    3: "Wednesday",
+    4: "Thursday",
+    5: "Friday",
+    6: "Saturday",
+}
+
+
 def _extract_day_of_week(col, encode_as_categories=False):
-    days = col.dt.day_name()
+    wd = Weekday()
+    days = wd(col) + 1
+    days = days.replace(7, 0)
     days_unique = days.unique()
-    days_encoded = days.map(lambda d: _day_to_int_mapping.get(d, np.nan))
     if encode_as_categories:
-        days_encoded = ww.init_series(days_encoded, logical_type="Categorical")
-    return days_encoded, {d: _day_to_int_mapping.get(d, np.nan) for d in days_unique}
+        days = ww.init_series(days, logical_type="Categorical")
+    return days, {_int_to_day_mapping.get(d, np.nan): d for d in days_unique}
 
 
 def _extract_hour(col, encode_as_categories=False):
-    return col.dt.hour, None
+    return Hour()(col), None
 
 
 class DateTimeFeaturizer(Transformer):

--- a/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
+++ b/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
@@ -120,7 +120,8 @@ def test_target_distribution_data_check_warning_action(
         test_og = statistic(y)
 
         details = {
-            f"{name}-statistic/pvalue": f"{round(test_og.statistic, 1)}/{round(test_og.pvalue, 3)}"
+            "normalization_method": name,
+            "pvalue": round(test_og.statistic, 1)}/{round(test_og.pvalue, 3)}
         }
         assert target_dist_ == {
             "warnings": [

--- a/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
+++ b/evalml/tests/data_checks_tests/test_target_distribution_data_check.py
@@ -121,7 +121,8 @@ def test_target_distribution_data_check_warning_action(
 
         details = {
             "normalization_method": name,
-            "pvalue": round(test_og.statistic, 1)}/{round(test_og.pvalue, 3)}
+            "statistic": round(test_og.statistic, 1),
+            "p-value": round(test_og.pvalue, 3),
         }
         assert target_dist_ == {
             "warnings": [


### PR DESCRIPTION
Closes #2943. I chose not to keep the string representation and moved the calculations into a separate helper method, but open to discussion if we feel like the string representation is helpful in addition to the float values.