### PR TITLE
Release 0.43.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,20 @@
 ﻿Release Notes
 -------------
+
 **Future Releases**
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.43.0 Jan. 25, 2022**
     * Enhancements
         * Updated new ``NullDataCheck`` to return a warning and suggest an action to impute columns with null values :pr:`3197`
         * Updated ``make_pipeline_from_actions`` to handle null column imputation :pr:`3237`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.42.0"
+__version__ = "0.43.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.42.0',
+    version='0.43.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.43.0 Jan. 25, 2022

### Enhancements
 - Updated new ``NullDataCheck`` to return a warning and suggest an action to impute columns with null values #3197
 - Updated ``make_pipeline_from_actions`` to handle null column imputation #3237
 - Updated data check actions API to return options instead of actions and add functionality to suggest and take action on columns with null values #3182
 
### Fixes
 - Fixed categorical data leaking into non-categorical sub-pipelines in ``DefaultAlgorithm`` #3209
 - Fixed Python 3.9 installation for prophet by updating ``pmdarima`` version in requirements #3268
 - Allowed DateTime columns to pass through PerColumnImputer without breaking #3267
### Changes
 - Updated ``DataCheck`` ``validate()`` output to return a dictionary instead of list for actions #3142
 - Updated ``DataCheck`` ``validate()`` API to use the new ``DataCheckActionOption`` class instead of ``DataCheckAction`` #3152
 - Uncapped numba version and removed it from requirements #3263
 - Renamed ``HighlyNullDataCheck`` to ``NullDataCheck`` #3197
 - Updated data check ``validate()`` output to return a list of warnings and errors instead of a dictionary #3244
 - Capped ``pandas`` at < 1.4.0 #3274
### Testing Changes
 - Bumped minimum ``IPython`` version to 7.16.3 in ``test-requirements.txt`` based on dependabot feedback #3269



## Breaking Changes 
 - Renamed ``HighlyNullDataCheck`` to ``NullDataCheck`` #3197
 - Updated data check ``validate()`` output to return a list of warnings and errors instead of a dictionary. See the Data Check or Data Check Actions pages (under User Guide) for examples. #3244
 - Removed ``impute_all`` and ``default_impute_strategy`` parameters from the ``PerColumnImputer`` #3267
 - Updated ``PerColumnImputer`` such that columns not specified in ``impute_strategies`` dict will not be imputed anymore #3267
