### PR TITLE
Nullable Types: Make Pipeline (Reloaded)

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,6 +25,7 @@ Release Notes
         * Cleaned up and refactored ``InvalidTargetDataCheck`` implementation and docstring :pr:`3122`
         * Removed indices information from the output of ``HighlyNullDataCheck``'s ``validate()`` method :pr:`3092`
         * Added ``ReplaceNullableTypes`` component to prepare for handling pandas nullable types. :pr:`3090`
+        * Updated ``make_pipeline`` for handling pandas nullable types in preprocessing pipeline. :pr:`3124`
         * Removed unused ``EnsembleMissingPipelinesError`` exception definition :pr:`3131`
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -25,7 +25,7 @@ Release Notes
         * Cleaned up and refactored ``InvalidTargetDataCheck`` implementation and docstring :pr:`3122`
         * Removed indices information from the output of ``HighlyNullDataCheck``'s ``validate()`` method :pr:`3092`
         * Added ``ReplaceNullableTypes`` component to prepare for handling pandas nullable types. :pr:`3090`
-        * Updated ``make_pipeline`` for handling pandas nullable types in preprocessing pipeline. :pr:`3124`
+        * Updated ``make_pipeline`` for handling pandas nullable types in preprocessing pipeline. :pr:`3129`
         * Removed unused ``EnsembleMissingPipelinesError`` exception definition :pr:`3131`
     * Documentation Changes
     * Testing Changes

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -94,7 +94,7 @@ class DefaultAlgorithm(AutoMLAlgorithm):
         )
 
         self.X = infer_feature_types(X, ignore_nullable_types=True)
-        self.y = infer_feature_types(y)
+        self.y = infer_feature_types(y, ignore_nullable_types=True)
         self.problem_type = problem_type
         self.sampler_name = sampler_name
 
@@ -186,13 +186,14 @@ class DefaultAlgorithm(AutoMLAlgorithm):
         estimators = self._naive_estimators()
         pipelines = [
             make_pipeline(
-                self.X,
-                self.y,
-                estimator,
-                self.problem_type,
+                X = self.X,
+                y = self.y,
+                estimator = estimator,
+                problem_type = self.problem_type,
                 sampler_name=self.sampler_name,
                 extra_components=feature_selector,
                 extra_components_position="after_preprocessing",
+                parameters=self._pipeline_params
             )
             for estimator in estimators
         ]

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -93,7 +93,7 @@ class DefaultAlgorithm(AutoMLAlgorithm):
             random_seed=random_seed,
         )
 
-        self.X = infer_feature_types(X)
+        self.X = infer_feature_types(X, ignore_nullable_types=True)
         self.y = infer_feature_types(y)
         self.problem_type = problem_type
         self.sampler_name = sampler_name

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -186,14 +186,14 @@ class DefaultAlgorithm(AutoMLAlgorithm):
         estimators = self._naive_estimators()
         pipelines = [
             make_pipeline(
-                X = self.X,
-                y = self.y,
-                estimator = estimator,
-                problem_type = self.problem_type,
+                X=self.X,
+                y=self.y,
+                estimator=estimator,
+                problem_type=self.problem_type,
                 sampler_name=self.sampler_name,
                 extra_components=feature_selector,
                 extra_components_position="after_preprocessing",
-                parameters=self._pipeline_params
+                parameters=self._pipeline_params,
             )
             for estimator in estimators
         ]

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -90,7 +90,7 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         verbose=False,
     ):
         self.X = infer_feature_types(X, ignore_nullable_types=True)
-        self.y = infer_feature_types(y)
+        self.y = infer_feature_types(y, ignore_nullable_types=True)
         self.problem_type = problem_type
         self.random_seed = random_seed
         self.sampler_name = sampler_name

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -89,7 +89,7 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         allow_long_running_models=False,
         verbose=False,
     ):
-        self.X = infer_feature_types(X)
+        self.X = infer_feature_types(X, ignore_nullable_types=True)
         self.y = infer_feature_types(y)
         self.problem_type = problem_type
         self.random_seed = random_seed

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -606,7 +606,7 @@ class AutoMLSearch:
         self._searched = False
 
         self.X_train = infer_feature_types(X_train, ignore_nullable_types=True)
