### PR TITLE
Fix threshold return in AutoMLSearch

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@
     * Enhancements
         * Added caching capability for ensemble training during ``AutoMLSearch`` :pr:`3257`
     * Fixes
+        * Fixed ``get_pipelines`` to reset pipeline threshold for binary cases :pr:``
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@
     * Enhancements
         * Added caching capability for ensemble training during ``AutoMLSearch`` :pr:`3257`
     * Fixes
-        * Fixed ``get_pipelines`` to reset pipeline threshold for binary cases :pr:``
+        * Fixed ``get_pipelines`` to reset pipeline threshold for binary cases :pr:`3360`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1276,7 +1276,7 @@ class AutoMLSearch:
             )
         new_pipeline = pipeline.new(parameters, random_seed=self.random_seed)
         if is_binary(self.problem_type):
-            new_pipeline.threshold = pipeline.threshold
+            new_pipeline.threshold = None
         return new_pipeline
 
     def describe_pipeline(self, pipeline_id, return_dict=False):

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -479,7 +479,7 @@ def test_non_optimizable_threshold(AutoMLTestEnv, X_y_binary):
     )
 
 
-def test_optimize_threshold_maintained(AutoMLTestEnv, X_y_binary):
+def test_optimize_threshold_get_pipeline_reset(AutoMLTestEnv, X_y_binary):
     X, y = X_y_binary
     automl = AutoMLSearch(
         X_train=X,
@@ -502,7 +502,7 @@ def test_optimize_threshold_maintained(AutoMLTestEnv, X_y_binary):
 
     best_pipeline_id = automl.rankings["id"][0]
     best_get = automl.get_pipeline(best_pipeline_id)
-    assert best_get.threshold == 0.8
+    assert best_get.threshold is None
 
 
 def test_describe_pipeline_objective_ordered(X_y_binary, caplog):


### PR DESCRIPTION
fix #3295 

Don't use the threshold of the last cv fold. Instead, we set to none.
