### PR TITLE
Fix some unit tests after vowpal wabbit got added to conda

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: acb758f2234a60dd606a4aa7dcde385e159c95a08470b0c5815d085db48aa985
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: evalml-core

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -10,7 +10,7 @@ on:
       - 'requirements.txt'
       - 'core-requirements.txt'
       - 'evalml/tests/dependency_update_check/*.txt'
-      - '.github/workflows/meta.yaml'
+      - '.github/meta.yaml'
 
 jobs:
   build_conda_pkg:

--- a/.github/workflows/build_conda_pkg.yml
+++ b/.github/workflows/build_conda_pkg.yml
@@ -10,6 +10,7 @@ on:
       - 'requirements.txt'
       - 'core-requirements.txt'
       - 'evalml/tests/dependency_update_check/*.txt'
+      - '.github/workflows/meta.yaml'
 
 jobs:
   build_conda_pkg:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@
         * Added the ``TimeSeriesRegularizer`` and ``TimeSeriesImputer`` to the timeseries section of the User Guide :pr:`3473`
     * Testing Changes
         * Updated unit tests to support woodwork 0.16.2 :pr:`3482`
+        * Fix some unit tests after vowpal wabbit got added to conda recipe :pr:`3486`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -101,9 +101,6 @@ not_supported_in_conda = set(
     [
         "ARIMA Regressor",
         "Prophet Regressor",
-        "Vowpal Wabbit Binary Classifier",
-        "Vowpal Wabbit Multiclass Classifier",
-        "Vowpal Wabbit Regressor",
     ]
 )
 not_supported_in_windows = set(

--- a/evalml/tests/utils_tests/test_dependencies.py
+++ b/evalml/tests/utils_tests/test_dependencies.py
@@ -26,7 +26,7 @@ def test_has_minimal_deps(
     extra_deps = [_get_req_name(req.name) for req in reqs]
     extra_deps += ["plotly.graph_objects"]
     for module in extra_deps:
-        if (module == "pmdarima" or module == "vowpalwabbit") and is_using_conda:
+        if module == "pmdarima" and is_using_conda:
             with pytest.raises(ModuleNotFoundError):
                 import_module(module)
             continue


### PR DESCRIPTION
### Pull Request Description

The build_conda_pkg job doesn't run when you change the meta.yaml so we didn't catch some very minor unit test failures once we merged to main:

https://github.com/alteryx/evalml/runs/6202590714?check_suite_focus=true

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
