### PR TITLE
Conditionally run scheduled workflows

### DIFF
--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -12,6 +12,7 @@ on:
       - completed
 jobs:
   build:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
       - name: Find dependency PRs

--- a/.github/workflows/auto_approve_dependency_PRs.yml
+++ b/.github/workflows/auto_approve_dependency_PRs.yml
@@ -12,7 +12,7 @@ on:
       - completed
 jobs:
   build:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     runs-on: ubuntu-latest
     steps:
       - name: Find dependency PRs

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   update-deps:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/latest_dependency_checker.yml
+++ b/.github/workflows/latest_dependency_checker.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   update-deps:
+    if: ${{ github.repository_owner == 'alteryx' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit_tests:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/linux_nightlies.yml
+++ b/.github/workflows/linux_nightlies.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   unit_tests:
+    if: ${{ github.repository_owner == 'alteryx' }}
     name: Nightly ${{ matrix.python_version }} ${{matrix.command}}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   win_unit_tests:
+    if: ${{ github.repository_owner == 'alteryx' }}
     name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/windows_nightlies.yml
+++ b/.github/workflows/windows_nightlies.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   win_unit_tests:
-    if: ${{ github.repository_owner == 'alteryx' }}
+    if: github.repository_owner == 'alteryx'
     name: Nightly ${{ matrix.python_version }} windows ${{ matrix.command}}
     runs-on: windows-latest
     strategy:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@
         * Allow woodwork version 0.14.0 to be installed :pr:`3381`
     * Documentation Changes
     * Testing Changes
+        * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`3395`)
 
 .. warning::
 


### PR DESCRIPTION
### Conditionally run scheduled workflows

Closes #3393 

Update scheduled workflows to run only if repository_owner is alteryx. This should prevent these scheduled workflows from running on repo forks and failing repeatedly.
