### PR TITLE
Release v0.42.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.42.0 Jan. 18, 2022**
+    * Enhancements
         * Required the separation of training and test data by ``gap`` + 1 units to be verified by ``time_index`` for time series problems :pr:`3208`
         * Added support for boolean features for ``ARIMARegressor`` :pr:`3187`
         * Updated dependency bot workflow to remove outdated description and add new configuration to delete branches automatically :pr:`3212`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.41.0',
+    version='0.42.0',
     author='Alteryx, Inc.',
     author_email='support@featurelabs.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.42.0 Jan. 18, 2022
### Enhancements
- Required the separation of training and test data by ``gap`` + 1 units to be verified by ``time_index`` for time series problems #3208
- Added support for boolean features for ``ARIMARegressor`` #3187
- Updated dependency bot workflow to remove outdated description and add new configuration to delete branches automatically #3212
- Added ``n_obs`` and ``n_splits`` to ``TimeSeriesParametersDataCheck`` error details #3246
### Fixes
- Fixed classification pipelines to only accept target data with the appropriate number of classes #3185
- Added support for time series in ``DefaultAlgorithm`` #3177
- Standardized names of featurization components #3192
- Removed empty cell in text_input.ipynb #3234
- Removed potential prediction explanations failure when pipelines predicted a class with probability 1 #3221
- Dropped NaNs before partial dependence grid generation #3235
- Fixed bug where ``InvalidTargetDataCheck`` would not check time series regression targets #3251
### Changes
- Raised lowest compatible numpy version to 1.21.0 to address security concerns #3207
- Changed the default objective to ``MedianAE`` from ``R2`` for time series regression #3205
- Removed all-nan Unknown to Double logical conversion in ``infer_feature_types`` #3196
- Checking the validity of holdout data for time series problems can be performed by calling ``pipelines.utils.validate_holdout_datasets`` prior to calling ``predict`` #3208
### Documentation Changes
### Testing Changes
### Breaking Changes
- Renamed ``DateTime Featurizer Component`` to ``DateTime Featurizer`` and ``Natural Language Featurization Component`` to ``Natural Language Featurizer`` #3192
