### PR TITLE
Release v0.44.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,18 @@
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.44.0 Feb. 04, 2022**
+    * Enhancements
         * Updated ``DefaultAlgorithm`` to also limit estimator usage for long-running multiclass problems :pr:`3099`
         * Added ``make_pipeline_from_data_check_output()`` utility method :pr:`3277`
         * Added more specific data check errors to ``DatetimeFormatDataCheck`` :pr:`3288`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.43.0',
+    version='0.44.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.44.0 Feb. 4, 2022
### Enhancements
- Updated ``DefaultAlgorithm`` to also limit estimator usage for long-running multiclass problems #3099
- Added ``make_pipeline_from_data_check_output()`` utility method #3277
- Added more specific data check errors to ``DatetimeFormatDataCheck`` #3288
### Fixes
- Updated the binary classification pipeline's ``optimize_thresholds`` method to use Nelder-Mead #3280
- Fixed bug where feature importance on time series pipelines only showed 0 for time index #3285
### Changes
- Removed ``DateTimeNaNDataCheck`` and ``NaturalLanguageNaNDataCheck`` in favor of ``NullDataCheck`` #3260
- Drop support for Python 3.7 #3291
- Updated minimum version of ``woodwork`` to ``v0.12.0`` #3290
### Documentation Changes
- Update documentation and docstring for `validate_holdout_datasets` for time series problems #3278
- Fixed mistake in documentation where wrong objective was used for calculating percent-better-than-baseline #3285
### Testing Changes
### Breaking Changes
- Removed ``DateTimeNaNDataCheck`` and ``NaturalLanguageNaNDataCheck`` in favor of ``NullDataCheck`` #3260
- Dropped support for Python 3.7 #3291