### PR TITLE
Add test to ensure `positive_label` passed properly in AMLSearch

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@
 
 **Future Releases**
     * Enhancements
+        * Added tests to ensure variables passed correctly to label encoder in ``AutoMLSearch`` :pr:``
     * Fixes
     * Changes
         * Added an ``is_cv`` property to the datasplitters used :pr:`3297`


### PR DESCRIPTION
fix #3068 