### PR TITLE
Release v0.46.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,26 +3,30 @@
 
 **Future Releases**
     * Enhancements
-        * Added ``test_size`` parameter to ``ClassImbalanceDataCheck`` :pr:`3341`
-        * Make target optional for ``NoVarianceDataCheck`` :pr:`3339`
     * Fixes
     * Changes
-        * Removed ``python_version<3.9`` environment marker from sktime dependency :pr:`3332`
-        * Updated ``DatetimeFormatDataCheck`` to return all messages and not return early if NaNs are detected :pr:`3354`
     * Documentation Changes
-        * Added in-line tabs and copy-paste functionality to documentation, overhauled Install page :pr:`3353`
     * Testing Changes
 
 .. warning::
 
     **Breaking Changes**
 
+**v0.46.0 Mar. 03, 2022**
+    * Enhancements
+        * Added ``test_size`` parameter to ``ClassImbalanceDataCheck`` :pr:`3341`
+        * Make target optional for ``NoVarianceDataCheck`` :pr:`3339`
+    * Changes
+        * Removed ``python_version<3.9`` environment marker from sktime dependency :pr:`3332`
+        * Updated ``DatetimeFormatDataCheck`` to return all messages and not return early if NaNs are detected :pr:`3354`
+    * Documentation Changes
+        * Added in-line tabs and copy-paste functionality to documentation, overhauled Install page :pr:`3353`
+
 **v0.45.0 Feb. 17, 2022**
     * Enhancements
         * Added support for pandas >= 1.4.0 :pr:`3324`
         * Standardized feature importance for estimators :pr:`3305`
         * Replaced usage of private method with Woodwork's public ``get_subset_schema`` method :pr:`3325`
-    * Fixes
     * Changes
         * Added an ``is_cv`` property to the datasplitters used :pr:`3297`
         * Changed SimpleImputer to ignore Natural Language columns :pr:`3324`
@@ -49,7 +53,6 @@
     * Documentation Changes
         * Update documentation and docstring for `validate_holdout_datasets` for time series problems :pr:`3278`
         * Fixed mistake in documentation where wrong objective was used for calculating percent-better-than-baseline :pr:`3285`
-    * Testing Changes
 
 
 .. warning::
@@ -75,7 +78,6 @@
         * Renamed ``HighlyNullDataCheck`` to ``NullDataCheck`` :pr:`3197`
         * Updated data check ``validate()`` output to return a list of warnings and errors instead of a dictionary :pr:`3244`
         * Capped ``pandas`` at < 1.4.0 :pr:`3274`
-    * Documentation Changes
     * Testing Changes
         * Bumped minimum ``IPython`` version to 7.16.3 in ``test-requirements.txt`` based on dependabot feedback :pr:`3269`
 
@@ -109,7 +111,6 @@
         * Changed the default objective to ``MedianAE`` from ``R2`` for time series regression :pr:`3205`
         * Removed all-nan Unknown to Double logical conversion in ``infer_feature_types`` :pr:`3196`
         * Checking the validity of holdout data for time series problems can be performed by calling ``pipelines.utils.validate_holdout_datasets`` prior to calling ``predict`` :pr:`3208`
-    * Documentation Changes
     * Testing Changes
         * Update auto approve workflow trigger and delete branch after merge :pr:`3265`
 

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.45.0',
+    version='0.46.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.46.0 Mar. 3, 2022
### Enhancements
- Added ``test_size`` parameter to ``ClassImbalanceDataCheck`` #3341
- Make target optional for ``NoVarianceDataCheck`` #3339
### Changes
- Removed ``python_version<3.9`` environment marker from sktime dependency #3332
- Updated ``DatetimeFormatDataCheck`` to return all messages and not return early if NaNs are detected #3354
### Documentation Changes
- Added in-line tabs and copy-paste functionality to documentation, overhauled Install page #3353