### PR TITLE
Fix bug where prediction explanations class_name was shown as float for boolean targets

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
         * Added string support for DataCheckActionCode :pr:`3167`
         * Added ``DataCheckActionOption`` class :pr:`3134`
     * Fixes
+        * Fix bug where prediction explanations ``class_name`` was shown as float for boolean targets :pr:`3179`
     * Changes
         * Removed usage of scikit-learn's ``LabelEncoder`` in favor of ours :pr:`3161`
         * Fixed ``mean_cv_data`` and ``validation_score`` values in AutoMLSearch.rankings to reflect cv score or ``NaN`` when appropriate :pr:`3162`

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -108,13 +108,16 @@ def _make_json_serializable(value):
 
     numpy.int64 or numpy.bool can't be serialized to json.
     """
-    if pd.api.types.is_number(value):
+    # Base boolean are identified as numbers by pandas
+    # so put the `is_bool` check prior
+    if pd.api.types.is_bool(value):
+        value = bool(value)
+    elif pd.api.types.is_number(value):
         if pd.api.types.is_integer(value):
             value = int(value)
         else:
             value = float(value)
-    elif pd.api.types.is_bool(value):
-        value = bool(value)
+
     return value
 
 

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1804,7 +1804,7 @@ def test_explain_predictions_class_name_matches_class_name_in_y(
         algorithm="shap",
     )
     if problem_type == ProblemTypes.BINARY:
-        assert exp["explanations"][0]["explanations"][0]["class_name"]
+        assert exp["explanations"][0]["explanations"][0]["class_name"] == True
     else:
         for i in range(3):
             assert (

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1759,6 +1759,7 @@ def test_explain_predictions_oversampler(estimator, algorithm, fraud_100):
     assert report["feature_values"].isnull().sum() == 0
 
 
+@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("problem_type", [ProblemTypes.MULTICLASS, ProblemTypes.BINARY])
 def test_explain_predictions_class_name_matches_class_name_in_y(
     problem_type, fraud_100

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1759,6 +1759,59 @@ def test_explain_predictions_oversampler(estimator, algorithm, fraud_100):
     assert report["feature_values"].isnull().sum() == 0
 
 
+@pytest.mark.parametrize("problem_type", [ProblemTypes.MULTICLASS, ProblemTypes.BINARY])
+def test_explain_predictions_class_name_matches_class_name_in_y(
+    problem_type, fraud_100
+):
+    if problem_type == ProblemTypes.BINARY:
+        X, y = fraud_100
+        pipeline_class = BinaryClassificationPipeline
+    else:
+        X, y = fraud_100
+        y = np.arange(X.shape[0]) % 3
+        pipeline_class = MulticlassClassificationPipeline
+    pipeline = pipeline_class(
+        component_graph={
+            "Imputer": ["Imputer", "X", "y"],
+            "One Hot Encoder": ["One Hot Encoder", "Imputer.x", "y"],
+            "DateTime Featurization Component": [
+                "DateTime Featurization Component",
+                "One Hot Encoder.x",
+                "y",
+            ],
+            "Oversampler": [
+                "Oversampler",
+                "DateTime Featurization Component.x",
+                "y",
+            ],
+            "Random Forest Classifier": [
+                "Random Forest Classifier",
+                "Oversampler.x",
+                "Oversampler.y",
+            ],
+        }
+    )
+
+    pipeline.fit(X, y)
+    exp = explain_predictions_best_worst(
+        pipeline,
+        X,
+        y,
+        num_to_explain=1,
+        output_format="dict",
+        top_k_features=2,
+        algorithm="shap",
+    )
+    if problem_type == ProblemTypes.BINARY:
+        assert exp["explanations"][0]["explanations"][0]["class_name"]
+    else:
+        for i in range(3):
+            assert (
+                exp["explanations"][0]["explanations"][i]["class_name"]
+                == pipeline.classes_[i]
+            )
+
+
 @patch(
     "evalml.model_understanding.prediction_explanations._user_interface._make_single_prediction_explanation_table"
 )

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1764,11 +1764,10 @@ def test_explain_predictions_oversampler(estimator, algorithm, fraud_100):
 def test_explain_predictions_class_name_matches_class_name_in_y(
     problem_type, fraud_100
 ):
+    X, y = fraud_100
     if problem_type == ProblemTypes.BINARY:
-        X, y = fraud_100
         pipeline_class = BinaryClassificationPipeline
     else:
-        X, y = fraud_100
         y = np.arange(X.shape[0]) % 3
         pipeline_class = MulticlassClassificationPipeline
     pipeline = pipeline_class(

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1804,7 +1804,8 @@ def test_explain_predictions_class_name_matches_class_name_in_y(
         algorithm="shap",
     )
     if problem_type == ProblemTypes.BINARY:
-        assert exp["explanations"][0]["explanations"][0]["class_name"] == True
+        assert exp["explanations"][0]["explanations"][0]["class_name"]
+        assert isinstance(exp["explanations"][0]["explanations"][0]["class_name"], bool)
     else:
         for i in range(3):
             assert (


### PR DESCRIPTION
### Pull Request Description
Fixes #3178

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
