### PR TITLE
Add auto approve dependency workflow schedule

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -1,5 +1,7 @@
 name: Auto Approve Dependency PRs
 on:
+  schedule:
+      - cron: '*/30 * * * *'
   workflow_dispatch:
   workflow_run:
     workflows: ["Unit tests, linux, latest dependencies", "Unit tests, linux, min dependencies"]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@
         * Added an ``is_cv`` property to the datasplitters used :pr:`3297`
     * Documentation Changes
     * Testing Changes
-
+        * Add auto approve dependency workflow schedule for every 30 mins :pr:`3312`
 
 .. warning::
 


### PR DESCRIPTION
- For some reason, the auto approve workflow does not get kickoff (with latest dependency PRs)
- This PR makes it so that it runs every 30 mins (which we knows works)
