### PR TITLE
Update DateTimeFormatDataCheck to flag all errors

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@
     * Fixes
     * Changes
         * Removed ``python_version<3.9`` environment marker from sktime dependency :pr:`3332`
+        * Updated ``DatetimeFormatDataCheck`` to return all messages and not return early if NaNs are detected :pr:`3354`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/data_checks/datetime_format_data_check.py
+++ b/evalml/data_checks/datetime_format_data_check.py
@@ -183,8 +183,6 @@ class DateTimeFormatDataCheck(DataCheck):
             self.datetime_column if self.datetime_column != "index" else "either index"
         )
 
-        is_increasing = pd.DatetimeIndex(datetime_values).is_monotonic_increasing
-
         nan_columns = datetime_values.isna().any()
         if nan_columns:
             messages.append(
@@ -194,8 +192,9 @@ class DateTimeFormatDataCheck(DataCheck):
                     message_code=DataCheckMessageCode.DATETIME_HAS_NAN,
                 ).to_dict()
             )
-            # NaN values are a more significant error than missing values and will break the data check logic, so we return here
-            return messages
+            datetime_values = datetime_values.dropna()
+
+        is_increasing = pd.DatetimeIndex(datetime_values).is_monotonic_increasing
 
         if not inferred_freq:
 


### PR DESCRIPTION
Instead of returning just an error if NaNs are found, `DateTimeFormatDataCheck` will now continue on and raise any other errors as well