### PR TITLE
Update `nlp-primitives` version to 2.1.0

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -40,7 +40,7 @@ outputs:
         - texttable >=1.6.2
         - woodwork >=0.8.2
         - featuretools>=1.2.0
-        - nlp-primitives>=2.0.0
+        - nlp-primitives>=2.1.0
         - python >=3.7.*
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -14,6 +14,6 @@ statsmodels>=0.12.2
 texttable>=1.6.2
 woodwork>=0.8.2
 dask>=2021.10.0
-nlp-primitives>=2.0.0
+nlp-primitives>=2.1.0
 featuretools>=1.2.0
 networkx>=2.5,<2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
     * Changes
         * ``TimeSeriesParametersDataCheck`` was added to ``DefaultDataChecks`` for time series problems :pr:`3139`
         * Renamed ``date_index`` to ``time_index`` in ``problem_configuration`` for time series problems :pr:`3137`
+        * Updated ``nlp-primitives`` minimum version to 2.1.0 :pr:`3166`
     * Documentation Changes
         * Added comments to provide clarity on doctests :pr:`3155`
     * Testing Changes

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -17,7 +17,7 @@ nlp-primitives==2.1.0
 numba==0.53.0
 numpy==1.21.5
 pandas==1.3.5
-plotly==5.4.0
+plotly==5.5.0
 pmdarima==1.8.0
 pyzmq==22.3.0
 requirements-parser==0.3.1

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -13,7 +13,7 @@ lime==0.2.0.1
 matplotlib==3.5.1
 matplotlib-inline==0.1.3
 networkx==2.5.1
-nlp-primitives==2.0.0
+nlp-primitives==2.1.0
 numba==0.53.0
 numpy==1.21.5
 pandas==1.3.5

--- a/evalml/tests/dependency_update_check/minimum_core_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_core_requirements.txt
@@ -14,6 +14,6 @@ statsmodels==0.12.2
 texttable==1.6.2
 woodwork==0.8.2
 dask==2021.10.0
-nlp-primitives==2.0.0
+nlp-primitives==2.1.0
 featuretools==1.2.0
 networkx==2.5


### PR DESCRIPTION
Need to wait for `nlp-primitives` to upload to conda but requesting review so we can press go when it's out: https://anaconda.org/conda-forge/nlp-primitives

Up for debate: do we *need* to update our min version of `nlp-primitives` to 2.1.0? Technically, our CI will pass even if we don't (since it'll install the latest). Doing it here because I think it'd be safer / in case users get unexpected behavior with different versions of nlp-primitives and nltk.