### PR TITLE
Fix Polynomial Detrender test for SKtime Upgrade

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@
     * Fixes
         * Updated the binary classification pipeline's ``optimize_thresholds`` method to use Nelder-Mead :pr:`3280`
         * Fixed bug where feature importance on time series pipelines only showed 0 for time index :pr:`3285`
-        * Fixed ``PolynomialDetrender`` test for sktime upgrade :pr:``
+        * Fixed ``PolynomialDetrender`` test for sktime upgrade :pr:`3300`
     * Changes
         * Removed ``DateTimeNaNDataCheck`` and ``NaturalLanguageNaNDataCheck`` in favor of ``NullDataCheck`` :pr:`3260`
         * Drop support for Python 3.7 :pr:`3291`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@
     * Fixes
         * Updated the binary classification pipeline's ``optimize_thresholds`` method to use Nelder-Mead :pr:`3280`
         * Fixed bug where feature importance on time series pipelines only showed 0 for time index :pr:`3285`
+        * Fixed ``PolynomialDetrender`` test for sktime upgrade :pr:``
     * Changes
         * Removed ``DateTimeNaNDataCheck`` and ``NaturalLanguageNaNDataCheck`` in favor of ``NullDataCheck`` :pr:`3260`
         * Drop support for Python 3.7 :pr:`3291`

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -106,7 +106,7 @@ def test_polynomial_detrender_needs_monotonic_index(ts_data):
     assert "monotonically" in str(exec_info.value)
 
     with pytest.raises(
-        NotImplementedError,
+        ValueError,
         match="class 'pandas.core.indexes.base.Index'> is not supported",
     ):
         y_string_index = pd.Series(np.arange(31), index=[f"row_{i}" for i in range(31)])


### PR DESCRIPTION
Sktime had an [upgrade](https://github.com/alan-turing-institute/sktime/compare/v0.9.0...v0.10.0) to v0.10.0, which broke one of our tests. This provides a fix to that test.