### PR TITLE
Preserve schema during column re-naming in xgboost and lightgbm

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Fixes
         * Fixed github workflows for featuretools and woodwork to test their main branch against evalml. :pr:`3517`
         * Supress warnings in ``TargetEncoder`` raised by a coming change to default parameters :pr:`3540`
+        * Fixed bug where schema was not being preserved in column renaming for XGBoost and LightGBM models :pr:`3496`
     * Changes
         * Transitioned to use pyproject.toml and setup.cfg away from setup.py :pr:`3494`, :pr:`3536`
     * Documentation Changes

--- a/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
@@ -108,7 +108,7 @@ class XGBoostClassifier(Estimator):
         """
         X, y = super()._manage_woodwork(X, y)
         self.input_feature_names = list(X.columns)
-        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
+        X = _rename_column_names_to_numeric(X)
         y = self._label_encode(y)
         self._component_obj.fit(X, y)
         return self
@@ -123,8 +123,7 @@ class XGBoostClassifier(Estimator):
             pd.DataFrame: Predicted values.
         """
         X, _ = super()._manage_woodwork(X)
-        X.ww.set_types(self._convert_bool_to_int(X))
-        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
+        X = _rename_column_names_to_numeric(X)
         predictions = super().predict(X)
         if not self._label_encoder:
             return predictions
@@ -143,8 +142,7 @@ class XGBoostClassifier(Estimator):
             pd.DataFrame: Predicted values.
         """
         X, _ = super()._manage_woodwork(X)
-        X.ww.set_types(self._convert_bool_to_int(X))
-        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
+        X = _rename_column_names_to_numeric(X)
         return super().predict_proba(X)
 
     @property

--- a/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
@@ -108,7 +108,7 @@ class XGBoostClassifier(Estimator):
         """
         X, y = super()._manage_woodwork(X, y)
         self.input_feature_names = list(X.columns)
-        X = _rename_column_names_to_numeric(X, flatten_tuples=False)
+        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
         y = self._label_encode(y)
         self._component_obj.fit(X, y)
         return self
@@ -122,7 +122,9 @@ class XGBoostClassifier(Estimator):
         Returns:
             pd.DataFrame: Predicted values.
         """
-        X = _rename_column_names_to_numeric(X, flatten_tuples=False)
+        X, _ = super()._manage_woodwork(X)
+        X.ww.set_types(self._convert_bool_to_int(X))
+        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
         predictions = super().predict(X)
         if not self._label_encoder:
             return predictions
@@ -140,7 +142,9 @@ class XGBoostClassifier(Estimator):
         Returns:
             pd.DataFrame: Predicted values.
         """
-        X = _rename_column_names_to_numeric(X, flatten_tuples=False)
+        X, _ = super()._manage_woodwork(X)
+        X.ww.set_types(self._convert_bool_to_int(X))
+        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
         return super().predict_proba(X)
 
     @property

--- a/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
@@ -92,7 +92,7 @@ class XGBoostRegressor(Estimator):
         """
         X, y = super()._manage_woodwork(X, y)
         self.input_feature_names = list(X.columns)
-        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
+        X = _rename_column_names_to_numeric(X)
         self._component_obj.fit(X, y)
         return self
 
@@ -106,8 +106,7 @@ class XGBoostRegressor(Estimator):
             pd.Series: Predicted values.
         """
         X, _ = super()._manage_woodwork(X)
-        X.ww.set_types(self._convert_bool_to_int(X))
-        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
+        X = _rename_column_names_to_numeric(X)
         return super().predict(X)
 
     @property

--- a/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
@@ -92,7 +92,7 @@ class XGBoostRegressor(Estimator):
         """
         X, y = super()._manage_woodwork(X, y)
         self.input_feature_names = list(X.columns)
-        X = _rename_column_names_to_numeric(X, flatten_tuples=False)
+        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
         self._component_obj.fit(X, y)
         return self
 
@@ -105,7 +105,9 @@ class XGBoostRegressor(Estimator):
         Returns:
             pd.Series: Predicted values.
         """
