### PR TITLE
Shorten results output in docs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@
         * Added an ``is_cv`` property to the datasplitters used :pr:`3297`
     * Documentation Changes
         * Update README.md with Alteryx link (:pr:`3319`)
+        * Added scrollbar to the AutoML user guide to shorten result outputs :pr:`3328`
     * Testing Changes
         * Add auto approve dependency workflow schedule for every 30 mins :pr:`3312`
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,7 +9,7 @@
         * Added an ``is_cv`` property to the datasplitters used :pr:`3297`
     * Documentation Changes
         * Update README.md with Alteryx link (:pr:`3319`)
-        * Added scrollbar to the AutoML user guide to shorten result outputs :pr:`3328`
+        * Added formatting to the AutoML user guide to shorten result outputs :pr:`3328`
     * Testing Changes
         * Add auto approve dependency workflow schedule for every 30 mins :pr:`3312`
 

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -653,7 +653,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "output_scroll"
+    ]     
+   },
    "outputs": [],
    "source": [
     "automl.results"

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -653,14 +653,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "output_scroll"
-    ]     
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "automl.results"
+    "import pprint\n",
+    "pp = pprint.PrettyPrinter(indent=0, width=100, depth=3, compact=True, sort_dicts=False)\n",
+    "\n",
+    "pp.pprint(automl.results)"
    ]
   },
   {

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -658,9 +658,18 @@
    "outputs": [],
    "source": [
     "import pprint\n",
-    "pp = pprint.PrettyPrinter(indent=0, width=100, depth=3, compact=True, sort_dicts=False)\n",
+    "pp = pprint.PrettyPrinter(indent=0, width=100, depth=2, compact=True, sort_dicts=False)\n",
     "\n",
     "pp.pprint(automl.results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "automl.results['pipeline_results'][0]"
    ]
   },
   {

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -658,18 +658,9 @@
    "outputs": [],
    "source": [
     "import pprint\n",
-    "pp = pprint.PrettyPrinter(indent=0, width=100, depth=2, compact=True, sort_dicts=False)\n",
+    "pp = pprint.PrettyPrinter(indent=0, width=100, depth=3, compact=True, sort_dicts=False)\n",
     "\n",
     "pp.pprint(automl.results)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "automl.results['pipeline_results'][0]"
    ]
   },
   {


### PR DESCRIPTION
fix #3032 

Rather than editing the output of the results themselves, I figured the better approach would be to truncate the cell output for this.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/22552445/153950585-ce452121-5456-464f-b672-69e05561910b.png">

https://feature-labs-inc-evalml--3328.com.readthedocs.build/en/3328/user_guide/automl.html#Access-raw-results