### PR TITLE
Revert "Remove `pipeline_parameters` and `custom_hyperparameters` and replace with `search_parameters`"

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@
     * Fixes
         * Fixed ``TimeSeriesFeaturizer`` to make it deterministic when creating and choosing columns :pr:`3384`
         * Fixed bug where Email/URL features with missing values would cause the imputer to error out :pr:`3388`
+        * Reverted changes to group parameters and hyper-params into ``search_parameters`` :pr:`3410`
     * Changes
         * Update maintainers to add Frank :pr:`3382`
         * Allow woodwork version 0.14.0 to be installed :pr:`3381`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,12 +3,10 @@
 
 **Future Releases**
     * Enhancements
-        * Replaced ``pipeline_parameters`` and ``custom_hyperparameters`` with ``search_parameters`` in ``AutoMLSearch`` :pr:`3373`
         * Add support for oversampling in time series classification problems :pr:`3387`
     * Fixes
         * Fixed ``TimeSeriesFeaturizer`` to make it deterministic when creating and choosing columns :pr:`3384`
         * Fixed bug where Email/URL features with missing values would cause the imputer to error out :pr:`3388`
-        * Simplified internal ``AutoMLSearch`` API to rely on ``search_parameters`` :pr:`3373`
     * Changes
         * Update maintainers to add Frank :pr:`3382`
         * Allow woodwork version 0.14.0 to be installed :pr:`3381`
@@ -23,7 +21,6 @@
 .. warning::
 
     **Breaking Changes**