-        X = _rename_column_names_to_numeric(X, flatten_tuples=False)
+        X, _ = super()._manage_woodwork(X)
+        X.ww.set_types(self._convert_bool_to_int(X))
+        X = _rename_column_names_to_numeric(X, flatten_tuples=True)
         return super().predict(X)
 
     @property

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -319,10 +319,10 @@ def test_lgbm_preserves_schema_in_rename(mock_predict_proba, mock_predict, mock_
     X.ww.init(logical_types={"a": "NaturalLanguage"})
     original_schema = X.ww.rename(columns={"a": 0}).ww.schema
 
-    xgb = LightGBMClassifier()
-    xgb.fit(X, pd.Series([0, 1, 1, 0]))
+    lgb = LightGBMClassifier()
+    lgb.fit(X, pd.Series([0, 1, 1, 0]))
     assert mock_fit.call_args[0][0].ww.schema == original_schema
-    xgb.predict(X)
+    lgb.predict(X)
     assert mock_predict.call_args[0][0].ww.schema == original_schema
-    xgb.predict_proba(X)
+    lgb.predict_proba(X)
     assert mock_predict_proba.call_args[0][0].ww.schema == original_schema

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -222,8 +222,8 @@ def test_lgbm_preserves_schema_in_rename(mock_predict, mock_fit):
     X.ww.init(logical_types={"a": "NaturalLanguage"})
     original_schema = X.ww.rename(columns={"a": 0}).ww.schema
 
-    xgb = LightGBMRegressor()
-    xgb.fit(X, pd.Series([0, 1, 1, 0]))
+    lgb = LightGBMRegressor()
+    lgb.fit(X, pd.Series([0, 1, 1, 0]))
     assert mock_fit.call_args[0][0].ww.schema == original_schema
-    xgb.predict(X)
+    lgb.predict(X)
     assert mock_predict.call_args[0][0].ww.schema == original_schema

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -213,3 +213,17 @@ def test_lightgbm_multiindex(data_type, X_y_regression, make_data_type):
     clf.fit(X, y)
     y_pred = clf.predict(X)
     assert not y_pred.isnull().values.any()
+
+
+@patch("lightgbm.LGBMRegressor.fit")
+@patch("lightgbm.LGBMRegressor.predict")
+def test_lgbm_preserves_schema_in_rename(mock_predict, mock_fit):
+    X = pd.DataFrame({"a": [1, 2, 3, 4]})
+    X.ww.init(logical_types={"a": "NaturalLanguage"})
+    original_schema = X.ww.rename(columns={"a": 0}).ww.schema
+
+    xgb = LightGBMRegressor()
+    xgb.fit(X, pd.Series([0, 1, 1, 0]))
+    assert mock_fit.call_args[0][0].ww.schema == original_schema
+    xgb.predict(X)
+    assert mock_predict.call_args[0][0].ww.schema == original_schema

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -309,10 +309,12 @@ def test_pad_with_nans_with_series_name():
 
 
 def test_rename_column_names_to_numeric():
-    X = np.array([[1, 2], [3, 4]])
+    X = pd.DataFrame(np.array([[1, 2], [3, 4]]))
+    X.ww.init()
     pd.testing.assert_frame_equal(_rename_column_names_to_numeric(X), pd.DataFrame(X))
 
     X = pd.DataFrame({"<>": [1, 2], ">>": [2, 4]})
+    X.ww.init()
     pd.testing.assert_frame_equal(
         _rename_column_names_to_numeric(X), pd.DataFrame({0: [1, 2], 1: [2, 4]})
     )

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -261,9 +261,11 @@ def _rename_column_names_to_numeric(X, flatten_tuples=True):
         return pd.DataFrame(X)
 
     X_renamed = X.copy()
+    logical_types = X.ww.logical_types
     if flatten_tuples and (len(X.columns) > 0 and isinstance(X.columns, pd.MultiIndex)):
         flat_col_names = list(map(str, X_renamed.columns))
         X_renamed.columns = flat_col_names
+        logical_types = {str(k): v for k, v in logical_types.items()}
         rename_cols_dict = dict(
             (str(col), col_num) for col_num, col in enumerate(list(X.columns))
         )
@@ -272,6 +274,9 @@ def _rename_column_names_to_numeric(X, flatten_tuples=True):
             (col, col_num) for col_num, col in enumerate(list(X.columns))
         )
     X_renamed.rename(columns=rename_cols_dict, inplace=True)
+    X_renamed.ww.init(
+        logical_types={rename_cols_dict[k]: v for k, v in logical_types.items()}
+    )
     return X_renamed
 
 

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -247,12 +247,11 @@ def get_importable_subclasses(base_class, used_in_automl=True):
     return classes
 
 
-def _rename_column_names_to_numeric(X, flatten_tuples=True):
+def _rename_column_names_to_numeric(X):
     """Used in LightGBM and XGBoost estimator classes to rename column names when the input is a pd.DataFrame in case it has column names that contain symbols ([, ], <) that these estimators cannot natively handle.
 
     Args:
         X (pd.DataFrame): The input training data of shape [n_samples, n_features]
-        flatten_tuples (bool): Whether to flatten MultiIndex or tuple column names. LightGBM cannot handle columns with tuple names.
 
     Returns:
         Transformed X where column names are renamed to numerical values
@@ -262,7 +261,7 @@ def _rename_column_names_to_numeric(X, flatten_tuples=True):
 
     X_renamed = X.copy()
     logical_types = X.ww.logical_types
-    if flatten_tuples and (len(X.columns) > 0 and isinstance(X.columns, pd.MultiIndex)):
+    if len(X.columns) > 0 and isinstance(X.columns, pd.MultiIndex):
         flat_col_names = list(map(str, X_renamed.columns))
         X_renamed.columns = flat_col_names
         logical_types = {str(k): v for k, v in logical_types.items()}


### PR DESCRIPTION
### Pull Request Description

The fact that we don't preserve the schema during column re-naming at the last step of xgboost + lightgbm pipelines makes it so that this unrelated ww bug (https://github.com/alteryx/woodwork/issues/1411) causes some of our pipelines to fail in corner cases.

This is a fix to prevent pipelines from crashing. We should have been preserving the schema anyways.

### Perf tests
[report.html.zip](https://github.com/alteryx/evalml/files/8614188/report.html.zip)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
