### PR TITLE
Mark which tests should be skipped for python 3.9

### DIFF
--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -6,10 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - 'requirements.txt'
-      - 'core-requirements.txt'
-      - 'evalml/tests/dependency_update_check/*.txt'
+#    paths:
+#      - 'requirements.txt'
+#      - 'core-requirements.txt'
+#      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   build_conda_pkg:

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -6,10 +6,10 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize ]
-#    paths:
-#      - 'requirements.txt'
-#      - 'core-requirements.txt'
-#      - 'evalml/tests/dependency_update_check/*.txt'
+    paths:
+      - 'requirements.txt'
+      - 'core-requirements.txt'
+      - 'evalml/tests/dependency_update_check/*.txt'
 
 jobs:
   build_conda_pkg:

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: main
+          ref: fix-windows-3.9-tests
       - name: Update apt and install Graphviz
         run: sudo apt update && sudo apt install -y graphviz
       - name: Create virtual environment, upgrade pip
@@ -56,15 +56,15 @@ jobs:
         run: |
           source test_python/bin/activate
           make ${{matrix.command}}
-      - name: Notify on Slack
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          job_name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
-          status: ${{ job.status }}
-          fields: workflow,job,took
-          mention: channel
-          if_mention: failure,cancelled
-          text: ':elmofire:'
-        if: failure() 
+#      - name: Notify on Slack
+#        uses: 8398a7/action-slack@v3
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#        with:
+#          job_name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
+#          status: ${{ job.status }}
+#          fields: workflow,job,took
+#          mention: channel
+#          if_mention: failure,cancelled
+#          text: ':elmofire:'
+#        if: failure()

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -3,8 +3,6 @@ name: Nightly unit tests, linux
 on:
   schedule:
       - cron: '0 7 * * *'
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   unit_tests:
@@ -13,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.7', '3.8', '3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-parallel', 'git-test-prophet']
     steps:
       - name: Set up Python ${{ matrix.python_version }}
@@ -24,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: fix-windows-3.9-tests
+          ref: main
       - name: Update apt and install Graphviz
         run: sudo apt update && sudo apt install -y graphviz
       - name: Create virtual environment, upgrade pip
@@ -56,15 +54,15 @@ jobs:
         run: |
           source test_python/bin/activate
           make ${{matrix.command}}
-#      - name: Notify on Slack
-#        uses: 8398a7/action-slack@v3
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          job_name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
-#          status: ${{ job.status }}
-#          fields: workflow,job,took
-#          mention: channel
-#          if_mention: failure,cancelled
-#          text: ':elmofire:'
-#        if: failure()
+      - name: Notify on Slack
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          job_name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
+          status: ${{ job.status }}
+          fields: workflow,job,took
+          mention: channel
+          if_mention: failure,cancelled
+          text: ':elmofire:'
+        if: failure()

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -3,6 +3,8 @@ name: Nightly unit tests, linux
 on:
   schedule:
       - cron: '0 7 * * *'
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   unit_tests:
@@ -11,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.7', '3.8', '3.9']
+        python_version: ['3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-parallel', 'git-test-prophet']
     steps:
       - name: Set up Python ${{ matrix.python_version }}

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: main
+          ref: fix-windows-3.9-tests
       - name: Install make
         run: |
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
@@ -72,15 +72,15 @@ jobs:
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
           conda activate curr_py
           make ${{matrix.command}}
-      - name: Notify on Slack
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          job_name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
-          status: ${{ job.status }}
-          fields: workflow,job,took
-          mention: channel
-          if_mention: failure,cancelled
-          text: ':elmofire:'
-        if: failure() 
+#      - name: Notify on Slack
+#        uses: 8398a7/action-slack@v3
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#        with:
+#          job_name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
+#          status: ${{ job.status }}
+#          fields: workflow,job,took
+#          mention: channel
+#          if_mention: failure,cancelled
+#          text: ':elmofire:'
+#        if: failure()

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -3,6 +3,8 @@ name: Nightly unit tests, windows
 on:
   schedule:
       - cron: '0 7 * * *'
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   win_unit_tests:
@@ -11,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.7', '3.8', '3.9']
+        python_version: ['3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-parallel']
     steps:
       - name: Download Miniconda

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -3,8 +3,6 @@ name: Nightly unit tests, windows
 on:
   schedule:
       - cron: '0 7 * * *'
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   win_unit_tests:
@@ -13,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ['3.9']
+        python_version: ['3.7', '3.8', '3.9']
         command: ['git-test-automl', 'git-test-modelunderstanding', 'git-test-other', 'git-test-parallel']
     steps:
       - name: Download Miniconda