-        * Replaced ``pipeline_parameters`` and ``custom_hyperparameters`` with ``search_parameters`` in ``AutoMLSearch`` :pr:`3373`
 
 
 **v0.47.0 Mar. 16, 2022**

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -477,11 +477,11 @@
    "metadata": {},
    "source": [
     "## Limiting the AutoML Search Space\n",
-    "The AutoML search algorithm first trains each component in the pipeline with their default values. After the first iteration, it then tweaks the parameters of these components using the pre-defined hyperparameter ranges that these components have. To limit the search over certain hyperparameter ranges, you can specify a `search_parameters` argument with your `AutoMLSearch` parameters. These parameters will limit the hyperparameter search space or pipeline parameter space. \n",
+    "The AutoML search algorithm first trains each component in the pipeline with their default values. After the first iteration, it then tweaks the parameters of these components using the pre-defined hyperparameter ranges that these components have. To limit the search over certain hyperparameter ranges, you can specify a `custom_hyperparameters` argument with your `AutoMLSearch` parameters. These parameters will limit the hyperparameter search space. \n",
     "\n",
-    "Hyperparameter ranges can be found through the [API reference](https://evalml.alteryx.com/en/stable/api_index.html) for each component. Parameter arguments must be specified as dictionaries, but the associated values must be `skopt.space` Real, Integer, Categorical objects for setting hyperparameter ranges.\n",
+    "Hyperparameter ranges can be found through the [API reference](https://evalml.alteryx.com/en/stable/api_index.html) for each component. Parameter arguments must be specified as dictionaries, but the associated values can be single values or `skopt.space` Real, Integer, Categorical values.\n",
     "\n",
-    "If however you'd like to specify certain values for the initial batch of the AutoML search algorithm, you can use the `search_parameters` argument with non `skopt.space` objects. This will set the initial batch's component parameters to the values passed by this argument."
+    "If however you'd like to specify certain values for the initial batch of the AutoML search algorithm, you can use the `pipeline_parameters` argument. This will set the initial batch's component parameters to the values passed by this argument."
    ]
   },
   {
@@ -499,50 +499,28 @@
     "X, y = load_fraud(n_rows=1000)\n",
     "\n",
     "# example of setting parameter to just one value\n",
-    "search_parameters = {'Imputer': {\n",
+    "custom_hyperparameters = {'Imputer': {\n",
     "    'numeric_impute_strategy': 'mean'\n",
     "}}\n",
     "\n",
     "\n",
     "# limit the numeric impute strategy to include only `median` and `most_frequent`\n",
     "# `mean` is the default value for this argument, but it doesn't need to be included in the specified hyperparameter range for this to work\n",
-    "search_parameters = {'Imputer': {\n",
+    "custom_hyperparameters = {'Imputer': {\n",
     "    'numeric_impute_strategy': Categorical(['median', 'most_frequent'])\n",
+    "}}\n",
+    "# set the initial batch numeric impute strategy strategy to 'median'\n",
+    "pipeline_parameters = {'Imputer': {\n",
+    "    'numeric_impute_strategy': 'median'\n",
     "}}\n",
     "\n",
     "# using this custom hyperparameter means that our Imputer components in these pipelines will only search through\n",
-    "# 'median' and 'most_frequent' strategies for 'numeric_impute_strategy'\n",
+    "# 'median' and 'most_frequent' strategies for 'numeric_impute_strategy', and the initial batch parameter will be\n",
+    "# set to 'median'\n",
     "automl_constrained = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', \n",
-    "                                  search_parameters=search_parameters,\n",
+    "                                  pipeline_parameters=pipeline_parameters,\n",
+    "                                  custom_hyperparameters=custom_hyperparameters, \n",
     "                                  verbose=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A `skopt.space` Integer, Real, or Categorical will set the hyperparameter space explored during search. All other values will set the pipeline parameters directly. Setting pipeline parameters directly defines the initialization parameters that a pipeline starts with during the first batch of AutoMLSearch. the hyperparameter range then defines the space of possible new parameter values, which the tuner chooses.\n",
-    "\n",
-    "Let's walk through some examples to explain this. For instance,\n",
-    "```python\n",
-    "search_parameters = {'Imputer': {\n",
-    "    'numeric_impute_strategy': 'mean'\n",
-    "}}\n",
-    "```\n",
-    "then in the initial search, the algorithm would use `mean` as the impute strategy in batch 1. However, since `Imputer.numeric_impute_strategy` has a valid hyperparameter range, if the algorithm suggests a different strategy, it can and will change this value. To limit this to using `mean` only for the duration of the search, it is necessary to use the `skopt.space`:\n",
-    "```python\n",
-    "search_parameters = {'Imputer': {\n",
-    "    'numeric_impute_strategy': Categorical(['mean'])\n",
-    "}}\n",
-    "```\n",
-    "\n",
-    "However, if a value has no hyperparameter range associated, then the algorithm will use this value as the only parameter. For instance,\n",
-    "```python\n",
-    "search_parameters = {'Label Encoder': {\n",
-    "    'positive_label': True\n",
-    "}}\n",
-    "```\n",
-    "Since `Label Encoder.positive_label` has no associated hyperparameter range, the algorithm will use this parameter for the entire duration of the search."
    ]
   },
   {
@@ -601,16 +579,16 @@
     "# for the oversampler, we don't want to oversample this class, so class 0 (majority) will have a ratio of 1 to itself\n",
     "# for the minority class 1, we want to oversample it to have a minority/majority ratio of 0.5, which means we want minority to have 1/2 the samples as the minority\n",
     "sampler_ratio_dict = {0: 1, 1: 0.5}\n",
-    "search_parameters = {\"Oversampler\": {\"sampler_balanced_ratio\": sampler_ratio_dict}}\n",
-    "automl_auto_ratio_dict = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', search_parameters=search_parameters, automl_algorithm='iterative')\n",
+    "pipeline_parameters = {\"Oversampler\": {\"sampler_balanced_ratio\": sampler_ratio_dict}}\n",
+    "automl_auto_ratio_dict = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', pipeline_parameters=pipeline_parameters, automl_algorithm='iterative')\n",
     "automl_auto_ratio_dict.allowed_pipelines[-1]\n",
     "\n",
     "# Undersampler case\n",
     "# we don't want to undersample this class, so class 1 (minority) will have a ratio of 1 to itself\n",
     "# for the majority class 0, we want to undersample it to have a minority/majority ratio of 0.5, which means we want majority to have 2x the samples as the minority\n",
     "# sampler_ratio_dict = {0: 0.5, 1: 1}\n",
-    "# search_parameters = {\"Oversampler\": {\"sampler_balanced_ratio\": sampler_ratio_dict}}\n",
-    "# automl_auto_ratio_dict = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', search_parameters=search_parameters)\n"
+    "# pipeline_parameters = {\"Oversampler\": {\"sampler_balanced_ratio\": sampler_ratio_dict}}\n",
+    "# automl_auto_ratio_dict = AutoMLSearch(X_train=X, y_train=y, problem_type='binary', pipeline_parameters=pipeline_parameters)\n"
    ]
   },
   {

--- a/evalml/automl/automl_algorithm/automl_algorithm.py
+++ b/evalml/automl/automl_algorithm/automl_algorithm.py
@@ -1,8 +1,5 @@
 """Base class for the AutoML algorithms which power EvalML."""
-import inspect
 from abc import ABC, abstractmethod
-
-from skopt.space import Categorical, Integer, Real
 
 from evalml.exceptions import PipelineNotFoundError
 from evalml.pipelines.utils import _make_stacked_ensemble_pipeline
@@ -25,7 +22,7 @@ class AutoMLAlgorithm(ABC):
 
     Args:
         allowed_pipelines (list(class)): A list of PipelineBase subclasses indicating the pipelines allowed in the search. The default of None indicates all pipelines for this problem type are allowed.
-        search_parameters (dict): Search parameter ranges specified for pipelines to iterate over.
+        custom_hyperparameters (dict): Custom hyperparameter ranges specified for pipelines to iterate over.
         tuner_class (class): A subclass of Tuner, to be used to find parameters for each pipeline. The default of None indicates the SKOptTuner will be used.
         text_in_ensembling (boolean): If True and ensembling is True, then n_jobs will be set to 1 to avoid downstream sklearn stacking issues related to nltk. Defaults to None.
         random_seed (int): Seed for the random number generator. Defaults to 0.
@@ -34,25 +31,27 @@ class AutoMLAlgorithm(ABC):
     def __init__(
         self,
         allowed_pipelines=None,
-        search_parameters=None,
+        custom_hyperparameters=None,
         tuner_class=None,
         text_in_ensembling=False,
         random_seed=0,
         n_jobs=-1,
     ):
         self.random_seed = random_seed
+        self.allowed_pipelines = allowed_pipelines or []
         self._tuner_class = tuner_class or SKOptTuner
         self._tuners = {}
         self._best_pipeline_info = {}
         self.text_in_ensembling = text_in_ensembling
         self.n_jobs = n_jobs
         self._selected_cols = None
-        self.search_parameters = search_parameters or {}
-        self._hyperparameters = {}
-        self._pipeline_parameters = {}
-        self.allowed_pipelines = []
-        if allowed_pipelines is not None:
-            self._set_allowed_pipelines(allowed_pipelines)
+        for pipeline in self.allowed_pipelines:
+            pipeline_hyperparameters = pipeline.get_hyperparameter_ranges(
+                custom_hyperparameters
+            )
+            self._tuners[pipeline.name] = self._tuner_class(
+                pipeline_hyperparameters, random_seed=self.random_seed
+            )
         self._pipeline_number = 0
         self._batch_number = 0
         self._default_max_batches = 1
@@ -65,72 +64,14 @@ class AutoMLAlgorithm(ABC):
             list[PipelineBase]: A list of instances of PipelineBase subclasses, ready to be trained and evaluated.
         """
 
-    def _set_allowed_pipelines(self, allowed_pipelines):
-        """Sets the allowed parameters and creates the tuners for the input pipelines."""
-        self.allowed_pipelines = allowed_pipelines
-        for pipeline in self.allowed_pipelines:
-            self._create_tuner(pipeline)
-
-    def _create_tuner(self, pipeline):
-        """Creates a tuner given the input pipeline."""
-        pipeline_hyperparameters = pipeline.get_hyperparameter_ranges(
-            self._hyperparameters
-        )
-        self._tuners[pipeline.name] = self._tuner_class(
-            pipeline_hyperparameters, random_seed=self.random_seed
-        )
-
-    def _separate_hyperparameters_from_parameters(self):
-        """Seperate out the parameter and hyperparameter values from the search parameters dict."""
-        for key, value in self.search_parameters.items():
-            hyperparam = {}
-            param = {}
-            for name, parameters in value.items():
-                if isinstance(parameters, (Integer, Categorical, Real)):
-                    hyperparam[name] = parameters
-                else:
-                    param[name] = parameters
-            if hyperparam:
-                self._hyperparameters[key] = hyperparam
-            if param:
-                self._pipeline_parameters[key] = param
-
+    @abstractmethod
     def _transform_parameters(self, pipeline, proposed_parameters):
-        """Given a pipeline parameters dict, make sure pipeline_parameters, custom_hyperparameters, n_jobs are set properly.
+        """Given a pipeline parameters dict, make sure pipeline_params, custom_hyperparameters, n_jobs are set properly.
 
         Arguments:
             pipeline (PipelineBase): The pipeline object to update the parameters.
             proposed_parameters (dict): Parameters to use when updating the pipeline.
         """
-        parameters = {}
-        if "pipeline" in self._pipeline_parameters:
-            parameters["pipeline"] = self._pipeline_parameters["pipeline"]
-        for (
-            name,
-            component_instance,
-        ) in pipeline.component_graph.component_instances.items():
-            component_class = type(component_instance)
-            component_parameters = proposed_parameters.get(name, {})
-            init_params = inspect.signature(component_class.__init__).parameters
-            # Only overwrite the parameters that were passed in on pipeline parameters
-            # if they don't exist in the propsed parameters
-            if name in self._pipeline_parameters and name not in component_parameters:
-                for param_name, value in self._pipeline_parameters[name].items():
-                    component_parameters[param_name] = value
-            # Inspects each component and adds the following parameters when needed
-            if "n_jobs" in init_params:
-                component_parameters["n_jobs"] = self.n_jobs
-            try:
-                if "number_features" in init_params:
-                    component_parameters["number_features"] = self.number_features
-            except AttributeError:
-                continue
-            if "pipeline" in self.search_parameters:
-                for param_name, value in self.search_parameters["pipeline"].items():
-                    if param_name in init_params:
-                        component_parameters[param_name] = value
-            parameters[name] = component_parameters
-        return parameters
 
     def add_result(self, score_to_minimize, pipeline, trained_pipeline_results):
         """Register results from evaluating a pipeline.
@@ -190,8 +131,8 @@ class AutoMLAlgorithm(ABC):
 
     def _set_additional_pipeline_params(self):
         drop_columns = (
-            self.search_parameters["Drop Columns Transformer"]["columns"]
-            if "Drop Columns Transformer" in self.search_parameters
+            self._pipeline_params["Drop Columns Transformer"]["columns"]
+            if "Drop Columns Transformer" in self._pipeline_params
             else None
         )
         index_and_unknown_columns = list(
@@ -199,22 +140,22 @@ class AutoMLAlgorithm(ABC):
         )
         unknown_columns = list(self.X.ww.select("unknown", return_schema=True).columns)
         if len(index_and_unknown_columns) > 0 and drop_columns is None:
-            self.search_parameters["Drop Columns Transformer"] = {
+            self._pipeline_params["Drop Columns Transformer"] = {
                 "columns": index_and_unknown_columns
             }
             if len(unknown_columns):
                 self.logger.info(
                     f"Removing columns {unknown_columns} because they are of 'Unknown' type"
                 )
-        kina_columns = self.search_parameters.get("pipeline", {}).get(
+        kina_columns = self._pipeline_params.get("pipeline", {}).get(
             "known_in_advance", []
         )
         if kina_columns:
             no_kin_columns = [c for c in self.X.columns if c not in kina_columns]
             kin_name = "Known In Advance Pipeline - Select Columns Transformer"
             no_kin_name = "Not Known In Advance Pipeline - Select Columns Transformer"
-            self.search_parameters[kin_name] = {"columns": kina_columns}
-            self.search_parameters[no_kin_name] = {"columns": no_kin_columns}
+            self._pipeline_params[kin_name] = {"columns": kina_columns}
+            self._pipeline_params[no_kin_name] = {"columns": no_kin_columns}
 
     def _filter_estimators(
         self,

--- a/evalml/automl/automl_algorithm/iterative_algorithm.py
+++ b/evalml/automl/automl_algorithm/iterative_algorithm.py
@@ -1,9 +1,11 @@
 """An automl algorithm which first fits a base round of pipelines with default parameters, then does a round of parameter tuning on each pipeline in order of performance."""
+import inspect
 import logging
 import warnings
 from operator import itemgetter
 
 import numpy as np
+from skopt.space import Categorical, Integer, Real
 
 from .automl_algorithm import AutoMLAlgorithm, AutoMLAlgorithmException
 
@@ -55,8 +57,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         number_features (int): The number of columns in the input features. Defaults to None.
         ensembling (boolean): If True, runs ensembling in a separate batch after every allowed pipeline class has been iterated over. Defaults to False.
         text_in_ensembling (boolean): If True and ensembling is True, then n_jobs will be set to 1 to avoid downstream sklearn stacking issues related to nltk. Defaults to False.
-        search_parameters (dict or None): Pipeline-level parameters and custom hyperparameter ranges specified for pipelines to iterate over. Hyperparameter ranges
-            must be passed in as skopt.space objects. Defaults to None.
+        pipeline_params (dict or None): Pipeline-level parameters that should be passed to the proposed pipelines. Defaults to None.
+        custom_hyperparameters (dict or None): Custom hyperparameter ranges specified for pipelines to iterate over. Defaults to None.
         _estimator_family_order (list(ModelFamily) or None): specify the sort order for the first batch. Defaults to None, which uses _ESTIMATOR_FAMILY_ORDER.
         allow_long_running_models (bool): Whether or not to allow longer-running models for large multiclass problems. If False and no pipelines, component graphs, or model families are provided,
             AutoMLSearch will not use Elastic Net or XGBoost when there are more than 75 multiclass targets and will not use CatBoost when there are more than 150 multiclass targets. Defaults to False.
@@ -81,7 +83,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         number_features=None,  # TODO remove
         ensembling=False,
         text_in_ensembling=False,
-        search_parameters=None,
+        pipeline_params=None,
+        custom_hyperparameters=None,
         _estimator_family_order=None,
         allow_long_running_models=False,
         features=None,
@@ -99,7 +102,8 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         self._first_batch_results = []
         self._best_pipeline_info = {}
         self.ensembling = ensembling
-        self.search_parameters = search_parameters or {}
+        self._pipeline_params = pipeline_params or {}
+        self._custom_hyperparameters = custom_hyperparameters or {}
         self.text_in_ensembling = text_in_ensembling
         self.max_batches = max_batches
         self.max_iterations = max_iterations
@@ -112,27 +116,40 @@ class IterativeAlgorithm(AutoMLAlgorithm):
         self._estimator_family_order = (
             _estimator_family_order or _ESTIMATOR_FAMILY_ORDER
         )
-        if search_parameters and not isinstance(search_parameters, dict):
-            raise ValueError(
-                f"If search_parameters provided, must be of type dict. Received {type(search_parameters)}"
-            )
-        self.allowed_pipelines = []
 
         self.features = features
         self.allowed_component_graphs = allowed_component_graphs
         self._set_additional_pipeline_params()
+        self._create_pipelines()
 
         super().__init__(
             allowed_pipelines=self.allowed_pipelines,
-            search_parameters=self.search_parameters,
+            custom_hyperparameters=custom_hyperparameters,
             tuner_class=tuner_class,
             text_in_ensembling=self.text_in_ensembling,
             random_seed=random_seed,
             n_jobs=self.n_jobs,
         )
-        self._separate_hyperparameters_from_parameters()
-        self._create_pipelines()
-        self._set_allowed_pipelines(self.allowed_pipelines)
+
+        if custom_hyperparameters and not isinstance(custom_hyperparameters, dict):
+            raise ValueError(
+                f"If custom_hyperparameters provided, must be of type dict. Received {type(custom_hyperparameters)}"
+            )
+
+        for param_name_val in self._pipeline_params.values():
+            for _, param_val in param_name_val.items():
+                if isinstance(param_val, (Integer, Real, Categorical)):
+                    raise ValueError(
+                        "Pipeline parameters should not contain skopt.Space variables, please pass them "
+                        "to custom_hyperparameters instead!"
+                    )
+        for hyperparam_name_val in self._custom_hyperparameters.values():
+            for _, hyperparam_val in hyperparam_name_val.items():
+                if not isinstance(hyperparam_val, (Integer, Real, Categorical)):
+                    raise ValueError(
+                        "Custom hyperparameters should only contain skopt.Space variables such as Categorical, Integer,"
+                        " and Real!"
+                    )
 
     def _create_pipelines(self):
         indices = []
@@ -163,11 +180,11 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                         self.y,
                         estimator,
                         self.problem_type,
-                        parameters=self._pipeline_parameters,
+                        parameters=self._pipeline_params,
                         sampler_name=self.sampler_name,
-                        known_in_advance=self._pipeline_parameters.get(
-                            "pipeline", {}
-                        ).get("known_in_advance", None),
+                        known_in_advance=self._pipeline_params.get("pipeline", {}).get(
+                            "known_in_advance", None
+                        ),
                         features=self.features,
                     )
                     for estimator in allowed_estimators
@@ -179,10 +196,11 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                 self.allowed_pipelines = get_pipelines_from_component_graphs(
                     self.allowed_component_graphs,
                     self.problem_type,
-                    self._pipeline_parameters,
+                    self._pipeline_params,
                     self.random_seed,
                 )
             self._catch_warnings(w)
+
         if self.allowed_pipelines == []:
             raise ValueError("No allowed pipelines to search")
 
@@ -283,14 +301,13 @@ class IterativeAlgorithm(AutoMLAlgorithm):
 
         next_batch = []
         if self._batch_number == 0:
-            for pipeline in self.allowed_pipelines:
-                starting_parameters = self._tuners[
-                    pipeline.name
-                ].get_starting_parameters()
-                parameters = self._transform_parameters(pipeline, starting_parameters)
-                next_batch.append(
-                    pipeline.new(parameters=parameters, random_seed=self.random_seed)
+            next_batch = [
+                pipeline.new(
+                    parameters=self._transform_parameters(pipeline, {}),
+                    random_seed=self.random_seed,
                 )
+                for pipeline in self.allowed_pipelines
+            ]
 
         # One after training all pipelines one round
         elif (
@@ -374,6 +391,60 @@ class IterativeAlgorithm(AutoMLAlgorithm):
                     }
                 }
             )
+
+    def _transform_parameters(self, pipeline, proposed_parameters):
+        """Given a pipeline parameters dict, make sure n_jobs and number_features are set."""
+        parameters = {}
+        if "pipeline" in self._pipeline_params:
+            parameters["pipeline"] = self._pipeline_params["pipeline"]
+
+        for (
+            name,
+            component_instance,
+        ) in pipeline.component_graph.component_instances.items():
+            component_class = type(component_instance)
+            component_parameters = proposed_parameters.get(name, {})
+            init_params = inspect.signature(component_class.__init__).parameters
+            # For first batch, pass the pipeline params to the components that need them
+            if name in self._custom_hyperparameters and self._batch_number == 0:
+                for param_name, value in self._custom_hyperparameters[name].items():
+                    if isinstance(value, (Integer, Real)):
+                        # get a random value in the space
+                        component_parameters[param_name] = value.rvs(
+                            random_state=self.random_seed
+                        )[0]
+                    # Categorical
+                    else:
+                        component_parameters[param_name] = value.rvs(
+                            random_state=self.random_seed
+                        )
+            if name in self._pipeline_params and self._batch_number == 0:
+                for param_name, value in self._pipeline_params[name].items():
+                    component_parameters[param_name] = value
+            # Inspects each component and adds the following parameters when needed
+            if "n_jobs" in init_params:
+                component_parameters["n_jobs"] = self.n_jobs
+            if "number_features" in init_params:
+                component_parameters["number_features"] = self.number_features
+            if name == "DFS Transformer" and self.features:
+                component_parameters["features"] = self.features
+            names_to_check = [
+                "Drop Columns Transformer",
+                "Known In Advance Pipeline - Select Columns Transformer",
+                "Not Known In Advance Pipeline - Select Columns Transformer",
+            ]
+            if (
+                name in self._pipeline_params
+                and name in names_to_check
+                and self._batch_number > 0
+            ):
+                component_parameters["columns"] = self._pipeline_params[name]["columns"]
+            if "pipeline" in self._pipeline_params:
+                for param_name, value in self._pipeline_params["pipeline"].items():
+                    if param_name in init_params:
+                        component_parameters[param_name] = value
+            parameters[name] = component_parameters
+        return parameters
 
     def _catch_warnings(self, warning_list):
         parameter_not_used_warnings = []

--- a/evalml/tests/automl_tests/parallel_tests/test_automl_dask.py
+++ b/evalml/tests/automl_tests/parallel_tests/test_automl_dask.py
@@ -205,9 +205,10 @@ def test_automl_immediate_quit(
         pipelines_per_batch=5,
         ensembling=False,
         text_in_ensembling=False,
-        search_parameters={},
+        pipeline_params={},
+        custom_hyperparameters=None,
     )
-    automl.automl_algorithm._set_allowed_pipelines(pipelines)
+    automl.automl_algorithm.allowed_pipelines = pipelines
 
     # Ensure the broken pipeline raises the error
     with pytest.raises(Exception, match="Yikes"):

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -1937,9 +1937,11 @@ def test_percent_better_than_baseline_in_rankings(
         pipelines_per_batch=5,
         ensembling=False,
         text_in_ensembling=False,
-        search_parameters=pipeline_parameters,
+        pipeline_params=pipeline_parameters,
+        custom_hyperparameters=None,
     )
-    automl.automl_algorithm._set_allowed_pipelines(allowed_pipelines)
+    automl.automl_algorithm.allowed_pipelines = allowed_pipelines
+    automl._SLEEP_TIME = 0.000001
     with patch(
         baseline_pipeline_class + ".score",
         return_value={objective.name: baseline_score},
@@ -2108,7 +2110,7 @@ def test_percent_better_than_baseline_computed_for_all_objectives(
         pipelines_per_batch=5,
         ensembling=False,
         text_in_ensembling=False,
-        search_parameters={
+        pipeline_params={
             "pipeline": {
                 "time_index": "date",
                 "gap": 1,
@@ -2116,8 +2118,10 @@ def test_percent_better_than_baseline_computed_for_all_objectives(
                 "forecast_horizon": 2,
             }
         },
+        custom_hyperparameters=None,
     )
-    automl.automl_algorithm._set_allowed_pipelines([DummyPipeline(parameters)])
+    automl.automl_algorithm.allowed_pipelines = [DummyPipeline(parameters)]
+    automl._SLEEP_TIME = 0.00001
     with patch(baseline_pipeline_class + ".score", return_value=mock_baseline_scores):
         automl.search()
         assert (
@@ -2157,9 +2161,7 @@ def test_time_series_regression_with_parameters(ts_data):
         problem_configuration=problem_configuration,
         max_batches=3,
     )
-    assert (
-        automl.automl_algorithm.search_parameters["pipeline"] == problem_configuration
-    )
+    assert automl.automl_algorithm._pipeline_params["pipeline"] == problem_configuration
 
 
 @pytest.mark.parametrize("graph_type", ["dict", "cg"])
@@ -2262,9 +2264,10 @@ def test_percent_better_than_baseline_scores_different_folds(
         pipelines_per_batch=5,
         ensembling=False,
         text_in_ensembling=False,
-        search_parameters={},
+        pipeline_params={},
+        custom_hyperparameters=None,
     )
-    automl.automl_algorithm._set_allowed_pipelines([DummyPipeline({})])
+    automl.automl_algorithm.allowed_pipelines = [DummyPipeline({})]
 
     env = AutoMLTestEnv("binary")
     with env.test_context(score_return_value={"Log Loss Binary": 1, "F1": 1}):
@@ -3042,7 +3045,7 @@ def test_automl_pipeline_params_simple(AutoMLTestEnv, X_y_binary):
         X_train=X,
         y_train=y,
         problem_type="binary",
-        search_parameters=params,
+        pipeline_parameters=params,
         optimize_thresholds=False,
         n_jobs=1,
     )
@@ -3083,7 +3086,7 @@ def test_automl_pipeline_params_multiple(AutoMLTestEnv, X_y_regression):
         X_train=X,
         y_train=y,
         problem_type="regression",
-        search_parameters=hyperparams,
+        custom_hyperparameters=hyperparams,
         optimize_thresholds=False,
         n_jobs=1,
     )
@@ -3111,6 +3114,31 @@ def test_automl_pipeline_params_multiple(AutoMLTestEnv, X_y_regression):
             ] == Categorical((0.01, 0.02, 0.03)).rvs(random_state=automl.random_seed)
 
 
+def test_automl_adds_pipeline_parameters_to_custom_pipeline_hyperparams(
+    AutoMLTestEnv, X_y_binary
+):
+    X, y = X_y_binary
+    pipeline_parameters = {"Imputer": {"numeric_impute_strategy": "most_frequent"}}
+    custom_hyperparameters = {
+        "One Hot Encoder": {"top_n": Categorical([12, 10])},
+        "Imputer": {
+            "numeric_impute_strategy": Categorical(["median", "most_frequent"])
+        },
+    }
+
+    automl = AutoMLSearch(
+        X,
+        y,
+        problem_type="binary",
+        pipeline_parameters={"Imputer": {"numeric_impute_strategy": "most_frequent"}},
+        custom_hyperparameters=custom_hyperparameters,
+        optimize_thresholds=False,
+        max_batches=4,
+    )
+    assert automl.automl_algorithm._custom_hyperparameters == custom_hyperparameters
+    assert automl.automl_algorithm._pipeline_params == pipeline_parameters
+
+
 def test_automl_pipeline_params_kwargs(AutoMLTestEnv, X_y_multi):
     X, y = X_y_multi
     hyperparams = {
@@ -3124,7 +3152,7 @@ def test_automl_pipeline_params_kwargs(AutoMLTestEnv, X_y_multi):
         X_train=X,
         y_train=y,
         problem_type="multiclass",
-        search_parameters=hyperparams,
+        custom_hyperparameters=hyperparams,
         allowed_model_families=[ModelFamily.DECISION_TREE],
         n_jobs=1,
     )
@@ -3141,7 +3169,7 @@ def test_automl_pipeline_params_kwargs(AutoMLTestEnv, X_y_multi):
             assert (
                 0.1 < row["parameters"]["Decision Tree Classifier"]["ccp_alpha"] < 0.5
             )
-            assert row["parameters"]["Decision Tree Classifier"]["max_depth"] == 2
+            assert row["parameters"]["Decision Tree Classifier"]["max_depth"] == 1
 
 
 @pytest.mark.parametrize("random_seed", [0, 1, 9])
@@ -4101,7 +4129,7 @@ def test_component_and_pipeline_warnings_surface_in_search(
             X_train=X,
             y_train=y,
             problem_type="regression",
-            search_parameters={"Decision Tree Classifier": {"max_depth": 1}},
+            pipeline_parameters={"Decision Tree Classifier": {"max_depth": 1}},
             max_batches=1,
             verbose=verbose,
         )
@@ -4458,87 +4486,6 @@ def test_cv_validation_scores_time_series(
     assert len(validation_vals) == 1
     assert validation_vals[0] == 0.5
     assert cv_vals[0] == validation_vals[0]
-
-
-@pytest.mark.parametrize("algorithm,batches", [("iterative", 2), ("default", 3)])
-@pytest.mark.parametrize(
-    "parameter,expected",
-    [
-        ("mean", ["mean", "median", "most_frequent"]),
-        (Categorical(["mean"]), Categorical(["mean"])),
-    ],
-)
-@pytest.mark.parametrize("problem_type", ["binary", "time series binary"])
-def test_search_parameters_held_automl(
-    problem_type, parameter, expected, algorithm, batches, X_y_binary, ts_data_binary
-):
-    if problem_type == "binary":
-        X, y = X_y_binary
-        problem_configuration = None
-        allowed_component_graphs = {
-            "cg": {
-                "Imputer": ["Imputer", "X", "y"],
-                "Label Encoder": ["Label Encoder", "Imputer.x", "y"],
-                "Decision Tree Classifier": [
-                    "Decision Tree Classifier",
-                    "Label Encoder.x",
-                    "Label Encoder.y",
-                ],
-            }
-        }
-    else:
-        X, y = ts_data_binary
-        problem_configuration = {
-            "time_index": "date",
-            "gap": 0,
-            "max_delay": 0,
-            "forecast_horizon": 1,
-        }
-        allowed_component_graphs = {
-            "cg": {
-                "Imputer": ["Imputer", "X", "y"],
-                "Label Encoder": ["Label Encoder", "Imputer.x", "y"],
-                "DateTime Featurizer": [
-                    "DateTime Featurizer",
-                    "Label Encoder.x",
-                    "Label Encoder.y",
-                ],
-                "Decision Tree Classifier": [
-                    "Decision Tree Classifier",
-                    "DateTime Featurizer.x",
-                    "Label Encoder.y",
-                ],
-            }
-        }
-    search_parameters = {
-        "Imputer": {"numeric_impute_strategy": parameter},
-        "DateTime Featurizer": {"features_to_extract": ["month", "day_of_week"]},
-        "Label Encoder": {"positive_label": 0},
-    }
-    aml = AutoMLSearch(
-        X_train=X,
-        y_train=y,
-        problem_type=problem_type,
-        problem_configuration=problem_configuration,
-        allowed_component_graphs=allowed_component_graphs,
-        search_parameters=search_parameters,
-        automl_algorithm=algorithm,
-        max_batches=batches,
-    )
-    aml.search()
-    for tuners in aml.automl_algorithm._tuners.values():
-        assert (
-            tuners._pipeline_hyperparameter_ranges["Imputer"]["numeric_impute_strategy"]
-            == expected
-        )
-        assert tuners._pipeline_hyperparameter_ranges["Imputer"][
-            "categorical_impute_strategy"
-        ] == ["most_frequent"]
-        # make sure that there are no set hyperparameters when we don't have defaults
-        assert tuners._pipeline_hyperparameter_ranges["Label Encoder"] == {}
-        assert tuners.propose()["Label Encoder"] == {}
-        if problem_type == "time series binary":
-            assert tuners._pipeline_hyperparameter_ranges["DateTime Featurizer"] == {}
 
 
 @pytest.mark.parametrize(

--- a/evalml/tests/automl_tests/test_automl_algorithm.py
+++ b/evalml/tests/automl_tests/test_automl_algorithm.py
@@ -26,17 +26,6 @@ class DummyAlgorithm(AutoMLAlgorithm):
         pass
 
 
-class AllowedPipelinesAlgorithm(AutoMLAlgorithm):
-    def __init__(self, allowed_pipelines=None, random_seed=0):
-        super().__init__(allowed_pipelines=allowed_pipelines, random_seed=random_seed)
-
-    def next_batch(self):
-        pass
-
-    def _transform_parameters(self, pipeline, proposed_parameters):
-        pass
-
-
 def test_automl_algorithm_dummy():
     algo = DummyAlgorithm()
     assert algo.pipeline_number == 0
@@ -100,17 +89,3 @@ def test_automl_algorithm_create_ensemble_cache():
         }
     }
     assert pipelines.component_graph.cached_data == expected_comp_graph
-
-
-def test_automl_algorithm_add_pipelines(dummy_binary_pipeline):
-    allowed_pipelines = [dummy_binary_pipeline]
-    aml = AllowedPipelinesAlgorithm(allowed_pipelines=allowed_pipelines)
-    aml_add_pipelines = AllowedPipelinesAlgorithm()
-    aml_add_pipelines._set_allowed_pipelines(allowed_pipelines)
-
-    assert aml.allowed_pipelines == aml_add_pipelines.allowed_pipelines
-    # the tuner objects themselves are different so we cannot check for dictionary equality
-    assert aml._tuners.keys() == aml_add_pipelines._tuners.keys()
-    assert aml._tuner_class == aml_add_pipelines._tuner_class
-    aml.next_batch()
-    aml._transform_parameters(None, None)

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -947,13 +947,13 @@ def test_automl_search_ratio_overrides_sampler_ratio(
     if has_minimal_dependencies and sampler == "Oversampler":
         pytest.skip("Skipping test with minimal dependencies")
     X, y = mock_imbalanced_data_X_y("binary", "none", "small")
-    search_parameters = {sampler: {"sampling_ratio": sampling_ratio}}
+    pipeline_parameters = {sampler: {"sampling_ratio": sampling_ratio}}
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
         problem_type="binary",
         sampler_method=sampler,
-        search_parameters=search_parameters,
+        pipeline_parameters=pipeline_parameters,
         sampler_balanced_ratio=0.5,
     )
     # make sure that our sampling_balanced_ratio of 0.5 overrides the pipeline params passed in
@@ -998,14 +998,14 @@ def test_automl_search_dictionary_undersampler(
         y = pd.Series([0] * 900 + [1] * 300)
     else:
         y = pd.Series([0] * 900 + [1] * 150 + [2] * 150)
-    search_parameters = {"Undersampler": {"sampling_ratio_dict": sampling_ratio_dict}}
+    pipeline_parameters = {"Undersampler": {"sampling_ratio_dict": sampling_ratio_dict}}
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
         problem_type=problem_type,
         optimize_thresholds=False,
         sampler_method="Undersampler",
-        search_parameters=search_parameters,
+        pipeline_parameters=pipeline_parameters,
         max_batches=3,
     )
     # check that the sampling dict got set properly
@@ -1054,14 +1054,14 @@ def test_automl_search_dictionary_oversampler(
     else:
         y = pd.Series([0] * 900 + [1] * 150 + [2] * 150)
 
-    search_parameters = {"Oversampler": {"sampling_ratio_dict": sampling_ratio_dict}}
+    pipeline_parameters = {"Oversampler": {"sampling_ratio_dict": sampling_ratio_dict}}
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
         problem_type=problem_type,
         sampler_method="Oversampler",
         optimize_thresholds=False,
-        search_parameters=search_parameters,
+        pipeline_parameters=pipeline_parameters,
         max_batches=3,
     )
     # check that the sampling dict got set properly
@@ -1101,7 +1101,7 @@ def test_automl_search_sampler_dictionary_keys(
     # split this from the undersampler since the dictionaries are formatted differently
     X = pd.DataFrame({"a": [i for i in range(1200)], "b": [i % 3 for i in range(1200)]})
     y = pd.Series(["majority"] * 900 + ["minority"] * 300)
-    search_parameters = {sampler: {"sampling_ratio_dict": sampling_ratio_dict}}
+    pipeline_parameters = {sampler: {"sampling_ratio_dict": sampling_ratio_dict}}
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
@@ -1109,7 +1109,7 @@ def test_automl_search_sampler_dictionary_keys(
         error_callback=raise_error_callback,
         sampler_method=sampler,
         optimize_thresholds=False,
-        search_parameters=search_parameters,
+        pipeline_parameters=pipeline_parameters,
         max_batches=3,
     )
     if errors:
@@ -1128,14 +1128,14 @@ def test_automl_search_sampler_k_neighbors_param(sampler, has_minimal_dependenci
     # split this from the undersampler since the dictionaries are formatted differently
     X = pd.DataFrame({"a": [i for i in range(1200)], "b": [i % 3 for i in range(1200)]})
     y = pd.Series(["majority"] * 900 + ["minority"] * 300)
-    search_parameters = {sampler: {"k_neighbors_default": 2}}
+    pipeline_parameters = {sampler: {"k_neighbors_default": 2}}
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
         problem_type="binary",
         sampler_method=sampler,
         sampler_balanced_ratio=0.5,
-        search_parameters=search_parameters,
+        pipeline_parameters=pipeline_parameters,
     )
     for pipeline in automl.allowed_pipelines:
         seen_under = False
@@ -1161,14 +1161,14 @@ def test_automl_search_sampler_k_neighbors_no_error(
         y_train=y,
         problem_type="binary",
         max_iterations=2,
-        search_parameters=parameters,
+        pipeline_parameters=parameters,
     )
     # check that the calling this doesn't fail
     automl.search()
 
 
 @pytest.mark.parametrize(
-    "search_parameters,set_values",
+    "pipeline_parameters,set_values",
     [
         ({"Logistic Regression Classifier": {"penalty": "l1"}}, {}),
         (
@@ -1181,9 +1181,9 @@ def test_automl_search_sampler_k_neighbors_no_error(
     ],
 )
 def test_time_series_pipeline_parameter_warnings(
-    search_parameters, set_values, AutoMLTestEnv, ts_data_binary
+    pipeline_parameters, set_values, AutoMLTestEnv, ts_data_binary
 ):
-    search_parameters.update(
+    pipeline_parameters.update(
         {
             "pipeline": {
                 "time_index": "date",
@@ -1210,7 +1210,7 @@ def test_time_series_pipeline_parameter_warnings(
             problem_type="time series binary",
             max_batches=1,
             n_jobs=1,
-            search_parameters=search_parameters,
+            pipeline_parameters=pipeline_parameters,
             problem_configuration=configuration,
             automl_algorithm="iterative",
         )

--- a/evalml/tests/automl_tests/test_automl_search_classification_iterative.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification_iterative.py
@@ -413,7 +413,7 @@ def test_automl_oversampler_selection():
         y,
         "binary",
         allowed_component_graphs={"pipeline": allowed_component_graph},
-        search_parameters={"DropCols": {"columns": ["a"]}},
+        pipeline_parameters={"DropCols": {"columns": ["a"]}},
         error_callback=raise_error_callback,
         automl_algorithm="iterative",
     )

--- a/evalml/tests/automl_tests/test_default_algorithm.py
+++ b/evalml/tests/automl_tests/test_default_algorithm.py
@@ -42,25 +42,49 @@ def test_default_algorithm_init(X_y_binary):
     assert algo.default_max_batches == 3
 
 
-def test_default_algorithm_search_parameters_error(X_y_binary):
+def test_default_algorithm_custom_hyperparameters_error(X_y_binary):
     X, y = X_y_binary
     problem_type = ProblemTypes.BINARY
     sampler_name = "Undersampler"
 
-    search_parameters = [
+    custom_hyperparameters = [
         {"Imputer": {"numeric_impute_strategy": ["median"]}},
         {"One Hot Encoder": {"value1": ["value2"]}},
     ]
 
     with pytest.raises(
-        ValueError, match="If search_parameters provided, must be of type dict"
+        ValueError, match="If custom_hyperparameters provided, must be of type dict"
     ):
         DefaultAlgorithm(
             X,
             y,
             problem_type,
             sampler_name,
-            search_parameters=search_parameters,
+            custom_hyperparameters=custom_hyperparameters,
+        )
+
+    with pytest.raises(
+        ValueError, match="Custom hyperparameters should only contain skopt"
+    ):
+        DefaultAlgorithm(
+            X,
+            y,
+            problem_type,
+            sampler_name,
+            random_seed=0,
+            custom_hyperparameters={"Imputer": {"impute_strategy": (1, 2)}},
+        )
+
+    with pytest.raises(
+        ValueError, match="Pipeline parameters should not contain skopt.Space variables"
+    ):
+        DefaultAlgorithm(
+            X,
+            y,
+            problem_type,
+            sampler_name,
+            random_seed=0,
+            pipeline_params={"Imputer": {"impute_strategy": Categorical([1, 3, 4])}},
         )
 
 
@@ -203,13 +227,13 @@ def test_default_algorithm(
 
 
 @patch("evalml.pipelines.components.FeatureSelector.get_names")
-def test_evalml_algo_search_params(mock_get_names, X_y_binary):
+def test_evalml_algo_pipeline_params(mock_get_names, X_y_binary):
     X, y = X_y_binary
     mock_get_names.return_value = ["0", "1", "2"]
 
     problem_type = ProblemTypes.BINARY
     sampler_name = None
-    search_params = {
+    pipeline_params = {
         "pipeline": {"gap": 2, "max_delay": 10},
         "Logistic Regression Classifier": {"C": 5},
     }
@@ -218,7 +242,7 @@ def test_evalml_algo_search_params(mock_get_names, X_y_binary):
         y,
         problem_type,
         sampler_name,
-        search_parameters=search_params,
+        pipeline_params=pipeline_params,
         num_long_explore_pipelines=1,
         num_long_pipelines_per_batch=1,
     )
@@ -235,7 +259,7 @@ def test_evalml_algo_search_params(mock_get_names, X_y_binary):
 
 @patch("evalml.pipelines.components.FeatureSelector.get_names")
 @patch("evalml.pipelines.components.OneHotEncoder._get_feature_provenance")
-def test_evalml_algo_search_hyperparameters(
+def test_evalml_algo_custom_hyperparameters(
     mock_get_feature_provenance, mock_get_names, X_y_categorical_classification
 ):
     X, y = X_y_categorical_classification
@@ -250,7 +274,7 @@ def test_evalml_algo_search_hyperparameters(
     problem_type = ProblemTypes.BINARY
     sampler_name = None
     impute_strategy = Categorical(["mean", "median"])
-    search_parameters = {
+    custom_hyperparameters = {
         "Random Forest Classifier": {
             "n_estimators": Integer(5, 7),
             "max_depth": Categorical([5, 6, 7]),
@@ -263,7 +287,7 @@ def test_evalml_algo_search_hyperparameters(
         y,
         problem_type,
         sampler_name,
-        search_parameters=search_parameters,
+        custom_hyperparameters=custom_hyperparameters,
         num_long_explore_pipelines=3,
         num_long_pipelines_per_batch=3,
     )
@@ -312,7 +336,7 @@ def test_default_algo_drop_columns(mock_get_names, columns, X_y_binary):
 
     algo = DefaultAlgorithm(X, y, ProblemTypes.BINARY, sampler_name=None)
 
-    assert algo.search_parameters["Drop Columns Transformer"]["columns"] == columns
+    assert algo._pipeline_params["Drop Columns Transformer"]["columns"] == columns
 
     for _ in range(2):
         batch = algo.next_batch()
@@ -330,7 +354,7 @@ def test_default_algo_drop_columns(mock_get_names, columns, X_y_binary):
         for component_name in pipeline.component_graph.compute_order:
             split = component_name.split(" - ")
             if "Drop Columns Transformer" in split:
-                assert algo.search_parameters[component_name]["columns"] == columns
+                assert algo._pipeline_params[component_name]["columns"] == columns
                 assert pipeline.parameters[component_name]["columns"] == columns
 
 
@@ -544,7 +568,7 @@ def test_default_algorithm_time_series(
     mock_get_names.return_value = ["0", "1", "2"]
     problem_type = ProblemTypes.TIME_SERIES_REGRESSION
     sampler_name = None
-    search_parameters = {
+    pipeline_params = {
         "pipeline": {
             "time_index": "date",
             "gap": 1,
@@ -555,7 +579,7 @@ def test_default_algorithm_time_series(
     }
 
     algo = DefaultAlgorithm(
-        X, y, problem_type, sampler_name, search_parameters=search_parameters
+        X, y, problem_type, sampler_name, pipeline_params=pipeline_params
     )
     naive_model_families = set([ModelFamily.LINEAR_MODEL, ModelFamily.RANDOM_FOREST])
 
@@ -563,7 +587,7 @@ def test_default_algorithm_time_series(
     assert len(first_batch) == 2
     assert {p.model_family for p in first_batch} == naive_model_families
     for pipeline in first_batch:
-        assert pipeline.parameters["pipeline"] == search_parameters["pipeline"]
+        assert pipeline.parameters["pipeline"] == pipeline_params["pipeline"]
         assert pipeline.parameters["DateTime Featurizer"]["time_index"]
     add_result(algo, first_batch)
 
@@ -571,7 +595,7 @@ def test_default_algorithm_time_series(
     assert len(second_batch) == 2
     assert {p.model_family for p in second_batch} == naive_model_families
     for pipeline in second_batch:
-        assert pipeline.parameters["pipeline"] == search_parameters["pipeline"]
+        assert pipeline.parameters["pipeline"] == pipeline_params["pipeline"]
         assert pipeline.parameters["DateTime Featurizer"]["time_index"]
     add_result(algo, second_batch)
 
@@ -582,7 +606,7 @@ def test_default_algorithm_time_series(
         ):
             assert pipeline.model_family not in naive_model_families
         assert algo._tuners[pipeline.name]
-        assert pipeline.parameters["pipeline"] == search_parameters["pipeline"]
+        assert pipeline.parameters["pipeline"] == pipeline_params["pipeline"]
         if not isinstance(pipeline.estimator, (ARIMARegressor, ProphetRegressor)):
             assert pipeline.parameters["DateTime Featurizer"]["time_index"]
     add_result(algo, final_batch)
@@ -631,7 +655,7 @@ def test_default_algorithm_time_series_known_in_advance(
     mock_get_names.return_value = ["0", "1", "2"]
     problem_type = ProblemTypes.TIME_SERIES_REGRESSION
     sampler_name = None
-    search_parameters = {
+    pipeline_params = {
         "pipeline": {
             "time_index": "date",
             "gap": 1,
@@ -643,7 +667,7 @@ def test_default_algorithm_time_series_known_in_advance(
     }
 
     algo = DefaultAlgorithm(
-        X, y, problem_type, sampler_name, search_parameters=search_parameters
+        X, y, problem_type, sampler_name, pipeline_params=pipeline_params
     )
     naive_model_families = set([ModelFamily.LINEAR_MODEL, ModelFamily.RANDOM_FOREST])
 
@@ -684,7 +708,7 @@ def test_default_algorithm_time_series_known_in_advance(
         ):
             assert pipeline.model_family not in naive_model_families
         assert algo._tuners[pipeline.name]
-        assert pipeline.parameters["pipeline"] == search_parameters["pipeline"]
+        assert pipeline.parameters["pipeline"] == pipeline_params["pipeline"]
         assert (
             pipeline.parameters[
                 "Known In Advance Pipeline - Select Columns Transformer"
@@ -749,7 +773,6 @@ def test_default_algorithm_accept_features(mock_get_names, X_y_binary, split):
         y,
         problem_type,
         sampler_name,
-        search_parameters={"DFS Transformer": {"features": features}},
         num_long_explore_pipelines=1,
         num_long_pipelines_per_batch=1,
         features=features,

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -83,7 +83,7 @@ def test_iterative_algorithm_init(
     )
 
 
-def test_make_iterative_algorithm_search_parameters_error(
+def test_make_iterative_algorithm_custom_hyperparameters_error(
     dummy_binary_pipeline_classes, X_y_binary
 ):
     (
@@ -92,20 +92,20 @@ def test_make_iterative_algorithm_search_parameters_error(
     ) = dummy_binary_pipeline_classes()
     X, y = X_y_binary
 
-    search_parameters = [
+    custom_hyperparameters = [
         {"Imputer": {"numeric_imput_strategy": ["median"]}},
         {"One Hot Encoder": {"value1": ["value2"]}},
     ]
 
     with pytest.raises(
-        ValueError, match="If search_parameters provided, must be of type dict"
+        ValueError, match="If custom_hyperparameters provided, must be of type dict"
     ):
         IterativeAlgorithm(
             X=X,
             y=y,
             problem_type="binary",
             allowed_component_graphs=allowed_component_graphs,
-            search_parameters=search_parameters,
+            custom_hyperparameters=custom_hyperparameters,
         )
 
 
@@ -281,7 +281,7 @@ def test_iterative_algorithm_passes_pipeline_params(
         y=y,
         problem_type="binary",
         allowed_component_graphs=allowed_component_graphs,
-        search_parameters={
+        pipeline_params={
             "pipeline": {"gap": 2, "max_delay": 10, "forecast_horizon": 3}
         },
     )
@@ -557,9 +557,9 @@ def test_iterative_algorithm_stacked_ensemble_n_jobs_regression(
 
 @pytest.mark.parametrize(
     "parameters",
-    [1, "hello", 1.3, -1.0006],
+    [1, "hello", 1.3, -1.0006, Categorical([1, 3, 4]), Integer(2, 4), Real(2, 6)],
 )
-def test_iterative_algorithm_search_params(
+def test_iterative_algorithm_pipeline_params(
     X_y_binary,
     parameters,
     dummy_binary_pipeline_classes,
@@ -571,17 +571,35 @@ def test_iterative_algorithm_search_params(
         allowed_component_graphs,
     ) = dummy_binary_pipeline_classes(parameters)
 
-    algo = IterativeAlgorithm(
-        X=X,
-        y=y,
-        problem_type="binary",
-        allowed_component_graphs=allowed_component_graphs,
-        random_seed=0,
-        search_parameters={
-            "pipeline": {"gap": 2, "max_delay": 10, "forecast_horizon": 3},
-            "Mock Classifier": {"dummy_parameter": parameters},
-        },
-    )
+    if isinstance(parameters, (Categorical, Integer, Real)):
+        with pytest.raises(
+            ValueError,
+            match="Pipeline parameters should not contain skopt.Space variables",
+        ):
+            IterativeAlgorithm(
+                X=X,
+                y=y,
+                problem_type="binary",
+                allowed_component_graphs=allowed_component_graphs,
+                random_seed=0,
+                pipeline_params={
+                    "pipeline": {"gap": 2, "max_delay": 10, "forecast_horizon": 3},
+                    "Mock Classifier": {"dummy_parameter": parameters},
+                },
+            )
+        return
+    else:
+        algo = IterativeAlgorithm(
+            X=X,
+            y=y,
+            problem_type="binary",
+            allowed_component_graphs=allowed_component_graphs,
+            random_seed=0,
+            pipeline_params={
+                "pipeline": {"gap": 2, "max_delay": 10, "forecast_horizon": 3},
+                "Mock Classifier": {"dummy_parameter": parameters},
+            },
+        )
 
     parameter = parameters
     next_batch = algo.next_batch()
@@ -615,7 +633,96 @@ def test_iterative_algorithm_search_params(
         )
 
 
-def test_iterative_algorithm_search_params_kwargs(
+@pytest.mark.parametrize(
+    "parameters,hyperparameters",
+    [
+        (1, Categorical([1, 3, 4])),
+        (3, Integer(2, 4)),
+        (5, Categorical([1, 3, 4])),
+        (1, 1),
+    ],
+)
+def test_iterative_algorithm_custom_hyperparameters(
+    parameters,
+    hyperparameters,
+    X_y_binary,
+    dummy_binary_pipeline_classes,
+):
+    X, y = X_y_binary
+
+    (
+        dummy_binary_pipeline_classes,
+        allowed_component_graphs,
+    ) = dummy_binary_pipeline_classes(parameters)
+
+    if not isinstance(hyperparameters, (Categorical, Integer, Real)):
+        with pytest.raises(
+            ValueError, match="Custom hyperparameters should only contain skopt"
+        ):
+            IterativeAlgorithm(
+                X=X,
+                y=y,
+                problem_type="binary",
+                allowed_component_graphs=allowed_component_graphs,
+                random_seed=0,
+                pipeline_params={"Mock Classifier": {"dummy_parameter": parameters}},
+                custom_hyperparameters={
+                    "Mock Classifier": {"dummy_parameter": hyperparameters}
+                },
+            )
+        return
+    else:
+        algo = IterativeAlgorithm(
+            X=X,
+            y=y,
+            problem_type="binary",
+            allowed_component_graphs=allowed_component_graphs,
+            random_seed=0,
+            pipeline_params={"Mock Classifier": {"dummy_parameter": parameters}},
+            custom_hyperparameters={
+                "Mock Classifier": {"dummy_parameter": hyperparameters}
+            },
+        )
+
+    next_batch = algo.next_batch()
+
+    assert all([p.parameters["Mock Classifier"]["n_jobs"] == -1 for p in next_batch])
+    assert all(
+        [
+            p.parameters["Mock Classifier"]["dummy_parameter"] == parameters
+            for p in next_batch
+        ]
+    )
+
+    scores = np.arange(0, len(next_batch))
+
+    if parameters not in hyperparameters:
+        for score, pipeline in zip(scores, next_batch):
+            with pytest.raises(ValueError, match="Default parameters for components"):
+                algo.add_result(score, pipeline, {"id": algo.pipeline_number})
+    else:
+        for score, pipeline in zip(scores, next_batch):
+            algo.add_result(score, pipeline, {"id": algo.pipeline_number})
+
+        # make sure that future batches remain in the hyperparam range
+        all_dummies = set()
+        for i in range(1, 5):
+            next_batch = algo.next_batch()
+            for p in next_batch:
+                dummy = p.parameters["Mock Classifier"]["dummy_parameter"]
+                if dummy not in all_dummies:
+                    all_dummies.add(dummy)
+            assert all(
+                [
+                    p.parameters["Mock Classifier"]["dummy_parameter"]
+                    in hyperparameters
+                    for p in next_batch
+                ]
+            )
+        assert all_dummies == {1, 3, 4} if parameters == 1 else all_dummies == {2, 3, 4}
+
+
+def test_iterative_algorithm_pipeline_params_kwargs(
     X_y_binary, dummy_binary_pipeline_classes
 ):
     X, y = X_y_binary
@@ -630,7 +737,7 @@ def test_iterative_algorithm_search_params_kwargs(
         y=y,
         problem_type="binary",
         allowed_component_graphs=allowed_component_graphs,
-        search_parameters={
+        pipeline_params={
             "Mock Classifier": {"dummy_parameter": "dummy", "fake_param": "fake"}
         },
         random_seed=0,
@@ -968,12 +1075,7 @@ def test_iterative_algorithm_passes_features(
     )
 
     algo = IterativeAlgorithm(
-        X=X,
-        y=y,
-        problem_type="binary",
-        search_parameters={"DFS Transformer": {"features": features}},
-        ensembling=False,
-        features=features,
+        X=X, y=y, problem_type="binary", ensembling=False, features=features
     )
     next_batch = algo.next_batch()
     assert all(

--- a/evalml/tests/tuner_tests/test_skopt_tuner.py
+++ b/evalml/tests/tuner_tests/test_skopt_tuner.py
@@ -70,18 +70,6 @@ def test_skopt_tuner_basic():
 
     tuner = SKOptTuner(pipeline_hyperparameter_ranges, random_seed=random_seed)
     assert isinstance(tuner, Tuner)
-    first_params = tuner.get_starting_parameters()
-    assert first_params == {
-        "Mock Classifier": {
-            "parameter a": 5,
-            "parameter b": 5.488135039273248,
-            "parameter c": 0,
-            "parameter d": 0,
-            "parameter e": "option a",
-            "parameter f": "option a 💩",
-            "parameter g": "option a",
-        }
-    }
     proposed_params = tuner.propose()
     assert proposed_params == {
         "Mock Classifier": {
@@ -98,6 +86,17 @@ def test_skopt_tuner_basic():
 
 
 def test_skopt_tuner_invalid_ranges():
+    SKOptTuner(
+        {
+            "Mock Classifier": {
+                "param a": Integer(0, 10),
+                "param b": Real(0, 10),
+                "param c": ["option a", "option b", "option c"],
+            }
+        },
+        random_seed=random_seed,
+    )
+
     with pytest.raises(
         ValueError,
         match="Invalid dimension \\[\\]. Read the documentation for supported types.",
@@ -129,12 +128,21 @@ def test_skopt_tuner_invalid_ranges():
 
 
 def test_skopt_tuner_single_value():
-    expected_params = {"Mock Classifier": {}}
+    SKOptTuner(
+        {
+            "Mock Classifier": {
+                "param a": Integer(0, 10),
+                "param b": Real(0, 10),
+                "param c": "Value",
+            }
+        },
+        random_seed=random_seed,
+    )
+
     tuner = SKOptTuner({"Mock Classifier": {"param c": 10}}, random_seed=random_seed)
-    starting_params = tuner.get_starting_parameters()
-    assert starting_params == expected_params
+
     proposed_params = tuner.propose()
-    assert proposed_params == expected_params
+    assert proposed_params == {"Mock Classifier": {}}
 
 
 def test_skopt_tuner_invalid_parameters_score():
@@ -255,14 +263,6 @@ def test_skopt_tuner_propose():
         }
     }
     tuner = SKOptTuner(pipeline_hyperparameter_ranges, random_seed=random_seed)
-    first_params = tuner.get_starting_parameters()
-    assert first_params == {
-        "Mock Classifier": {
-            "param a": 5,
-            "param b": 5.488135039273248,
-            "param c": "option a",
-        }
-    }
     tuner.add(
         {"Mock Classifier": {"param a": 0, "param b": 1.0, "param c": "option a"}}, 0.5
     )

--- a/evalml/tuners/tuner.py
+++ b/evalml/tuners/tuner.py
@@ -89,32 +89,6 @@ class Tuner(ABC):
             pipeline_parameters[component_name][parameter_name] = parameter_value
         return pipeline_parameters
 
-    def get_starting_parameters(self):
-        """Gets the starting parameters given the pipeline hyperparameter range.
-
-        Returns:
-            dict: The starting parameters, randomly chosen, to initialize a pipeline with.
-        """
-        starting_parameters = {}
-        for name, param_dict in self._pipeline_hyperparameter_ranges.items():
-            component_parameters = {}
-            for param_name, value in param_dict.items():
-                if isinstance(value, (Integer, Real)):
-                    # get a random value in the space
-                    component_parameters[param_name] = value.rvs(
-                        random_state=self.random_seed
-                    )[0]
-                elif isinstance(value, Categorical):
-                    # Categorical
-                    component_parameters[param_name] = value.rvs(
-                        random_state=self.random_seed
-                    )
-                elif isinstance(value, (list, tuple)):
-                    # list value from our internal hyperparameter_ranges
-                    component_parameters[param_name] = value[0]
-            starting_parameters[name] = component_parameters
-        return starting_parameters
-
     @abstractmethod
     def add(self, pipeline_parameters, score):
         """Register a set of hyperparameters with the score obtained from training a pipeline with those hyperparameters.


### PR DESCRIPTION
Reverts alteryx/evalml#3373.  Removing due to bug/regression.  Will be targeted to next release.