-        self.y_train = infer_feature_types(y_train)
+        self.y_train = infer_feature_types(y_train, ignore_nullable_types=True)
 
         default_data_splitter = make_data_splitter(
             self.X_train,

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -605,7 +605,7 @@ class AutoMLSearch:
         self._best_pipeline = None
         self._searched = False
 
-        self.X_train = infer_feature_types(X_train)
+        self.X_train = infer_feature_types(X_train, ignore_nullable_types=True)
         self.y_train = infer_feature_types(y_train)
 
         default_data_splitter = make_data_splitter(

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -80,7 +80,8 @@ def _get_replace_null(X, y, problem_type, estimator_class, sampler_name=None):
     all_nullable_cols = X.ww.select(
         ["IntegerNullable", "AgeNullable", "BooleanNullable"], return_schema=True
     ).columns
-    if len(all_nullable_cols) > 0:
+    nullable_target = isinstance(y.ww.logical_type, (logical_types.AgeNullable, logical_types.BooleanNullable, logical_types.IntegerNullable))
+    if len(all_nullable_cols) > 0 or nullable_target:
         component.append(ReplaceNullableTypes)
     return component
 
@@ -310,7 +311,7 @@ def make_pipeline(
         ValueError: If estimator is not valid for the given problem type, or sampling is not supported for the given problem type.
     """
     X = infer_feature_types(X, ignore_nullable_types=True)
-    y = infer_feature_types(y)
+    y = infer_feature_types(y, ignore_nullable_types=True)
 
     if estimator:
         problem_type = handle_problem_types(problem_type)

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -169,7 +169,9 @@ def _get_ohe(X, y, problem_type, estimator_class, sampler_name=None):
 
     # The URL and EmailAddress Featurizers will create categorical columns
     categorical_cols = list(
-        X.ww.select(["category", "URL", "EmailAddress"], return_schema=True).columns
+        X.ww.select(
+            ["category", "URL", "EmailAddress", "BooleanNullable"], return_schema=True
+        ).columns
     )
     if len(categorical_cols) > 0 and estimator_class not in {
         CatBoostClassifier,

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -80,7 +80,14 @@ def _get_replace_null(X, y, problem_type, estimator_class, sampler_name=None):
     all_nullable_cols = X.ww.select(
         ["IntegerNullable", "AgeNullable", "BooleanNullable"], return_schema=True
     ).columns
-    nullable_target = isinstance(y.ww.logical_type, (logical_types.AgeNullable, logical_types.BooleanNullable, logical_types.IntegerNullable))
+    nullable_target = isinstance(
+        y.ww.logical_type,
+        (
+            logical_types.AgeNullable,
+            logical_types.BooleanNullable,
+            logical_types.IntegerNullable,
+        ),
+    )
     if len(all_nullable_cols) > 0 or nullable_target:
         component.append(ReplaceNullableTypes)
     return component

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -136,10 +136,13 @@ def _get_imputer(X, y, problem_type, estimator_class, sampler_name=None):
     text_columns = list(X.ww.select("NaturalLanguage", return_schema=True).columns)
 
     types_imputer_handles = {
+        logical_types.AgeNullable,
         logical_types.Boolean,
+        logical_types.BooleanNullable,
         logical_types.Categorical,
         logical_types.Double,
         logical_types.Integer,
+        logical_types.IntegerNullable,
         logical_types.URL,
         logical_types.EmailAddress,
         logical_types.Datetime,

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -33,6 +33,7 @@ from evalml.pipelines.components import (  # noqa: F401
     OneHotEncoder,
     Oversampler,
     RandomForestClassifier,
+    ReplaceNullableTypes,
     StackedEnsembleClassifier,
     StackedEnsembleRegressor,
     StandardScaler,
@@ -71,6 +72,16 @@ def _get_drop_all_null(X, y, problem_type, estimator_class, sampler_name=None):
     all_null_cols = X.columns[X.isnull().all()]
     if len(all_null_cols) > 0:
         component.append(DropNullColumns)
+    return component
+
+
+def _get_replace_null(X, y, problem_type, estimator_class, sampler_name=None):
+    component = []
+    all_nullable_cols = X.ww.select(
+        ["IntegerNullable", "AgeNullable", "BooleanNullable"], return_schema=True
+    ).columns
+    if len(all_nullable_cols) > 0:
+        component.append(ReplaceNullableTypes)
     return component
 
 
@@ -214,6 +225,7 @@ def _get_preprocessing_components(
         components_functions = [
             _get_label_encoder,
             _get_drop_all_null,
+            _get_replace_null,
             _get_drop_index_unknown,
             _get_url_email,
             _get_natural_language,
@@ -228,6 +240,7 @@ def _get_preprocessing_components(
         components_functions = [
             _get_label_encoder,
             _get_drop_all_null,
+            _get_replace_null,
             _get_drop_index_unknown,
             _get_url_email,
             _get_datetime,
@@ -293,7 +306,7 @@ def make_pipeline(
     Raises:
         ValueError: If estimator is not valid for the given problem type, or sampling is not supported for the given problem type.
     """
-    X = infer_feature_types(X)
+    X = infer_feature_types(X, ignore_nullable_types=True)
     y = infer_feature_types(y)
 
     if estimator:

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -177,7 +177,7 @@ def get_test_data_from_configuration():
             if "int_null" in column_names:
                 logical_types.update({"int_null": "integer_nullable"})
             if "age_null" in column_names:
-                logical_types.update({"age_null": "integer_nullable"})
+                logical_types.update({"age_null": "age_nullable"})
             if "bool_null" in column_names:
                 logical_types.update({"bool_null": "boolean_nullable"})
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -98,7 +98,9 @@ def graphviz():
 
 @pytest.fixture
 def get_test_data_from_configuration():
-    def _get_test_data_from_configuration(input_type, problem_type, column_names=None, nullable_target=False):
+    def _get_test_data_from_configuration(
+        input_type, problem_type, column_names=None, nullable_target=False
+    ):
         X_all = pd.DataFrame(
             {
                 "all_null": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -104,6 +104,7 @@ def get_test_data_from_configuration():
                 "all_null": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
                 * 2,
                 "int_null": [0, 1, 2, np.nan, 4, np.nan, 6] * 2,
+                "age_null": [0, 1, 2, np.nan, 4, np.nan, 6] * 2,
                 "bool_null": [True, None, False, True, False, None, True] * 2,
                 "numerical": range(14),
                 "categorical": ["a", "b", "a", "b", "b", "a", "b"] * 2,
@@ -169,6 +170,8 @@ def get_test_data_from_configuration():
                 logical_types.update({"email": "EmailAddress"})
             if "int_null" in column_names:
                 logical_types.update({"int_null": "integer_nullable"})
+            if "age_null" in column_names:
+                logical_types.update({"age_null": "integer_nullable"})
             if "bool_null" in column_names:
                 logical_types.update({"bool_null": "boolean_nullable"})
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -96,6 +96,91 @@ def graphviz():
     return graphviz
 
 
+@pytest.fixture
+def get_test_data_from_configuration():
+    def _get_test_data_from_configuration(input_type, problem_type, column_names=None):
+        X_all = pd.DataFrame(
+            {
+                "all_null": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
+                * 2,
+                "int_null": [0, 1, 2, np.nan, 4, np.nan, 6] * 2,
+                "bool_null": [True, None, False, True, False, None, True] * 2,
+                "numerical": range(14),
+                "categorical": ["a", "b", "a", "b", "b", "a", "b"] * 2,
+                "dates": pd.date_range("2000-02-03", periods=14, freq="W"),
+                "text": [
+                    "this is a string",
+                    "this is another string",
+                    "this is just another string",
+                    "evalml should handle string input",
+                    "cats are gr8",
+                    "hello world",
+                    "evalml is gr8",
+                ]
+                * 2,
+                "email": [
+                    "abalone_0@gmail.com",
+                    "AbaloneRings@yahoo.com",
+                    "abalone_2@abalone.com",
+                    "titanic_data@hotmail.com",
+                    "fooEMAIL@email.org",
+                    "evalml@evalml.org",
+                    "evalml@alteryx.org",
+                ]
+                * 2,
+                "url": [
+                    "https://evalml.alteryx.com/en/stable/",
+                    "https://woodwork.alteryx.com/en/stable/guides/statistical_insights.html",
+                    "https://twitter.com/AlteryxOSS",
+                    "https://www.twitter.com/AlteryxOSS",
+                    "https://www.evalml.alteryx.com/en/stable/demos/text_input.html",
+                    "https://github.com/alteryx/evalml",
+                    "https://github.com/alteryx/featuretools",
+                ]
+                * 2,
+                "ip": [
+                    "0.0.0.0",
+                    "1.1.1.101",
+                    "1.1.101.1",
+                    "1.101.1.1",
+                    "101.1.1.1",
+                    "192.168.1.1",
+                    "255.255.255.255",
+                ]
+                * 2,
+            }
+        )
+        y = pd.Series([0, 0, 1, 0, 0, 1, 1] * 2)
+        if problem_type == ProblemTypes.MULTICLASS:
+            y = pd.Series([0, 2, 1, 2, 0, 2, 1] * 2)
+        elif is_regression(problem_type):
+            y = pd.Series([1, 2, 3, 3, 3, 4, 5] * 2)
+        X = X_all[column_names]
+
+        if input_type == "ww":
+            logical_types = {}
+            if "text" in column_names:
+                logical_types.update({"text": "NaturalLanguage"})
+            if "categorical" in column_names:
+                logical_types.update({"categorical": "Categorical"})
+            if "url" in column_names:
+                logical_types.update({"url": "URL"})
+            if "email" in column_names:
+                logical_types.update({"email": "EmailAddress"})
+            if "int_null" in column_names:
+                logical_types.update({"int_null": "integer_nullable"})
+            if "bool_null" in column_names:
+                logical_types.update({"bool_null": "boolean_nullable"})
+
+            X.ww.init(logical_types=logical_types)
+
+            y = ww.init_series(y)
+
+        return X, y
+
+    return _get_test_data_from_configuration
+
+
 def create_mock_pipeline(estimator, problem_type, add_label_encoder=False):
     est_parameters = (
         {estimator.name: {"n_jobs": 1}}

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -98,7 +98,7 @@ def graphviz():
 
 @pytest.fixture
 def get_test_data_from_configuration():
-    def _get_test_data_from_configuration(input_type, problem_type, column_names=None):
+    def _get_test_data_from_configuration(input_type, problem_type, column_names=None, nullable_target=False):
         X_all = pd.DataFrame(
             {
                 "all_null": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
@@ -156,6 +156,10 @@ def get_test_data_from_configuration():
             y = pd.Series([0, 2, 1, 2, 0, 2, 1] * 2)
         elif is_regression(problem_type):
             y = pd.Series([1, 2, 3, 3, 3, 4, 5] * 2)
+        if nullable_target:
+            y.iloc[2] = None
+            if input_type == "ww":
+                y = ww.init_series(y, logical_type="integer_nullable")
         X = X_all[column_names]
 
         if input_type == "ww":

--- a/evalml/tests/integration_tests/test_nullable_types.py
+++ b/evalml/tests/integration_tests/test_nullable_types.py
@@ -11,7 +11,7 @@ from evalml.problem_types import ProblemTypes, is_time_series
     "test_description, column_names",
     [
         ("all_null", ["dates", "all_null"]),
-        ("nullable_types", ["dates", "numerical", "int_null", "bool_null"]),
+        ("nullable_types", ["dates", "numerical", "int_null", "bool_null", "age_null"]),
     ],
 )
 def test_nullable_types_builds_pipelines(

--- a/evalml/tests/integration_tests/test_nullable_types.py
+++ b/evalml/tests/integration_tests/test_nullable_types.py
@@ -1,0 +1,53 @@
+import pytest
+
+from evalml.automl import AutoMLSearch
+from evalml.pipelines.components.transformers import ReplaceNullableTypes
+from evalml.problem_types import ProblemTypes, is_time_series
+
+
+@pytest.mark.parametrize("input_type", ["pd", "ww"])
+@pytest.mark.parametrize("problem_type", ProblemTypes.all_problem_types)
+@pytest.mark.parametrize(
+    "test_description, column_names",
+    [
+        ("all_null", ["dates", "all_null"]),
+        ("nullable_types", ["dates", "numerical", "int_null", "bool_null"]),
+    ],
+)
+def test_nullable_types_builds_pipelines(
+    problem_type,
+    input_type,
+    test_description,
+    column_names,
+    get_test_data_from_configuration,
+):
+    parameters = {}
+    if is_time_series(problem_type):
+        parameters = {
+            "date_index": "dates",
+            "gap": 1,
+            "max_delay": 1,
+            "forecast_horizon": 3,
+        }
+
+    X, y = get_test_data_from_configuration(
+        input_type,
+        problem_type,
+        column_names=column_names,
+    )
+
+    automl = AutoMLSearch(
+        X_train=X,
+        y_train=y,
+        problem_type=problem_type,
+        problem_configuration=parameters,
+    )
+    pipelines = [pl.name for pl in automl.allowed_pipelines]
+
+    if test_description == "nullable_types":
+        if input_type == "pd":
+            assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])
+        elif input_type == "ww":
+            assert all([ReplaceNullableTypes.name in pl for pl in pipelines])
+    else:
+        assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])

--- a/evalml/tests/integration_tests/test_nullable_types.py
+++ b/evalml/tests/integration_tests/test_nullable_types.py
@@ -6,6 +6,7 @@ from evalml.problem_types import ProblemTypes, is_time_series
 
 
 @pytest.mark.parametrize("input_type", ["pd", "ww"])
+@pytest.mark.parametrize("automl_algorithm", ["iterative", "default"])
 @pytest.mark.parametrize("problem_type", ProblemTypes.all_problem_types)
 @pytest.mark.parametrize(
     "test_description, column_names",
@@ -15,6 +16,7 @@ from evalml.problem_types import ProblemTypes, is_time_series
     ],
 )
 def test_nullable_types_builds_pipelines(
+    automl_algorithm,
     problem_type,
     input_type,
     test_description,
@@ -41,6 +43,7 @@ def test_nullable_types_builds_pipelines(
         y_train=y,
         problem_type=problem_type,
         problem_configuration=parameters,
+        _automl_algorithm=automl_algorithm,
     )
     pipelines = [pl.name for pl in automl.allowed_pipelines]
 

--- a/evalml/tests/integration_tests/test_nullable_types.py
+++ b/evalml/tests/integration_tests/test_nullable_types.py
@@ -56,19 +56,19 @@ def test_nullable_types_builds_pipelines(
     if automl_algorithm == "iterative":
         pipelines = [pl.name for pl in automl.allowed_pipelines]
     elif automl_algorithm == "default":
-        pipelines = [pl.name for pl in automl._automl_algorithm.next_batch()]
+        # TODO: Upon resolution of GH Issue #2691, increase the num of batches.
+        for _ in range(2):
+            pipelines = [pl.name for pl in automl._automl_algorithm.next_batch()]
+
+    # A check to make sure we actually retrieve constructed pipelines from the algo.
     assert len(pipelines) > 0
 
-    if test_description == "just nullable target":
-        if input_type == "pd":
-            assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])
-        elif input_type == "ww":
-            assert all([ReplaceNullableTypes.name in pl for pl in pipelines])
-    elif test_description in [
+    if test_description in [
         "only null int",
         "only null bool",
         "only null age",
         "nullable types",
+        "just nullable target",
     ]:
         if input_type == "pd":
             assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])

--- a/evalml/tests/integration_tests/test_nullable_types.py
+++ b/evalml/tests/integration_tests/test_nullable_types.py
@@ -11,7 +11,10 @@ from evalml.problem_types import ProblemTypes, is_time_series
 @pytest.mark.parametrize(
     "test_description, column_names",
     [
-        ("all null", ["dates", "all_null"]), # Should result only in Drop Null Columns Transformer
+        (
+            "all null",
+            ["dates", "all_null"],
+        ),  # Should result only in Drop Null Columns Transformer
         ("only null int", ["int_null"]),
         ("only null bool", ["bool_null"]),
         ("only null age", ["age_null"]),
@@ -40,7 +43,7 @@ def test_nullable_types_builds_pipelines(
         input_type,
         problem_type,
         column_names=column_names,
-        nullable_target=True if "nullable target" in test_description else False
+        nullable_target=True if "nullable target" in test_description else False,
     )
 
     automl = AutoMLSearch(
@@ -61,11 +64,15 @@ def test_nullable_types_builds_pipelines(
             assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])
         elif input_type == "ww":
             assert all([ReplaceNullableTypes.name in pl for pl in pipelines])
-    elif test_description in ["only null int", "only null bool", "only null age", "nullable types"]:
+    elif test_description in [
+        "only null int",
+        "only null bool",
+        "only null age",
+        "nullable types",
+    ]:
         if input_type == "pd":
             assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])
         elif input_type == "ww":
             assert all([ReplaceNullableTypes.name in pl for pl in pipelines])
     else:
         assert not any([ReplaceNullableTypes.name in pl for pl in pipelines])
-

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -66,7 +66,10 @@ from evalml.problem_types import ProblemTypes, is_time_series
         ("url with other features", ["url", "numerical", "categorical"]),
         ("ip with other features", ["ip", "numerical", "categorical"]),
         ("email with other features", ["email", "numerical", "categorical"]),
-        ("nullable_types", ["numerical", "int_null", "bool_null"]),
+        ("only null int", ["int_null"]),
+        ("only null bool", ["bool_null"]),
+        ("only null age", ["age_null"]),
+        ("nullable_types", ["numerical", "int_null", "bool_null", "age_null"]),
     ],
 )
 def test_make_pipeline(
@@ -136,7 +139,9 @@ def test_make_pipeline(
             replace_null = (
                 [ReplaceNullableTypes]
                 if (
-                    any(x in column_names for x in ["bool_null", "int_null"])
+                    any(
+                        x in column_names for x in ["bool_null", "int_null", "age_null"]
+                    )
                     and input_type == "ww"
                 )
                 else []

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -110,14 +110,11 @@ def test_make_pipeline(
                 else []
             )
 
-            if estimator_class.model_family != ModelFamily.CATBOOST:
-                if any(
-                    column_name in ["url", "email", "categorical", "bool_null"]
-                    for column_name in column_names
-                ):
-                    ohe = [OneHotEncoder]
-                else:
-                    ohe = []
+            if estimator_class.model_family != ModelFamily.CATBOOST and any(
+                column_name in ["url", "email", "categorical", "bool_null"]
+                for column_name in column_names
+            ):
+                ohe = [OneHotEncoder]
             else:
                 ohe = []
 

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -112,11 +112,9 @@ def test_make_pipeline(
 
             if estimator_class.model_family != ModelFamily.CATBOOST:
                 if any(
-                    column_name in ["url", "email", "categorical"]
+                    column_name in ["url", "email", "categorical", "bool_null"]
                     for column_name in column_names
                 ):
-                    ohe = [OneHotEncoder]
-                elif "bool_null" in column_names and input_type == "pd":
                     ohe = [OneHotEncoder]
                 else:
                     ohe = []

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 
 from evalml.data_checks import DataCheckAction, DataCheckActionCode
 from evalml.model_family import ModelFamily
@@ -24,6 +23,7 @@ from evalml.pipelines.components import (
     LogisticRegressionClassifier,
     NaturalLanguageFeaturizer,
     OneHotEncoder,
+    ReplaceNullableTypes,
     StandardScaler,
     TargetImputer,
     TimeSeriesFeaturizer,
@@ -44,86 +44,7 @@ from evalml.pipelines.utils import (
     make_pipeline_from_actions,
     rows_of_interest,
 )
-from evalml.problem_types import ProblemTypes, is_regression, is_time_series
-
-
-@pytest.fixture
-def get_test_data_from_configuration():
-    def _get_test_data_from_configuration(input_type, problem_type, column_names=None):
-        X_all = pd.DataFrame(
-            {
-                "all_null": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
-                * 2,
-                "numerical": range(14),
-                "categorical": ["a", "b", "a", "b", "b", "a", "b"] * 2,
-                "dates": pd.date_range("2000-02-03", periods=14, freq="W"),
-                "text": [
-                    "this is a string",
-                    "this is another string",
-                    "this is just another string",
-                    "evalml should handle string input",
-                    "cats are gr8",
-                    "hello world",
-                    "evalml is gr8",
-                ]
-                * 2,
-                "email": [
-                    "abalone_0@gmail.com",
-                    "AbaloneRings@yahoo.com",
-                    "abalone_2@abalone.com",
-                    "titanic_data@hotmail.com",
-                    "fooEMAIL@email.org",
-                    "evalml@evalml.org",
-                    "evalml@alteryx.org",
-                ]
-                * 2,
-                "url": [
-                    "https://evalml.alteryx.com/en/stable/",
-                    "https://woodwork.alteryx.com/en/stable/guides/statistical_insights.html",
-                    "https://twitter.com/AlteryxOSS",
-                    "https://www.twitter.com/AlteryxOSS",
-                    "https://www.evalml.alteryx.com/en/stable/demos/text_input.html",
-                    "https://github.com/alteryx/evalml",
-                    "https://github.com/alteryx/featuretools",
-                ]
-                * 2,
-                "ip": [
-                    "0.0.0.0",
-                    "1.1.1.101",
-                    "1.1.101.1",
-                    "1.101.1.1",
-                    "101.1.1.1",
-                    "192.168.1.1",
-                    "255.255.255.255",
-                ]
-                * 2,
-            }
-        )
-        y = pd.Series([0, 0, 1, 0, 0, 1, 1] * 2)
-        if problem_type == ProblemTypes.MULTICLASS:
-            y = pd.Series([0, 2, 1, 2, 0, 2, 1] * 2)
-        elif is_regression(problem_type):
-            y = pd.Series([1, 2, 3, 3, 3, 4, 5] * 2)
-        X = X_all[column_names]
-
-        if input_type == "ww":
-            logical_types = {}
-            if "text" in column_names:
-                logical_types.update({"text": "NaturalLanguage"})
-            if "categorical" in column_names:
-                logical_types.update({"categorical": "Categorical"})
-            if "url" in column_names:
-                logical_types.update({"url": "URL"})
-            if "email" in column_names:
-                logical_types.update({"email": "EmailAddress"})
-
-            X.ww.init(logical_types=logical_types)
-
-            y = ww.init_series(y)
-
-        return X, y
-
-    return _get_test_data_from_configuration
+from evalml.problem_types import ProblemTypes, is_time_series
 
 
 @pytest.mark.parametrize("input_type", ["pd", "ww"])
@@ -145,6 +66,7 @@ def get_test_data_from_configuration():
         ("url with other features", ["url", "numerical", "categorical"]),
         ("ip with other features", ["ip", "numerical", "categorical"]),
         ("email with other features", ["email", "numerical", "categorical"]),
+        ("nullable_types", ["numerical", "int_null", "bool_null"]),
     ],
 )
 def test_make_pipeline(
@@ -184,17 +106,20 @@ def test_make_pipeline(
                 and estimator_class.model_family != ModelFamily.ARIMA
                 else []
             )
-            ohe = (
-                [OneHotEncoder]
-                if estimator_class.model_family != ModelFamily.CATBOOST
-                and (
-                    any(
-                        ltype in column_names
-                        for ltype in ["url", "email", "categorical"]
-                    )
-                )
-                else []
-            )
+
+            if estimator_class.model_family != ModelFamily.CATBOOST:
+                if any(
+                    column_name in ["url", "email", "categorical"]
+                    for column_name in column_names
+                ):
+                    ohe = [OneHotEncoder]
+                elif "bool_null" in column_names and input_type == "pd":
+                    ohe = [OneHotEncoder]
+                else:
+                    ohe = []
+            else:
+                ohe = []
+
             datetime = (
                 [DateTimeFeaturizer]
                 if estimator_class.model_family
@@ -208,6 +133,14 @@ def test_make_pipeline(
                 else []
             )
             drop_null = [DropNullColumns] if "all_null" in column_names else []
+            replace_null = (
+                [ReplaceNullableTypes]
+                if (
+                    any(x in column_names for x in ["bool_null", "int_null"])
+                    and input_type == "ww"
+                )
+                else []
+            )
             natural_language_featurizer = (
                 [NaturalLanguageFeaturizer]
                 if "text" in column_names and input_type == "ww"
@@ -232,6 +165,7 @@ def test_make_pipeline(
                     label_encoder
                     + email_featurizer
                     + url_featurizer
+                    + replace_null
                     + drop_null
                     + drop_col
                     + natural_language_featurizer
@@ -247,6 +181,7 @@ def test_make_pipeline(
                     label_encoder
                     + email_featurizer
                     + url_featurizer
+                    + replace_null
                     + drop_null
                     + drop_col
                     + delayed_features


### PR DESCRIPTION
Addresses: #3124 

This PR should update `make_pipeline()` such that it now appropriately addresses the presence of AgeNullable, BooleanNullable, and IntegerNullable dtypes in Woodwork dataframes and adds them into the preprocessing pipelines of these.  Added a new integration test file with the intent of adding more integration testing in addition to what's in here.