### PR TITLE
Change default parameters for feature selectors

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
         * Renamed ``DelayedFeatureTransformer`` to ``TimeSeriesFeaturizer`` and enhanced it to compute rolling features :pr:`3028`
     * Fixes
+        * Default parameters for ``RFRegressorSelectFromModel`` and ``RFClassifierSelectFromModel`` has been fixed to avoid selecting all features :pr:`3110`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
@@ -28,11 +28,11 @@ class RFClassifierSelectFromModel(FeatureSelector):
     name = "RF Classifier Select From Model"
     hyperparameter_ranges = {
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean"],
+        "threshold": ["mean", "median"],
     }
     """{
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean"],
+        "threshold": ["mean", "median"],
     }"""
 
     def __init__(
@@ -41,7 +41,7 @@ class RFClassifierSelectFromModel(FeatureSelector):
         n_estimators=10,
         max_depth=None,
         percent_features=0.5,
-        threshold="mean",
+        threshold="median",
         n_jobs=-1,
         random_seed=0,
         **kwargs,

--- a/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
@@ -29,11 +29,11 @@ class RFClassifierSelectFromModel(FeatureSelector):
     name = "RF Classifier Select From Model"
     hyperparameter_ranges = {
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean", -np.inf],
+        "threshold": ["mean"],
     }
     """{
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean", -np.inf],
+        "threshold": ["mean"],
     }"""
 
     def __init__(
@@ -42,7 +42,7 @@ class RFClassifierSelectFromModel(FeatureSelector):
         n_estimators=10,
         max_depth=None,
         percent_features=0.5,
-        threshold=-np.inf,
+        threshold="mean",
         n_jobs=-1,
         random_seed=0,
         **kwargs,

--- a/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_classifier_feature_selector.py
@@ -1,5 +1,4 @@
 """Component that selects top features based on importance weights using a Random Forest classifier."""
-import numpy as np
 from sklearn.ensemble import RandomForestClassifier as SKRandomForestClassifier
 from sklearn.feature_selection import SelectFromModel as SkSelect
 from skopt.space import Real

--- a/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
@@ -1,5 +1,4 @@
 """Component that selects top features based on importance weights using a Random Forest regresor."""
-import numpy as np
 from sklearn.ensemble import RandomForestRegressor as SKRandomForestRegressor
 from sklearn.feature_selection import SelectFromModel as SkSelect
 from skopt.space import Real

--- a/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
@@ -28,11 +28,11 @@ class RFRegressorSelectFromModel(FeatureSelector):
     name = "RF Regressor Select From Model"
     hyperparameter_ranges = {
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean"],
+        "threshold": ["mean", "median"],
     }
     """{
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean"],
+        "threshold": ["mean", "median"],
     }"""
 
     def __init__(
@@ -41,7 +41,7 @@ class RFRegressorSelectFromModel(FeatureSelector):
         n_estimators=10,
         max_depth=None,
         percent_features=0.5,
-        threshold="mean",
+        threshold="median",
         n_jobs=-1,
         random_seed=0,
         **kwargs,

--- a/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
@@ -29,11 +29,11 @@ class RFRegressorSelectFromModel(FeatureSelector):
     name = "RF Regressor Select From Model"
     hyperparameter_ranges = {
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean", -np.inf],
+        "threshold": ["mean"],
     }
     """{
         "percent_features": Real(0.01, 1),
-        "threshold": ["mean", -np.inf],
+        "threshold": ["mean"],
     }"""
 
     def __init__(
@@ -42,7 +42,7 @@ class RFRegressorSelectFromModel(FeatureSelector):
         n_estimators=10,
         max_depth=None,
         percent_features=0.5,
-        threshold=-np.inf,
+        threshold="mean",
         n_jobs=-1,
         random_seed=0,
         **kwargs,

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -888,6 +888,10 @@ def test_transformer_transform_output_type(X_y_binary):
                 component, SelectByType
             ):
                 assert transform_output.shape == (X.shape[0], 0)
+            elif isinstance(component, RFRegressorSelectFromModel):
+                assert transform_output.shape == (X.shape[0], 2)
+            elif isinstance(component, RFClassifierSelectFromModel):
+                assert transform_output.shape == (X.shape[0], 5)
             elif isinstance(component, PCA) or isinstance(
                 component, LinearDiscriminantAnalysis
             ):
@@ -915,6 +919,10 @@ def test_transformer_transform_output_type(X_y_binary):
                 component, SelectByType
             ):
                 assert transform_output.shape == (X.shape[0], 0)
+            elif isinstance(component, RFRegressorSelectFromModel):
+                assert transform_output.shape == (X.shape[0], 2)
+            elif isinstance(component, RFClassifierSelectFromModel):
+                assert transform_output.shape == (X.shape[0], 5)
             elif isinstance(component, PCA) or isinstance(
                 component, LinearDiscriminantAnalysis
             ):

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -889,9 +889,9 @@ def test_transformer_transform_output_type(X_y_binary):
             ):
                 assert transform_output.shape == (X.shape[0], 0)
             elif isinstance(component, RFRegressorSelectFromModel):
-                assert transform_output.shape == (X.shape[0], 2)
+                assert transform_output.shape == (X.shape[0], 10)
             elif isinstance(component, RFClassifierSelectFromModel):
-                assert transform_output.shape == (X.shape[0], 5)
+                assert transform_output.shape == (X.shape[0], 10)
             elif isinstance(component, PCA) or isinstance(
                 component, LinearDiscriminantAnalysis
             ):
@@ -920,9 +920,9 @@ def test_transformer_transform_output_type(X_y_binary):
             ):
                 assert transform_output.shape == (X.shape[0], 0)
             elif isinstance(component, RFRegressorSelectFromModel):
-                assert transform_output.shape == (X.shape[0], 2)
+                assert transform_output.shape == (X.shape[0], 10)
             elif isinstance(component, RFClassifierSelectFromModel):
-                assert transform_output.shape == (X.shape[0], 5)
+                assert transform_output.shape == (X.shape[0], 10)
             elif isinstance(component, PCA) or isinstance(
                 component, LinearDiscriminantAnalysis
             ):


### PR DESCRIPTION
This PR proposes changing the default parameters for `RFRegressorSelectFromModel` and `RFClassifierSelectFromModel`. The current, incorrect, behavior of these components is as follows:

- `number_features=None`, `percent_features=0.5`, and `threshold=-np.inf`
- max features is then calculated as: 
```
max_features = (
            max(1, int(percent_features * number_features)) if number_features else None
        )
```
- therefore, `max_features = None`
- with `max_features == None and `threshold=-np.inf`, the component will select every feature with importance above `-np.inf` which is every feature available.

Performance tests using default algorithm:
[fs_parameters_tests.zip](https://github.com/alteryx/evalml/files/7637092/fs_parameters_tests.zip)