### PR TITLE
Release v0.51.0.

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+    
+
+**v0.51.0 Apr. 28, 2022**
+    * Enhancements
         * Updated ``make_pipeline_from_data_check_output`` to work with time series problems. :pr:`3454`
     * Fixes
         * Changed ``PipelineBase.graph_json()`` to return a python dictionary and renamed as ``graph_dict()``:pr:`3463`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.50.0"
+__version__ = "0.51.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.50.0',
+    version='0.51.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.51.0 Apr. 28, 2022
### Enhancements
- Updated ``make_pipeline_from_data_check_output`` to work with time series problems. #3454
### Fixes
- Changed ``PipelineBase.graph_json()`` to return a python dictionary and renamed as ``graph_dict()``#3463
### Changes
- Added ``vowpalwabbit`` to local recipe and remove ``is_using_conda`` pytest skip markers from relevant tests #3481 
### Documentation Changes
- Fixed broken link in contributing guide #3464
- Improved development instructions #3468
- Added the ``TimeSeriesRegularizer`` and ``TimeSeriesImputer`` to the timeseries section of the User Guide #3473
- Updated OSS slack link #3487
### Testing Changes
- Updated unit tests to support woodwork 0.16.2 #3482
- Fix some unit tests after vowpal wabbit got added to conda recipe #3486
### Breaking Changes
- Renamed ``PipelineBase.graph_json()`` to ``PipelineBase.graph_dict()`` #3463
- Minimum supported woodwork version is now 0.16.2 #3482