### PR TITLE
exclude non-latest versions of docs from broken link checker

### DIFF
--- a/.github/workflows/broken_link_checker.yml
+++ b/.github/workflows/broken_link_checker.yml
@@ -15,7 +15,7 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://evalml.alteryx.com/en/latest/index.html
-          cmd_params: '--max-connections=10 --color=always --ignore-fragments --buffer-size=8192 --exclude="(twitter|github|cloudflare)"'
+          cmd_params: '--max-connections=10 --color=always --ignore-fragments --buffer-size=8192 --exclude="(twitter|github|cloudflare|evalml\\.alteryx\\.com\\/en\\/(stable|main|v.+).*)"'
       - name: Notify on Slack
         uses: 8398a7/action-slack@v3
         env:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@
         * Pinned jinja2 to 3.0.3 :pr:`3402`
     * Testing Changes
         * Updated scheduled workflows to only run on Alteryx owned repos (:pr:`3395`)
+        * Exclude documentation versions other than latest from broken link check :pr:`3401`
 
 .. warning::
 


### PR DESCRIPTION
### Pull Request Description
Follow up to https://github.com/alteryx/evalml/pull/3398

The crawler ended up following a link on the latest version of the docs to the stable version of the docs, which did not contain a fix to a broken link, leading to a failed check. This PR updates the `exclude` argument to not check documentation pages for versions other than latest. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
