### PR TITLE
Release v0.49.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,17 @@
 
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.49.0 Mar. 31, 2022**
+    * Enhancements
         * Added ``use_covariates`` parameter to ``ARIMARegressor`` :pr:`3407`
         * ``AutoMLSearch`` will set ``use_covariates`` to ``False`` for ARIMA when dataset is large :pr:`3407`
         * Add ability to retrieve logical types to a component in the graph via ``get_component_input_logical_types`` :pr:`3428`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.48.0',
+    version='0.49.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.49.0 Mar. 31, 2022
### Enhancements
- Added ``use_covariates`` parameter to ``ARIMARegressor`` #3407
- ``AutoMLSearch`` will set ``use_covariates`` to ``False`` for ARIMA when dataset is large #3407
- Add ability to retrieve logical types to a component in the graph via ``get_component_input_logical_types`` #3428
- Add ability to get logical types passed to the last component via ``last_component_input_logical_types`` #3428
### Fixes
- Fix conda build after PR `3407` #3429
### Changes
- Moved model understanding metrics from ``graph.py`` into a separate file #3417
- Unpin ``click`` dependency #3420
- For ``IterativeAlgorithm``, put time series algorithms first #3407
- Use ``prophet-prebuilt`` to install prophet in extras #3407
### Breaking Changes
- Moved model understanding metrics from ``graph.py`` to ``metrics.py`` #3417