### PR TITLE
Ensure prediction explanations are json-serializable

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@
         * Removed empty cell in text_input.ipynb :pr:`3234`
         * Removed potential prediction explanations failure when pipelines predicted a class with probability 1 :pr:`3221`
         * Dropped NaNs before partial dependence grid generation :pr:`3235`
+        * Allowed prediction explanations to be json-serializable :pr:`3262`
     * Changes
         * Raised lowest compatible numpy version to 1.21.0 to address security concerns :pr:`3207`
         * Changed the default objective to ``MedianAE`` from ``R2`` for time series regression :pr:`3205`

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -61,8 +61,6 @@ def _make_rows(
         else:
             feature_value = pipeline_features[feature_name].iloc[0]
 
-        feature_value = _make_json_serializable(feature_value)
-
         if convert_numeric_to_string:
             if pd.api.types.is_number(feature_value) and not pd.api.types.is_bool(
                 feature_value
@@ -70,6 +68,9 @@ def _make_rows(
                 feature_value = "{:.2f}".format(feature_value)
             else:
                 feature_value = str(feature_value)
+
+        feature_value = _make_json_serializable(feature_value)
+        
         row = [feature_name, feature_value, display_text]
         if include_explainer_values:
             explainer_value = explainer_values[feature_name][0]
@@ -120,7 +121,7 @@ def _make_json_serializable(value):
         else:
             value = float(value)
     elif isinstance(value, pd.Timestamp):
-        value = value.ctime()
+        value = value.isoformat()
 
     return value
 

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -70,7 +70,7 @@ def _make_rows(
                 feature_value = str(feature_value)
 
         feature_value = _make_json_serializable(feature_value)
-        
+
         row = [feature_name, feature_value, display_text]
         if include_explainer_values:
             explainer_value = explainer_values[feature_name][0]

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -121,7 +121,7 @@ def _make_json_serializable(value):
         else:
             value = float(value)
     elif isinstance(value, pd.Timestamp):
-        value = value.isoformat()
+        value = str(value)
 
     return value
 

--- a/evalml/model_understanding/prediction_explanations/_user_interface.py
+++ b/evalml/model_understanding/prediction_explanations/_user_interface.py
@@ -61,6 +61,8 @@ def _make_rows(
         else:
             feature_value = pipeline_features[feature_name].iloc[0]
 
+        feature_value = _make_json_serializable(feature_value)
+
         if convert_numeric_to_string:
             if pd.api.types.is_number(feature_value) and not pd.api.types.is_bool(
                 feature_value
@@ -117,6 +119,8 @@ def _make_json_serializable(value):
             value = int(value)
         else:
             value = float(value)
+    elif isinstance(value, pd.Timestamp):
+        value = value.ctime()
 
     return value
 

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1442,7 +1442,11 @@ def test_categories_aggregated_pca_dag(
         assert all(
             [
                 f in explanation["feature_values"]
-                for f in [pd.Timestamp("2019-01-01 00:12:26").isoformat(), "Mastercard", "CUC"]
+                for f in [
+                    pd.Timestamp("2019-01-01 00:12:26").isoformat(),
+                    "Mastercard",
+                    "CUC",
+                ]
             ]
         )
         assert explanation["drill_down"].keys() == {"currency", "provider", "datetime"}
@@ -2043,7 +2047,7 @@ def test_explain_predictions_report_shows_original_value_if_possible(
         top_k_features=20,
         algorithm=algorithm,
     )
-    X['datetime'] = X['datetime'].map(lambda val: val.isoformat())
+    X["datetime"] = X["datetime"].map(lambda val: val.isoformat())
     expected_feature_values = set(X.ww.iloc[0, :].tolist())
     for explanation in report["explanations"][0]["explanations"]:
         assert set(explanation["feature_names"]) == set(X.columns)
@@ -2107,7 +2111,7 @@ def test_explain_predictions_best_worst_report_shows_original_value_if_possible(
         algorithm=algorithm,
     )
 
-    X['datetime'] = X['datetime'].map(lambda val: val.isoformat())
+    X["datetime"] = X["datetime"].map(lambda val: val.isoformat())
     for index, explanation in enumerate(report["explanations"]):
         for exp in explanation["explanations"]:
             assert set(exp["feature_names"]) == set(X.columns)
@@ -2136,6 +2140,24 @@ def test_explain_predictions_best_worst_report_shows_original_value_if_possible(
             ):
                 if feature_name == "lat":
                     assert np.isnan(feature_value)
+
+
+@pytest.mark.parametrize("algorithm", algorithms)
+def test_explain_predictions_best_worst_json(algorithm, fraud_100):
+    pipeline = BinaryClassificationPipeline(
+        [
+            "Natural Language Featurizer",
+            "DateTime Featurizer",
+            "One Hot Encoder",
+            "CatBoost Classifier",
+        ]
+    )
+    X, y = fraud_100
+    pipeline.fit(X, y)
+
+    report = explain_predictions_best_worst(pipeline, X, y, output_format="dict")
+    json_output = json.dumps(report)
+    assert isinstance(json_output, str)
 
 
 def test_explain_predictions_invalid_algorithm():

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -2149,7 +2149,7 @@ def test_explain_predictions_best_worst_json(algorithm, fraud_100):
             "Natural Language Featurizer",
             "DateTime Featurizer",
             "One Hot Encoder",
-            "CatBoost Classifier",
+            "Logistic Regression Classifier",
         ]
     )
     X, y = fraud_100

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -2155,7 +2155,9 @@ def test_explain_predictions_best_worst_json(algorithm, fraud_100):
     X, y = fraud_100
     pipeline.fit(X, y)
 
-    report = explain_predictions_best_worst(pipeline, X, y, output_format="dict")
+    report = explain_predictions_best_worst(
+        pipeline, X, y, algorithm=algorithm, output_format="dict"
+    )
     json_output = json.dumps(report)
     assert isinstance(json_output, str)
 

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1303,7 +1303,7 @@ def test_categories_aggregated_text(
             "CUC",
             "Mastercard",
             24900,
-            pd.Timestamp("2019-01-01 00:12:26"),
+            pd.Timestamp("2019-01-01 00:12:26").isoformat(),
         }
         assert explanation["drill_down"].keys() == {"currency", "provider", "datetime"}
         assert (
@@ -1368,7 +1368,7 @@ def test_categories_aggregated_date_ohe(
             "datetime",
         }
         assert set(explanation["feature_values"]) == {
-            pd.Timestamp("2019-01-01 00:12:26"),
+            pd.Timestamp("2019-01-01 00:12:26").isoformat(),
             "Mastercard",
             "CUC",
             24900,
@@ -1442,7 +1442,7 @@ def test_categories_aggregated_pca_dag(
         assert all(
             [
                 f in explanation["feature_values"]
-                for f in [pd.Timestamp("2019-01-01 00:12:26"), "Mastercard", "CUC"]
+                for f in [pd.Timestamp("2019-01-01 00:12:26").isoformat(), "Mastercard", "CUC"]
             ]
         )
         assert explanation["drill_down"].keys() == {"currency", "provider", "datetime"}
@@ -1567,7 +1567,7 @@ def test_categories_aggregated_when_some_are_dropped(
             "CUC",
             "Mastercard",
             24900,
-            pd.Timestamp("2019-01-01 00:12:26"),
+            pd.Timestamp("2019-01-01 00:12:26").isoformat(),
         }
         assert explanation["drill_down"].keys() == {"currency", "provider", "datetime"}
         assert (
@@ -2043,6 +2043,7 @@ def test_explain_predictions_report_shows_original_value_if_possible(
         top_k_features=20,
         algorithm=algorithm,
     )
+    X['datetime'] = X['datetime'].map(lambda val: val.isoformat())
     expected_feature_values = set(X.ww.iloc[0, :].tolist())
     for explanation in report["explanations"][0]["explanations"]:
         assert set(explanation["feature_names"]) == set(X.columns)
@@ -2106,6 +2107,7 @@ def test_explain_predictions_best_worst_report_shows_original_value_if_possible(
         algorithm=algorithm,
     )
 
+    X['datetime'] = X['datetime'].map(lambda val: val.isoformat())
     for index, explanation in enumerate(report["explanations"]):
         for exp in explanation["explanations"]:
             assert set(exp["feature_names"]) == set(X.columns)


### PR DESCRIPTION
Closes #2366 

Since the writing of this issue, a couple other data types also caused issues, so I added those as well.