### PR TITLE
Release v0.39.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.39.0 Dec. 9, 2021**
+    * Enhancements
         * Renamed ``DelayedFeatureTransformer`` to ``TimeSeriesFeaturizer`` and enhanced it to compute rolling features :pr:`3028`
         * Added ability to impute only specific columns in ``PerColumnImputer`` :pr:`3123`
         * Added ``TimeSeriesParametersDataCheck`` to verify the time series parameters are valid given the number of splits in cross validation :pr:`3111`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.38.0',
+    version='0.39.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.39.0 Dec. 9, 2021
### Enhancements
- Renamed ``DelayedFeatureTransformer`` to ``TimeSeriesFeaturizer`` and enhanced it to compute rolling features #3028
- Added ability to impute only specific columns in ``PerColumnImputer`` #3123
- Added ``TimeSeriesParametersDataCheck`` to verify the time series parameters are valid given the number of splits in cross validation #3111
### Fixes
- Default parameters for ``RFRegressorSelectFromModel`` and ``RFClassifierSelectFromModel`` has been fixed to avoid selecting all features #3110
### Changes
- Removed reliance on a datetime index for ``ARIMARegressor`` and ``ProphetRegressor`` #3104
- Included target leakage check when fitting ``ARIMARegressor`` to account for the lack of ``TimeSeriesFeaturizer`` in ``ARIMARegressor`` based pipelines #3104
- Cleaned up and refactored ``InvalidTargetDataCheck`` implementation and docstring #3122
- Removed indices information from the output of ``HighlyNullDataCheck``'s ``validate()`` method #3092
- Added ``ReplaceNullableTypes`` component to prepare for handling pandas nullable types. #3090
- Removed unused ``EnsembleMissingPipelinesError`` exception definition #3131
### Documentation Changes
### Testing Changes
- Refactored tests to avoid using ``importorskip`` #3126
- Added ``skip_during_conda`` test marker to skip tests that are not supposed to run during conda build #3127
- Added ``skip_if_39`` test marker to skip tests that are not supposed to run during python 3.9 #3133
### Breaking Changes
- Renamed ``DelayedFeatureTransformer`` to ``TimeSeriesFeaturizer`` #3028
- ``ProphetRegressor`` now requires a datetime column in ``X`` represented by the ``date_index`` parameter #3104
- Renamed module ``evalml.data_checks.invalid_target_data_check`` to ``evalml.data_checks.invalid_targets_data_check`` #3122
- Removed unused ``EnsembleMissingPipelinesError`` exception definition #3131