### PR TITLE
Pin nltk to 3.6.5

### DIFF
--- a/.github/conda_version_check.py
+++ b/.github/conda_version_check.py
@@ -37,7 +37,7 @@ def get_evalml_pip_requirements(evalml_path):
     extra_reqs = open(pathlib.Path(evalml_path, "requirements.txt")).readlines()
     extra_reqs = [req for req in extra_reqs if "-r core-requirements.txt" not in req]
     all_reqs = core_reqs + extra_reqs
-    return standardize_format(requirements.parse("".join(all_reqs)))
+    return standardize_format(requirements.parse("\n".join(all_reqs)))
 
 
 def get_evalml_conda_requirements(conda_recipe):

--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -45,6 +45,7 @@ outputs:
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2
         - python-graphviz >=0.13
+        - nltk ==3.6.5
     test:
       imports:
         - evalml

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -17,3 +17,4 @@ dask>=2021.10.0
 nlp-primitives>=2.0.0
 featuretools>=1.2.0
 networkx>=2.5,<2.6
+nltk==3.6.5

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Added support for known-in-advance features :pr:`3149`
     * Fixes
         * Fixed error caused when tuning threshold for time series binary classification :pr:`3140`
+        * Pinned nltk to version 3.6.5 to prevent components that rely on nlp-primitives from breaking :pr:`3164`
     * Changes
         * ``TimeSeriesParametersDataCheck`` was added to ``DefaultDataChecks`` for time series problems :pr:`3139`
         * Renamed ``date_index`` to ``time_index`` in ``problem_configuration`` for time series problems :pr:`3137`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -14,10 +14,11 @@ matplotlib==3.5.1
 matplotlib-inline==0.1.3
 networkx==2.5.1
 nlp-primitives==2.0.0
+nltk==3.6.5
 numba==0.53.0
 numpy==1.21.5
 pandas==1.3.5
-plotly==5.4.0
+plotly==5.5.0
 pmdarima==1.8.0
 pyzmq==22.3.0
 requirements-parser==0.3.1

--- a/evalml/tests/dependency_update_check/minimum_core_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_core_requirements.txt
@@ -17,3 +17,4 @@ dask==2021.10.0
 nlp-primitives==2.0.0
 featuretools==1.2.0
 networkx==2.5
+nltk==3.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pmdarima==1.8.0
 sktime>=0.7.0;python_version<"3.9"
 lime>=0.2.0.1
 vowpalwabbit>=8.11.0
-nltk>=3.6.5
+nltk==3.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ pmdarima==1.8.0
 sktime>=0.7.0;python_version<"3.9"
 lime>=0.2.0.1
 vowpalwabbit>=8.11.0
-nltk==3.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pmdarima==1.8.0
 sktime>=0.7.0;python_version<"3.9"
 lime>=0.2.0.1
 vowpalwabbit>=8.11.0
+nltk>=3.6.5


### PR DESCRIPTION
The dependency bot failed via https://github.com/alteryx/evalml/runs/4590658210?check_suite_focus=true, but the stack is coming from `nltk`. Since that package also updated today, I'm using this branch to pin `nltk` and see if that resolves the issue.

Stack trace:
```
E         Resource omw-1.4 not found.
E         Please use the NLTK Downloader to obtain the resource:
E       
E         >>> import nltk
E         >>> nltk.download('omw-1.4')
```