### PR TITLE
raise custom exception for pipeline errors

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@
     * Fixes
     * Changes
         * Updated ``roc_curve()`` and ``conf_matrix()`` to work with IntegerNullable and BooleanNullable types. :pr:`3465`
-        * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` insteaed of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
+        * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` instead of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@
     * Fixes
     * Changes
         * Updated ``roc_curve()`` and ``conf_matrix()`` to work with IntegerNullable and BooleanNullable types. :pr:`3465`
+        * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` insteaed of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/exceptions/__init__.py
+++ b/evalml/exceptions/__init__.py
@@ -16,4 +16,6 @@ from .exceptions import (
     PartialDependenceErrorCode,
     PartialDependenceError,
     ValidationErrorCode,
+    PipelineError,
+    PipelineErrorCodeEnum,
 )

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -143,3 +143,19 @@ class PartialDependenceError(ValueError):
     def __init__(self, message, code):
         self.code = code
         super().__init__(message)
+
+
+class PipelineErrorCodeEnum(Enum):
+    """Enum identifying the type of error encountered while applying a pipeline."""
+
+    PREDICT_INPUT_SCHEMA_UNEQUAL = "predict_input_schema_unequal"
+    """predict_input_schema_unequal"""
+
+
+class PipelineError(ValueError):
+    """Exception raised for errors that can be raised when applying a pipeline"""
+
+    def __init__(self, message, code, details=None):
+        self.code = code
+        self.details = details
+        super().__init__(message)

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -153,7 +153,7 @@ class PipelineErrorCodeEnum(Enum):
 
 
 class PipelineError(ValueError):
-    """Exception raised for errors that can be raised when applying a pipeline"""
+    """Exception raised for errors that can be raised when applying a pipeline."""
 
     def __init__(self, message, code, details=None):
         self.code = code

--- a/evalml/exceptions/exceptions.py
+++ b/evalml/exceptions/exceptions.py
@@ -138,7 +138,12 @@ class PartialDependenceErrorCode(Enum):
 
 
 class PartialDependenceError(ValueError):
-    """Exception raised for all errors that partial dependence can raise."""
+    """Exception raised for all errors that partial dependence can raise.
+
+    Args:
+        message (str): descriptive error message
+        code (PartialDependenceErrorCode): code for speicific error
+    """
 
     def __init__(self, message, code):
         self.code = code
@@ -153,7 +158,13 @@ class PipelineErrorCodeEnum(Enum):
 
 
 class PipelineError(ValueError):
-    """Exception raised for errors that can be raised when applying a pipeline."""
+    """Exception raised for errors that can be raised when applying a pipeline.
+
+    Args:
+        message (str): descriptive error message
+        code (PipelineErrorCodeEnum): code for specific error
+        details (dict): additional details for error
+    """
 
     def __init__(self, message, code, details=None):
         self.code = code

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -25,6 +25,8 @@ from evalml.exceptions import (
     MethodPropertyNotFoundError,
     MissingComponentError,
     ParameterNotUsedWarning,
+    PipelineError,
+    PipelineErrorCodeEnum,
 )
 from evalml.pipelines import ComponentGraph
 from evalml.pipelines.components import (
@@ -2470,9 +2472,12 @@ def test_fit_predict_different_types(
     component_graph = ComponentGraph(component_dict).instantiate({})
     component_graph.fit(X, y)
     with pytest.raises(
-        ValueError, match="Input X data types are different from the input types"
-    ):
+        PipelineError, match="Input X data types are different from the input types"
+    ) as e:
         component_graph.predict(X2)
+    assert e.value.code == PipelineErrorCodeEnum.PREDICT_INPUT_SCHEMA_UNEQUAL
+    assert e.value.details["input_features_types"] is not None
+    assert e.value.details["pipeline_features_types"] is not None
 
 
 def test_fit_transform_different_types(X_y_binary):
@@ -2485,9 +2490,12 @@ def test_fit_transform_different_types(X_y_binary):
     component_graph = ComponentGraph(component_dict).instantiate({})
     component_graph.fit(X, y)
     with pytest.raises(
-        ValueError, match="Input X data types are different from the input types"
-    ):
+        PipelineError, match="Input X data types are different from the input types"
+    ) as e:
         component_graph.transform(X2)
+    assert e.value.code == PipelineErrorCodeEnum.PREDICT_INPUT_SCHEMA_UNEQUAL
+    assert e.value.details["input_features_types"] is not None
+    assert e.value.details["pipeline_features_types"] is not None
 
 
 def test_component_graph_cache():

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -15,6 +15,8 @@ from evalml.exceptions import (
     MissingComponentError,
     ObjectiveCreationError,
     ObjectiveNotFoundError,
+    PipelineError,
+    PipelineErrorCodeEnum,
     PipelineNotYetFittedError,
     PipelineScoreError,
 )
@@ -2865,13 +2867,19 @@ def test_fit_predict_proba_types(problem_type, X_y_binary, X_y_multi):
 
     pipeline.fit(X, y)
     with pytest.raises(
-        ValueError, match="Input X data types are different from the input types"
-    ):
+        PipelineError, match="Input X data types are different from the input types"
+    ) as e:
         pipeline.predict(X2)
+    assert e.value.code == PipelineErrorCodeEnum.PREDICT_INPUT_SCHEMA_UNEQUAL
+    assert e.value.details["input_features_types"] is not None
+    assert e.value.details["pipeline_features_types"] is not None
     with pytest.raises(
-        ValueError, match="Input X data types are different from the input types"
-    ):
+        PipelineError, match="Input X data types are different from the input types"
+    ) as e:
         pipeline.predict_proba(X2)
+    assert e.value.code == PipelineErrorCodeEnum.PREDICT_INPUT_SCHEMA_UNEQUAL
+    assert e.value.details["input_features_types"] is not None
+    assert e.value.details["pipeline_features_types"] is not None
 
 
 def test_pipeline_cache_clone():


### PR DESCRIPTION
### Pull Request Description
Adds new exception class `PipelineError` to be raised for errors encountered when applying pipelines. The first implementation will be for raising an error in `_transform_features` when input data types are different from the input types the pipeline was fitted on.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
