### PR TITLE
Add DataCheck to validate time series problem configuration parameters

### DIFF
--- a/docs/source/api_index.rst
+++ b/docs/source/api_index.rst
@@ -417,6 +417,7 @@ Data Check Classes
     evalml.data_checks.DateTimeNaNDataCheck
     evalml.data_checks.NaturalLanguageNaNDataCheck
     evalml.data_checks.DateTimeFormatDataCheck
+    evalml.data_checks.TimeSeriesParametersDataCheck
     evalml.data_checks.DataChecks
     evalml.data_checks.DefaultDataChecks
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Renamed ``DelayedFeatureTransformer`` to ``TimeSeriesFeaturizer`` and enhanced it to compute rolling features :pr:`3028`
+        * Added ``TimeSeriesParametersDataCheck`` to verify the time series parameters are valid given the number of splits in cross validation :pr:`3111`
     * Fixes
         * Default parameters for ``RFRegressorSelectFromModel`` and ``RFClassifierSelectFromModel`` has been fixed to avoid selecting all features :pr:`3110`
     * Changes

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -57,6 +57,7 @@ from evalml.problem_types import (
 )
 from evalml.tuners import SKOptTuner
 from evalml.utils import convert_to_seconds, infer_feature_types
+from evalml.utils.gen_utils import contains_all_ts_parameters
 from evalml.utils.logger import (
     get_logger,
     log_subtitle,
@@ -791,14 +792,9 @@ class AutoMLSearch:
 
     def _validate_problem_configuration(self, problem_configuration=None):
         if is_time_series(self.problem_type):
-            required_parameters = {"date_index", "gap", "max_delay", "forecast_horizon"}
-            if not problem_configuration or not all(
-                p in problem_configuration for p in required_parameters
-            ):
-                raise ValueError(
-                    "problem_configuration must be a dict containing values for at least the date_index, gap, max_delay, "
-                    f"and forecast_horizon parameters. Received {problem_configuration}."
-                )
+            is_valid, msg = contains_all_ts_parameters(problem_configuration)
+            if not is_valid:
+                raise ValueError(msg)
             if problem_configuration["date_index"] is None:
                 raise ValueError("date_index cannot be None!")
         return problem_configuration or {}

--- a/evalml/automl/utils.py
+++ b/evalml/automl/utils.py
@@ -90,6 +90,7 @@ def make_data_splitter(
             gap=problem_configuration.get("gap"),
             max_delay=problem_configuration.get("max_delay"),
             date_index=problem_configuration.get("date_index"),
+            forecast_horizon=problem_configuration.get("forecast_horizon"),
         )
     if X.shape[0] > _LARGE_DATA_ROW_THRESHOLD:
         return TrainingValidationSplit(

--- a/evalml/data_checks/__init__.py
+++ b/evalml/data_checks/__init__.py
@@ -21,3 +21,4 @@ from .datetime_nan_data_check import DateTimeNaNDataCheck
 from .natural_language_nan_data_check import NaturalLanguageNaNDataCheck
 from .target_distribution_data_check import TargetDistributionDataCheck
 from .datetime_format_data_check import DateTimeFormatDataCheck
+from .ts_parameters_data_check import TimeSeriesParametersDataCheck

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -108,3 +108,8 @@ class DataCheckMessageCode(Enum):
 
     DATETIME_IS_NOT_MONOTONIC = "datetime_is_not_monotonic"
     """Message code for when the datetime values are not monotonically increasing."""
+
+    TIMESERIES_PARAMETERS_NOT_COMPATIBLE_WITH_SPLIT = (
+        "timeseries_parameters_not_compatible_with_split"
+    )
+    """Message code when the time series parameters are too large for the smallest data split."""

--- a/evalml/data_checks/ts_parameters_data_check.py
+++ b/evalml/data_checks/ts_parameters_data_check.py
@@ -9,14 +9,14 @@ from evalml.utils.gen_utils import (
 class TimeSeriesParametersDataCheck(DataCheck):
     """Checks whether the time series parameters are compatible with data splitting.
 
-    If gap + max_delay + forecast_horizon > X.shape[0] // (n_splits + 1)
+    If `gap + max_delay + forecast_horizon > X.shape[0] // (n_splits + 1)`
 
     then the feature engineering window is larger than the smallest split. This will cause the
     pipeline to create features from data that does not exist, which will cause errors.
 
     Args:
         problem_configuration (dict): Dict containing problem_configuration parameters.
-        n_splits (int): Number of time series split.
+        n_splits (int): Number of time series splits.
     """
 
     def __init__(self, problem_configuration, n_splits):

--- a/evalml/data_checks/ts_parameters_data_check.py
+++ b/evalml/data_checks/ts_parameters_data_check.py
@@ -22,7 +22,7 @@ class TimeSeriesParametersDataCheck(DataCheck):
     def __init__(self, problem_configuration, n_splits):
         is_valid, msg = contains_all_ts_parameters(problem_configuration)
         if not is_valid:
-            raise ValueError(problem_configuration)
+            raise ValueError(msg)
 
         self.gap = problem_configuration["gap"]
         self.forecast_horizon = problem_configuration["forecast_horizon"]

--- a/evalml/data_checks/ts_parameters_data_check.py
+++ b/evalml/data_checks/ts_parameters_data_check.py
@@ -1,0 +1,64 @@
+"""Data check that checks whether the time series parameters are compatible with the data size."""
+from evalml.data_checks import DataCheck, DataCheckError, DataCheckMessageCode
+from evalml.utils.gen_utils import (
+    are_ts_parameters_valid_for_split,
+    contains_all_ts_parameters,
+)
+
+
+class TimeSeriesParametersDataCheck(DataCheck):
+    """Checks whether the time series parameters are compatible with data splitting.
+
+    If gap + max_delay + forecast_horizon > X.shape[0] // (n_splits + 1)
+
+    then the feature engineering window is larger than the smallest split. This will cause the
+    pipeline to create features from data that does not exist, which will cause errors.
+
+    Args:
+        problem_configuration (dict): Dict containing problem_configuration parameters.
+        n_splits (int): Number of time series split.
+    """
+
+    def __init__(self, problem_configuration, n_splits):
+        is_valid, msg = contains_all_ts_parameters(problem_configuration)
+        if not is_valid:
+            raise ValueError(problem_configuration)
+
+        self.gap = problem_configuration["gap"]
+        self.forecast_horizon = problem_configuration["forecast_horizon"]
+        self.max_delay = problem_configuration["max_delay"]
+        self.n_splits = n_splits
+
+    def validate(self, X, y=None):
+        """Check if the time series parameters are compatible with data splitting.
+
+        Args:
+            X (pd.DataFrame, np.ndarray): Features.
+            y (pd.Series, np.ndarray): Ignored.  Defaults to None.
+
+        Returns:
+            dict: dict with a DataCheckError if parameters are too big for the split sizes.
+
+        """
+        results = {"warnings": [], "errors": [], "actions": []}
+
+        validation = are_ts_parameters_valid_for_split(
+            gap=self.gap,
+            max_delay=self.max_delay,
+            forecast_horizon=self.forecast_horizon,
+            n_splits=self.n_splits,
+            n_obs=X.shape[0],
+        )
+        if not validation.is_valid:
+            results["errors"].append(
+                DataCheckError(
+                    message=validation.msg,
+                    data_check_name=self.name,
+                    message_code=DataCheckMessageCode.TIMESERIES_PARAMETERS_NOT_COMPATIBLE_WITH_SPLIT,
+                    details={
+                        "max_window_size": validation.max_window_size,
+                        "min_split_size": validation.smallest_split_size,
+                    },
+                ).to_dict()
+            )
+        return results

--- a/evalml/data_checks/ts_parameters_data_check.py
+++ b/evalml/data_checks/ts_parameters_data_check.py
@@ -34,7 +34,7 @@ class TimeSeriesParametersDataCheck(DataCheck):
 
         Args:
             X (pd.DataFrame, np.ndarray): Features.
-            y (pd.Series, np.ndarray): Ignored.  Defaults to None.
+            y (pd.Series, np.ndarray): Ignored. Defaults to None.
 
         Returns:
             dict: dict with a DataCheckError if parameters are too big for the split sizes.

--- a/evalml/preprocessing/data_splitters/time_series_split.py
+++ b/evalml/preprocessing/data_splitters/time_series_split.py
@@ -8,7 +8,7 @@ from evalml.utils.gen_utils import are_ts_parameters_valid_for_split
 class TimeSeriesSplit(BaseCrossValidator):
     """Rolling Origin Cross Validation for time series problems.
 
-    The max_delay, gap, and forecast_horizon parameters are just used to validate that the requested split size
+    The max_delay, gap, and forecast_horizon parameters are only used to validate that the requested split size
     is not too small given these parameters.
 
     Args:

--- a/evalml/preprocessing/data_splitters/time_series_split.py
+++ b/evalml/preprocessing/data_splitters/time_series_split.py
@@ -18,7 +18,7 @@ class TimeSeriesSplit(BaseCrossValidator):
             of rows of the current split to avoid "throwing out" more data than in necessary. Defaults to 0.
         gap (int): Number of time units separating the data used to generate features and the data to forecast on.
             Defaults to 0.
-        forecast_horizon (int): Number of time units to forecast. Defaults to 0.
+        forecast_horizon (int): Number of time units to forecast. Defaults to 1.
         date_index (str): Name of the column containing the datetime information used to order the data. Defaults to None.
         n_splits (int): number of data splits to make. Defaults to 3.
 

--- a/evalml/tests/automl_tests/parallel_tests/test_automl_dask.py
+++ b/evalml/tests/automl_tests/parallel_tests/test_automl_dask.py
@@ -327,7 +327,7 @@ def test_score_pipelines_passes_X_train_y_train(
             "date_index": "date",
             "gap": 0,
             "forecast_horizon": 1,
-            "max_delay": 2,
+            "max_delay": 1,
         },
         engine=engine_str,
     )

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -3703,9 +3703,9 @@ def test_timeseries_baseline_init_with_correct_gap_max_delay(AutoMLTestEnv, ts_d
         problem_type="time series regression",
         problem_configuration={
             "date_index": "date",
-            "gap": 6,
+            "gap": 2,
             "max_delay": 3,
-            "forecast_horizon": 7,
+            "forecast_horizon": 1,
         },
         max_iterations=1,
     )
@@ -3717,21 +3717,21 @@ def test_timeseries_baseline_init_with_correct_gap_max_delay(AutoMLTestEnv, ts_d
     assert automl.best_pipeline.parameters == {
         "pipeline": {
             "date_index": "date",
-            "gap": 6,
+            "gap": 2,
             "max_delay": 0,
-            "forecast_horizon": 7,
+            "forecast_horizon": 1,
         },
         "Time Series Featurizer": {
             "date_index": "date",
             "delay_features": False,
             "delay_target": True,
             "max_delay": 0,
-            "gap": 6,
-            "forecast_horizon": 7,
+            "gap": 2,
+            "forecast_horizon": 1,
             "conf_level": 0.05,
             "rolling_window_size": 0.25,
         },
-        "Time Series Baseline Estimator": {"forecast_horizon": 7, "gap": 6},
+        "Time Series Baseline Estimator": {"forecast_horizon": 1, "gap": 2},
     }
 
 

--- a/evalml/tests/automl_tests/test_automl_search_regression.py
+++ b/evalml/tests/automl_tests/test_automl_search_regression.py
@@ -420,13 +420,13 @@ def test_automl_allowed_component_graphs_search(
 @pytest.mark.parametrize("freq", ["D", "MS"])
 def test_automl_supports_time_series_regression(freq, AutoMLTestEnv, ts_data):
     X, y = ts_data
-    X["date"] = pd.date_range(start="1/1/2018", periods=X.shape[0], freq=freq)
+    X["date"] = pd.date_range(start="1/1/2018", periods=31, freq=freq)
 
     configuration = {
         "date_index": "date",
         "gap": 0,
         "max_delay": 0,
-        "forecast_horizon": 10,
+        "forecast_horizon": 6,
         "delay_target": False,
         "delay_features": True,
     }

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -74,7 +74,12 @@ def test_make_data_splitter_default(problem_type, large_data):
         ProblemTypes.TIME_SERIES_BINARY,
         ProblemTypes.TIME_SERIES_MULTICLASS,
     ]:
-        problem_configuration = {"gap": 1, "max_delay": 7, "date_index": "foo"}
+        problem_configuration = {
+            "gap": 1,
+            "max_delay": 7,
+            "date_index": "foo",
+            "forecast_horizon": 4,
+        }
 
     data_splitter = make_data_splitter(
         X, y, problem_type, problem_configuration=problem_configuration
@@ -112,6 +117,7 @@ def test_make_data_splitter_default(problem_type, large_data):
         assert data_splitter.n_splits == 3
         assert data_splitter.gap == 1
         assert data_splitter.max_delay == 7
+        assert data_splitter.forecast_horizon == 4
         assert data_splitter.date_index == "foo"
 
 

--- a/evalml/tests/automl_tests/test_time_series_split.py
+++ b/evalml/tests/automl_tests/test_time_series_split.py
@@ -35,7 +35,7 @@ def test_time_series_split_n_splits_too_big(gap, max_delay, forecast_horizon, n_
     )
     X = pd.DataFrame({"features": range(15)})
     with pytest.raises(
-        ValueError, match="Please use a smaller number of splits or collect more data."
+        ValueError, match="Please use a smaller number of splits"
     ):
         list(splitter.split(X))
 

--- a/evalml/tests/automl_tests/test_time_series_split.py
+++ b/evalml/tests/automl_tests/test_time_series_split.py
@@ -34,8 +34,6 @@ def test_time_series_split_n_splits_too_big(gap, max_delay, forecast_horizon, n_
         date_index="date",
     )
     X = pd.DataFrame({"features": range(15)})
-    # Each split would have 15 // 5 = 3 data points. However, this is smaller than the number of data_points required
-    # for max_delay and gap
     with pytest.raises(
         ValueError, match="Please use a smaller number of splits or collect more data."
     ):

--- a/evalml/tests/automl_tests/test_time_series_split.py
+++ b/evalml/tests/automl_tests/test_time_series_split.py
@@ -21,8 +21,18 @@ def test_time_series_split_init():
         _ = list(ts_split.split(X=pd.DataFrame(), y=pd.Series([])))
 
 
-def test_time_series_split_n_splits_too_big():
-    splitter = TimeSeriesSplit(gap=7, n_splits=4, max_delay=3, date_index=None)
+@pytest.mark.parametrize(
+    "gap,max_delay,forecast_horizon,n_splits",
+    [[7, 3, 1, 4], [0, 3, 2, 3], [1, 1, 1, 4]],
+)
+def test_time_series_split_n_splits_too_big(gap, max_delay, forecast_horizon, n_splits):
+    splitter = TimeSeriesSplit(
+        gap=gap,
+        max_delay=max_delay,
+        forecast_horizon=forecast_horizon,
+        n_splits=n_splits,
+        date_index="date",
+    )
     X = pd.DataFrame({"features": range(15)})
     # Each split would have 15 // 5 = 3 data points. However, this is smaller than the number of data_points required
     # for max_delay and gap
@@ -33,20 +43,17 @@ def test_time_series_split_n_splits_too_big():
 
 
 @pytest.mark.parametrize(
-    "max_delay,gap,date_index",
+    "max_delay,gap,forecast_horizon,date_index",
     [
-        (0, 0, "Date"),
-        (1, 0, None),
-        (2, 0, "Date"),
-        (0, 3, None),
-        (1, 1, "Date"),
-        (4, 2, None),
+        (0, 0, 1, "Date"),
+        (1, 0, 1, None),
+        (2, 0, 1, "Date"),
+        (0, 3, 1, None),
+        (1, 1, 1, "Date"),
     ],
 )
-@pytest.mark.parametrize(
-    "X_none,y_none", [(False, False), (True, False), (False, True)]
-)
-def test_time_series_split(max_delay, gap, date_index, X_none, y_none):
+@pytest.mark.parametrize("y_none", [False, True])
+def test_time_series_split(max_delay, gap, forecast_horizon, date_index, y_none):
     X = pd.DataFrame({"features": range(1, 32)})
     y = pd.Series(range(1, 32))
 
@@ -78,21 +85,23 @@ def test_time_series_split(max_delay, gap, date_index, X_none, y_none):
         (pd.Index(range(24)), pd.Index(range(24, 31))),
     ]
 
-    if X_none:
-        X = None
     if y_none:
         y = None
 
-    ts_split = TimeSeriesSplit(gap=gap, max_delay=max_delay, date_index=date_index)
+    ts_split = TimeSeriesSplit(
+        gap=gap,
+        max_delay=max_delay,
+        forecast_horizon=forecast_horizon,
+        date_index=date_index,
+    )
     for i, (train, test) in enumerate(ts_split.split(X, y)):
-        if not X_none:
-            X_train, X_test = X.iloc[train], X.iloc[test]
-            if date_index:
-                pd.testing.assert_index_equal(X_train.index, answer_dt[i][0])
-                pd.testing.assert_index_equal(X_test.index, answer_dt[i][1])
-            else:
-                pd.testing.assert_index_equal(X_train.index, answer[i][0])
-                pd.testing.assert_index_equal(X_test.index, answer[i][1])
+        X_train, X_test = X.iloc[train], X.iloc[test]
+        if date_index:
+            pd.testing.assert_index_equal(X_train.index, answer_dt[i][0])
+            pd.testing.assert_index_equal(X_test.index, answer_dt[i][1])
+        else:
+            pd.testing.assert_index_equal(X_train.index, answer[i][0])
+            pd.testing.assert_index_equal(X_test.index, answer[i][1])
         if not y_none:
             y_train, y_test = y.iloc[train], y.iloc[test]
             pd.testing.assert_index_equal(y_train.index, answer[i][0])

--- a/evalml/tests/automl_tests/test_time_series_split.py
+++ b/evalml/tests/automl_tests/test_time_series_split.py
@@ -34,9 +34,7 @@ def test_time_series_split_n_splits_too_big(gap, max_delay, forecast_horizon, n_
         date_index="date",
     )
     X = pd.DataFrame({"features": range(15)})
-    with pytest.raises(
-        ValueError, match="Please use a smaller number of splits"
-    ):
+    with pytest.raises(ValueError, match="Please use a smaller number of splits"):
         list(splitter.split(X))
 
 

--- a/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
+++ b/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
@@ -7,6 +7,14 @@ from evalml.data_checks import (
 )
 
 
+def test_time_series_param_data_check_raises_value_error():
+    with pytest.raises(
+        ValueError,
+        match="containing values for at least the date_index, gap, max_delay",
+    ):
+        TimeSeriesParametersDataCheck({}, n_splits=3)
+
+
 @pytest.mark.parametrize(
     "gap,max_delay,forecast_horizon,n_obs,n_splits,is_valid",
     [

--- a/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
+++ b/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import pytest
+
+from evalml.data_checks import (
+    DataCheckMessageCode,
+    TimeSeriesParametersDataCheck,
+)
+
+
+@pytest.mark.parametrize(
+    "gap,max_delay,forecast_horizon,n_obs,n_splits,is_valid",
+    [
+        [0, 5, 2, 100, 3, True],
+        [0, 50, 1, 100, 3, False],
+        [0, 24, 1, 100, 3, False],
+        [0, 24, 1, 100, 2, True],
+        [1, 23, 1, 100, 3, False],
+        [1, 8, 2, 100, 9, False],
+    ],
+)
+def test_time_series_param_data_check(
+    gap, max_delay, forecast_horizon, n_obs, n_splits, is_valid
+):
+
+    config = {
+        "gap": gap,
+        "max_delay": max_delay,
+        "forecast_horizon": forecast_horizon,
+        "date_index": "date",
+    }
+    data_check = TimeSeriesParametersDataCheck(config, n_splits)
+    X = pd.DataFrame({"feature": range(n_obs)})
+    results = data_check.validate(X)
+    code = DataCheckMessageCode.TIMESERIES_PARAMETERS_NOT_COMPATIBLE_WITH_SPLIT.name
+    if not is_valid:
+        assert len(results["errors"]) == 1
+        assert results["errors"][0]["details"] == {
+            "max_window_size": gap + max_delay + forecast_horizon,
+            "min_split_size": n_obs // (n_splits + 1),
+            "columns": None,
+            "rows": None,
+        }
+        assert results["errors"][0]["code"] == code
+    else:
+        assert results == {"warnings": [], "errors": [], "actions": []}

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -12,7 +12,9 @@ from evalml.pipelines.components import ComponentBase
 from evalml.utils.gen_utils import (
     SEED_BOUNDS,
     _rename_column_names_to_numeric,
+    are_ts_parameters_valid_for_split,
     classproperty,
+    contains_all_ts_parameters,
     convert_to_seconds,
     deprecate_arg,
     get_importable_subclasses,
@@ -715,3 +717,26 @@ def test_deprecate_arg():
         assert str(warn[0].message).startswith(
             "Argument 'foo' has been deprecated in favor of 'bar'"
         )
+
+
+def test_contains_all_ts_parameters():
+    is_valid, msg = contains_all_ts_parameters(
+        {"date_index": "date", "max_delay": 1, "forecast_horizon": 3, "gap": 7}
+    )
+    assert is_valid and not msg
+
+    is_valid, msg = contains_all_ts_parameters({"date_index": "date"})
+
+    assert not is_valid and msg
+
+
+def test_are_ts_parameters_valid():
+    result = are_ts_parameters_valid_for_split(
+        gap=1, max_delay=4, forecast_horizon=2, n_obs=20, n_splits=3
+    )
+    assert not result.is_valid and result.msg
+
+    result = are_ts_parameters_valid_for_split(
+        gap=1, max_delay=4, forecast_horizon=2, n_obs=200, n_splits=3
+    )
+    assert result.is_valid and not result.msg

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -566,8 +566,8 @@ def are_ts_parameters_valid_for_split(
         TsParameterValidationResult - named tuple with four fields
             is_valid (bool): True if parameters are valid.
             msg (str): Contains error message to display. Empty if is_valid.
-            smallest_split_size (int): smallest split size given n_obs and n_splits.
-            max_window_size (int): max window size given gap, max_delay, forecast_horizon.
+            smallest_split_size (int): Smallest split size given n_obs and n_splits.
+            max_window_size (int): Max window size given gap, max_delay, forecast_horizon.
     """
     split_size = n_obs // (n_splits + 1)
     window_size = gap + max_delay + forecast_horizon

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -578,6 +578,6 @@ def are_ts_parameters_valid_for_split(
             f"the smallest split would have {split_size} observations. "
             f"Since {gap + max_delay + forecast_horizon} (gap + max_delay + forecast_horizon)  > {split_size}, "
             "then at least one of the splits would be empty by the time it reaches the pipeline. "
-            "Please use a smaller number of splits or collect more data."
+            "Please use a smaller number of splits, reduce one or more these parameters, or collect more data."
         )
     return _validation_result(not msg, msg, split_size, window_size)


### PR DESCRIPTION
### Pull Request Description
Fixes #3103 and also updates the time series data splitter to use the same logic as the data check to validate the parameters. This was something the splitter was doing before, but it was buggy given the addition of `forecast_horizon` . 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