@@ -40,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}
-          ref: fix-windows-3.9-tests
+          ref: main
       - name: Install make
         run: |
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
@@ -72,15 +70,15 @@ jobs:
           . $env:USERPROFILE\Miniconda3\shell\condabin\conda-hook.ps1
           conda activate curr_py
           make ${{matrix.command}}
-#      - name: Notify on Slack
-#        uses: 8398a7/action-slack@v3
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          job_name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
-#          status: ${{ job.status }}
-#          fields: workflow,job,took
-#          mention: channel
-#          if_mention: failure,cancelled
-#          text: ':elmofire:'
-#        if: failure()
+      - name: Notify on Slack
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          job_name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
+          status: ${{ job.status }}
+          fields: workflow,job,took
+          mention: channel
+          if_mention: failure,cancelled
+          text: ':elmofire:'
+        if: failure()

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -17,6 +17,7 @@ Release Notes
     * Testing Changes
         * Refactored tests to avoid using ``importorskip`` :pr:`3126`
         * Added ``skip_during_conda`` test marker to skip tests that are not supposed to run during conda build :pr:`3127`
+        * Added ``skip_if_39`` test marker to skip tests that are not supposed to run during python 3.9 :pr:`3133`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_arima_regressor.py
+++ b/evalml/tests/component_tests/test_arima_regressor.py
@@ -8,7 +8,11 @@ from evalml.model_family import ModelFamily
 from evalml.pipelines.components import ARIMARegressor
 from evalml.problem_types import ProblemTypes
 
-pytestmark = [pytest.mark.noncore_dependency, pytest.mark.skip_during_conda]
+pytestmark = [
+    pytest.mark.noncore_dependency,
+    pytest.mark.skip_during_conda,
+    pytest.mark.skip_if_39,
+]
 
 
 @pytest.fixture(scope="module")

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -7,7 +7,7 @@ from sklearn.preprocessing import PolynomialFeatures
 
 from evalml.pipelines.components import PolynomialDetrender
 
-pytestmark = pytest.mark.noncore_dependency
+pytestmark = [pytest.mark.noncore_dependency, pytest.mark.skip_if_39]
 
 
 def test_polynomial_detrender_init():

--- a/evalml/tests/component_tests/test_prophet_regressor.py
+++ b/evalml/tests/component_tests/test_prophet_regressor.py
@@ -6,7 +6,11 @@ from evalml.model_family import ModelFamily
 from evalml.pipelines.components import ProphetRegressor
 from evalml.problem_types import ProblemTypes
 
-pytestmark = [pytest.mark.noncore_dependency, pytest.mark.skip_during_conda]
+pytestmark = [
+    pytest.mark.noncore_dependency,
+    pytest.mark.skip_during_conda,
+    pytest.mark.skip_if_39,
+]
 
 
 def test_model_family():

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -319,7 +319,7 @@ def pytest_collection_modifyitems(config, items):
     if sys.version_info >= (3, 9):
         skip_39 = pytest.mark.skip(reason="Test dependency not supported in python 3.9")
         for item in items:
-            if "skip_if_39":
+            if "skip_if_39" in item.keywords:
                 item.add_marker(skip_39)
 
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -55,6 +55,10 @@ def pytest_configure(config):
         "markers",
         "skip_during_conda: mark test to be skipped if running during conda build",
     )
+    config.addinivalue_line(
+        "markers",
+        "skip_if_39: mark test to be skipped if running during conda build",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -312,6 +316,11 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "skip_during_conda" in item.keywords:
                 item.add_marker(skip_conda)
+    if sys.version_info >= (3, 9):
+        skip_39 = pytest.mark.skip(reason="Test dependency not supported in python 3.9")
+        for item in items:
+            if "skip_if_39":
+                item.add_marker(skip_39)
 
 
 @pytest.fixture

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1171,6 +1171,7 @@ def test_time_series_pipeline_fit_with_transformed_target(
     pd.testing.assert_series_equal(mock_to_check.call_args[0][1], y + 2)
 
 
+@pytest.mark.skip_if_39
 @pytest.mark.noncore_dependency
 def test_time_series_pipeline_with_detrender(ts_data):
     X, y = ts_data


### PR DESCRIPTION
### Pull Request Description
Third time's the charm 😅 

Fix [broken nightlies](https://github.com/alteryx/evalml/runs/4453892142?check_suite_focus=true) by marking tests as being skipped for 3.9.


-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
