### PR TITLE
Release v.0.38.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.38.0 Nov. 27, 2021**
+    * Enhancements
         * Added ``data_check_name`` attribute to the data check action class :pr:`3034`
         * Added ``NumWords`` and ``NumCharacters`` primitives to ``TextFeaturizer`` and renamed ``TextFeaturizer` to ``NaturalLanguageFeaturizer`` :pr:`3030`
         * Added support for ``scikit-learn > 1.0.0`` :pr:`3051`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.37.0',
+    version='0.38.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.38.0 Nov. 29, 2021
### Enhancements
- Added ``data_check_name`` attribute to the data check action class #3034
- Added ``NumWords`` and ``NumCharacters`` primitives to ``TextFeaturizer`` and renamed ``TextFeaturizer` to ``NaturalLanguageFeaturizer`` #3030
- Added support for ``scikit-learn > 1.0.0`` #3051
- Required the ``date_index`` parameter to be specified for time series problems  in ``AutoMLSearch`` #3041
- Allowed time series pipelines to predict on test datasets whose length is less than or equal to the ``forecast_horizon``. Also allowed the test set index to start at 0. #3071
- Enabled time series pipeline to predict on data with features that are not known-in-advanced #3094
### Fixes
- Added in error message when fit and predict/predict_proba data types are different #3036
- Fixed bug where ensembling components could not get converted to JSON format #3049
- Fixed bug where components with tuned integer hyperparameters could not get converted to JSON format #3049
- Included confusion matrix at the pipeline threshold for ``find_confusion_matrix_per_threshold`` #3080
- Fixed bug where One Hot Encoder would error out if a non-categorical feature had a missing value #3083
- Fixed bug where features created from categorical columns by ``Delayed Feature Transformer`` would be inferred as categorical #3083
### Changes
- Delete ``predict_uses_y`` estimator attribute #3069
- Change ``DateTimeFeaturizer`` to use corresponding Featuretools primitives #3081
- Updated ``TargetDistributionDataCheck`` to return metadata details as floats rather strings #3085
- Removed dependency on ``psutil`` package #3093
### Documentation Changes
- Updated docs to use data check action methods rather than manually cleaning data #3050
### Testing Changes
- Updated integration tests to use ``make_pipeline_from_actions`` instead of private method #3047
### Breaking Changes
- Added ``data_check_name`` attribute to the data check action class #3034
- Renamed ``TextFeaturizer` to ``NaturalLanguageFeaturizer`` #3030
- Updated the ``Pipeline.graph_json`` function to return a dictionary of "from" and "to" edges instead of tuples #3049
- Delete ``predict_uses_y`` estimator attribute #3069
- Changed time series problems in ``AutoMLSearch`` to need a not-``None`` ``date_index`` #3041
- Changed the ``DelayedFeatureTransformer`` to throw a ``ValueError`` during fit if the ``date_index`` is ``None`` #3041
- Passing ``X=None`` to ``DelayedFeatureTransformer`` is deprecated #3041