### PR TITLE
Holdout Dataset Spike

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,7 +18,7 @@ Release Notes
         * Added ability to log how long each batch and pipeline take in ``automl.search()`` :pr:`3577`
         * Added the option to set the ``sp`` parameter for ARIMA models :pr:`3597`
         * Updated the CV split size of time series problems to match forecast horizon for improved performance :pr:`3616`
-        * Added holdout set evaluation as part of AutoML search :pr:`3499`
+        * Added holdout set evaluation as part of AutoML search and pipeline ranking :pr:`3499`
     * Fixes
         * Fixed iterative graphs not appearing in documentation :pr:`3592`
         * Updated the ``load_diabetes()`` method to account for scikit-learn 1.1.1 changes to the dataset :pr:`3591`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,6 +18,7 @@ Release Notes
         * Added ability to log how long each batch and pipeline take in ``automl.search()`` :pr:`3577`
         * Added the option to set the ``sp`` parameter for ARIMA models :pr:`3597`
         * Updated the CV split size of time series problems to match forecast horizon for improved performance :pr:`3616`
+        * Added holdout set evaluation as part of AutoML search :pr:`3499`
     * Fixes
         * Fixed iterative graphs not appearing in documentation :pr:`3592`
         * Updated the ``load_diabetes()`` method to account for scikit-learn 1.1.1 changes to the dataset :pr:`3591`

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -52,7 +52,7 @@
     "import evalml\n",
     "from evalml.utils import infer_feature_types\n",
     "\n",
-    "X, y = evalml.demos.load_fraud(n_rows=250)"
+    "X, y = evalml.demos.load_fraud(n_rows=650)"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "source": [
     "### Data Checks\n",
     "\n",
-    "Before calling `AutoMLSearch.search`, we should run some sanity checks on our data to ensure that the input data being passed will not run into some common issues before running a potentially time-consuming search. EvalML has various data checks that makes this easy. Each data check will return a collection of warnings and errors if it detects potential issues with the input data. This allows users to inspect their data to avoid confusing errors that may arise during the search process. You can learn about each of the data checks available through our [data checks guide](data_checks.ipynb) \n",
+    "Before calling `AutoMLSearch.search`, we should run some sanity checks on our data to ensure that the input data being passed will not run into some common issues before running a potentially time-consuming search. EvalML has various data checks that makes this easy. Each data check will return a collection of warnings and errors if it detects potential issues with the input data. This allows users to inspect their data to avoid confusing errors that may arise during the search process. You can learn about each of the data checks available through our [data checks guide](data_checks.ipynb). \n",
     "\n",
     "Here, we will run the `DefaultDataChecks` class, which contains a series of data checks that are generally useful."
    ]
@@ -138,6 +138,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Holdout Set for Pipeline Ranking"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For datasets that have more than 500 rows, AutoMLSearch will automatically create a holdout set from 10% of the training data. Alternatively, a holdout set can be manually specified by using the `X_holdout` and `y_holdout` parameters in `AutoMLSearch()`.\n",
+    "\n",
+    "During the AutoML search process, the pipeline will be fitted on the entire training dataset and scored on this new holdout set. This score is represented under the \"validation_score\" column on the pipeline rankings board. \n",
+    "\n",
+    "If a dataset has less than 500 rows, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings) will be used as the validation_score instead. If `holdout_set_size=0`, then a holdout set will not be taken as part of AutoML search regardless of the number of rows in the dataset."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -153,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With the `verbose` argument set to True, the AutoML search will log its progress, reporting each pipeline and parameter set evaluated during the search.\n",
+    "With the `verbose` argument set to True, the AutoML search will log its progress, reporting each pipeline and parameter set evaluated during the search. The search iteration plot shown during AutoML search tracks the current pipeline's validation score (tracked as the gray point) against the best pipeline validation score (tracked as the blue line).\n",
     "\n",
     "There are a number of mechanisms to control the AutoML search time. One way is to set the `max_batches` parameter which controls the maximum number of rounds of AutoML to evaluate, where each round may train and score a variable number of pipelines. Another way is to set the `max_iterations` parameter which controls the maximum number of candidate models to be evaluated during AutoML. By default, AutoML will search for a single batch. The first pipeline to be evaluated will always be a baseline model representing a trivial solution. "
    ]
@@ -356,7 +374,9 @@
    "metadata": {},
    "source": [
     "## View Rankings\n",
-    "A summary of all the pipelines built can be returned as a pandas DataFrame which is sorted by score. The score column contains the average score across all cross-validation folds while the validation_score column is computed from the first cross-validation fold."
+    "A summary of all the pipelines built can be returned as a pandas DataFrame which is sorted by the validation score.\n",
+    "- For AutoML searches completed with a holdout set, the validation score is the holdout score of the pipeline fitted using the entire training dataset. \n",
+    "- For AutoML searches completed without a holdout set, the validation score is the average score across all cross-validation folds. "
    ]
   },
   {
@@ -1048,7 +1068,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.5 ('evalml')",
    "language": "python",
    "name": "python3"
   },
@@ -1063,6 +1083,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "fb5a3afe2d0dd7ad0fd9e1ff89de4e0e95804490c629f36065bf8d930a66d311"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "During the AutoML search process, the pipeline will be fitted on the entire training dataset and scored on this new holdout set. This score is represented under the \"validation_score\" column on the pipeline rankings board. \n",
     "\n",
-    "If a dataset has less than 500 rows, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings) will be used as the validation_score instead. If `holdout_set_size=0`, then a holdout set will not be taken as part of AutoML search regardless of the number of rows in the dataset."
+    "If a dataset has less than 500 rows or `holdout_set_size=0`, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings) will be used as the validation_score instead."
    ]
   },
   {
@@ -1068,7 +1068,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.5 ('evalml')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1083,11 +1083,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "fb5a3afe2d0dd7ad0fd9e1ff89de4e0e95804490c629f36065bf8d930a66d311"
-   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -148,11 +148,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For datasets that have more than 500 rows, AutoMLSearch will automatically create a holdout set from 10% of the training data. Alternatively, a holdout set can be manually specified by using the `X_holdout` and `y_holdout` parameters in `AutoMLSearch()`.\n",
+    "For datasets that have more than 500 rows, AutoMLSearch will automatically create a holdout set from 10% of the training data. Alternatively, a holdout set can be manually specified by using the `X_holdout` and `y_holdout` parameters in `AutoMLSearch()`. In this example, the holdout set created previously will be used by AutoML search.\n",
     "\n",
-    "During the AutoML search process, the pipeline will be fitted on the entire training dataset and scored on this new holdout set. This score is represented under the \"validation_score\" column on the pipeline rankings board. \n",
+    "During the AutoML search process, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings), is calculated. This score is passed to the AutoML search tuner to further optimize the hyperparameters of the next batch of pipelines.\n",
     "\n",
-    "If a dataset has less than 500 rows or `holdout_set_size=0`, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings) will be used as the validation_score instead."
+    "After, the pipeline will be fitted on the entire training dataset and scored on this new holdout set. This score is represented under the \"validation_score\" column on the pipeline rankings board and is used to rank pipeline performance.\n",
+    "\n",
+    "If a dataset has less than 500 rows or `holdout_set_size=0`, the \"mean_cv_score\" will be used as the validation_score instead."
    ]
   },
   {
@@ -162,7 +164,12 @@
    "outputs": [],
    "source": [
     "automl = evalml.automl.AutoMLSearch(\n",
-    "    X_train=X_train, y_train=y_train, problem_type=\"binary\", verbose=True\n",
+    "    X_train=X_train,\n",
+    "    y_train=y_train,\n",
+    "    X_holdout=X_holdout,\n",
+    "    y_holdout=y_holdout,\n",
+    "    problem_type=\"binary\",\n",
+    "    verbose=True,\n",
     ")\n",
     "automl.search(interactive_plot=False)"
    ]
@@ -375,6 +382,7 @@
    "source": [
     "## View Rankings\n",
     "A summary of all the pipelines built can be returned as a pandas DataFrame which is sorted by the validation score.\n",
+    "\n",
     "- For AutoML searches completed with a holdout set, the validation score is the holdout score of the pipeline fitted using the entire training dataset. \n",
     "- For AutoML searches completed without a holdout set, the validation score is the average score across all cross-validation folds. "
    ]
@@ -1068,7 +1076,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.5 ('evalml')",
    "language": "python",
    "name": "python3"
   },
@@ -1083,6 +1091,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "fb5a3afe2d0dd7ad0fd9e1ff89de4e0e95804490c629f36065bf8d930a66d311"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/data_check_actions.ipynb
+++ b/docs/source/user_guide/data_check_actions.ipynb
@@ -124,7 +124,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl = AutoMLSearch(X_train=X_train, y_train=y_train, problem_type=\"binary\")\n",
+    "automl = AutoMLSearch(\n",
+    "    X_train=X_train, y_train=y_train, problem_type=\"binary\", _holdout_set_size=0\n",
+    ")\n",
     "try:\n",
     "    automl.search()\n",
     "except ValueError as e:\n",
@@ -320,6 +322,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "fb5a3afe2d0dd7ad0fd9e1ff89de4e0e95804490c629f36065bf8d930a66d311"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/data_check_actions.ipynb
+++ b/docs/source/user_guide/data_check_actions.ipynb
@@ -322,11 +322,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.6"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "fb5a3afe2d0dd7ad0fd9e1ff89de4e0e95804490c629f36065bf8d930a66d311"
-   }
   }
  },
  "nbformat": 4,

--- a/docs/source/user_guide/data_check_actions.ipynb
+++ b/docs/source/user_guide/data_check_actions.ipynb
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "automl = AutoMLSearch(\n",
-    "    X_train=X_train, y_train=y_train, problem_type=\"binary\", _holdout_set_size=0\n",
+    "    X_train=X_train, y_train=y_train, problem_type=\"binary\", holdout_set_size=0\n",
     ")\n",
     "try:\n",
     "    automl.search()\n",

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -475,11 +475,11 @@ class AutoMLSearch:
         if X_train is not None or y_train is not None:
             if X_train is None:
                 raise ValueError(
-                    "Must specify training data as a 2d array using the X_train argument"
+                    "Must specify training data as a 2d array using the X_train argument",
                 )
             if y_train is None:
                 raise ValueError(
-                    "Must specify training data target values as a 1d vector using the y_train argument"
+                    "Must specify training data target values as a 1d vector using the y_train argument",
                 )
         if X_holdout is not None and y_holdout is not None:
             self.passed_holdout_set = True
@@ -487,11 +487,11 @@ class AutoMLSearch:
             self.passed_holdout_set = False
         elif X_holdout is None and y_holdout is not None:
             raise ValueError(
-                "Must specify holdout data as a 2d array using the X_holdout argument"
+                "Must specify holdout data as a 2d array using the X_holdout argument",
             )
         elif X_holdout is not None and y_holdout is None:
             raise ValueError(
-                "Must specify training data target values as a 1d vector using the y_holdout argument"
+                "Must specify training data target values as a 1d vector using the y_holdout argument",
             )
 
         try:
@@ -657,7 +657,7 @@ class AutoMLSearch:
                     random_seed=self.random_seed,
                 )
                 self.logger.info(
-                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows. AutoMLSearch will use the holdout set to score and rank pipelines."
+                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows. AutoMLSearch will use the holdout set to score and rank pipelines.",
                 )
             else:
                 self.X_train = X_train
@@ -665,11 +665,11 @@ class AutoMLSearch:
                 self.X_holdout = None
                 self.y_holdout = None
                 self.logger.info(
-                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. AutoMLSearch will use mean CV score to rank pipelines."
+                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. AutoMLSearch will use mean CV score to rank pipelines.",
                 )
         elif self._holdout_set_size < 0:
             raise ValueError(
-                "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation."
+                "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation.",
             )
         else:
             self.X_train = X_train
@@ -682,7 +682,7 @@ class AutoMLSearch:
             )
             if self.passed_holdout_set is False:
                 self.logger.info(
-                    f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines."
+                    f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines.",
                 )
         self.X_train = infer_feature_types(self.X_train)
         self.y_train = infer_feature_types(self.y_train)

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -668,16 +668,18 @@ class AutoMLSearch:
         else:
             self.X_train = X_train
             self.y_train = y_train
-            self.X_holdout = X_holdout if X_holdout is not None else None
-            self.y_holdout = y_holdout if y_holdout is not None else None
-            self.logger.info(
-                f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines."
+            self.X_holdout = (
+                infer_feature_types(X_holdout) if X_holdout is not None else None
             )
+            self.y_holdout = (
+                infer_feature_types(y_holdout) if y_holdout is not None else None
+            )
+            if self.passed_holdout_set is False:
+                self.logger.info(
+                    f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines."
+                )
         self.X_train = infer_feature_types(self.X_train)
         self.y_train = infer_feature_types(self.y_train)
-        if self.X_holdout is not None and self.y_holdout is not None:
-            self.X_holdout = infer_feature_types(self.X_holdout)
-            self.y_holdout = infer_feature_types(self.y_holdout)
         default_data_splitter = make_data_splitter(
             self.X_train,
             self.y_train,

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -420,6 +420,8 @@ class AutoMLSearch:
         verbose (boolean): Whether or not to display semi-real-time updates to stdout while search is running. Defaults to False.
 
         timing (boolean): Whether or not to write pipeline search times to the logger. Defaults to False.
+
+        holdout_set_size (float): The size of the holdout set that AutoML search will take for datasets larger than 500 rows. If set to 0, holdout set will not be taken regardless of number of rows. Must be between 0 and 1, exclusive. Defaults to 0.1.
     """
 
     _MAX_NAME_LEN = 40
@@ -465,7 +467,7 @@ class AutoMLSearch:
         engine="sequential",
         verbose=False,
         timing=False,
-        _holdout_set_size=0.1,
+        holdout_set_size=0.1,
     ):
         self.verbose = verbose
         if verbose:
@@ -594,7 +596,7 @@ class AutoMLSearch:
         self.max_iterations = max_iterations
         self.max_batches = max_batches
         self._pipelines_per_batch = _pipelines_per_batch
-        self._holdout_set_size = _holdout_set_size
+        self.holdout_set_size = holdout_set_size
 
         if patience and (not isinstance(patience, int) or patience < 0):
             raise ValueError(
@@ -646,7 +648,7 @@ class AutoMLSearch:
         self._best_pipeline = None
         self._searched = False
 
-        if self._holdout_set_size < 0:
+        if self.holdout_set_size < 0:
             raise ValueError(
                 "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation.",
             )
@@ -659,7 +661,7 @@ class AutoMLSearch:
                 y_train,
                 problem_type=self.problem_type,
                 problem_configuration=self.problem_configuration,
-                test_size=self._holdout_set_size,
+                test_size=self.holdout_set_size,
                 random_seed=self.random_seed,
             )
         else:
@@ -673,7 +675,7 @@ class AutoMLSearch:
             )
         if self.X_holdout is None and self.y_holdout is None:
             # Holdout set enabled but not enough rows
-            if len(X_train) < self._HOLDOUT_SET_MIN_ROWS and self._holdout_set_size > 0:
+            if len(X_train) < self._HOLDOUT_SET_MIN_ROWS and self.holdout_set_size > 0:
                 self.logger.info(
                     f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. Holdout set evaluation is disabled.",
                 )

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -424,6 +424,7 @@ class AutoMLSearch:
 
     _MAX_NAME_LEN = 40
 
+    # Minimum number of rows dataset must have before a holdout set is used to rank pipelines.
     _HOLDOUT_SET_MIN_ROWS = 500
 
     def __init__(
@@ -472,15 +473,16 @@ class AutoMLSearch:
         else:
             self.logger = logging.getLogger(__name__)
         self.timing = timing
-        if X_train is not None or y_train is not None:
-            if X_train is None:
-                raise ValueError(
-                    "Must specify training data as a 2d array using the X_train argument",
-                )
-            if y_train is None:
-                raise ValueError(
-                    "Must specify training data target values as a 1d vector using the y_train argument",
-                )
+
+        if X_train is None:
+            raise ValueError(
+                "Must specify training data as a 2d array using the X_train argument",
+            )
+        if y_train is None:
+            raise ValueError(
+                "Must specify training data target values as a 1d vector using the y_train argument",
+            )
+
         if X_holdout is not None and y_holdout is not None:
             self.passed_holdout_set = True
         elif X_holdout is None and y_holdout is None:
@@ -644,48 +646,49 @@ class AutoMLSearch:
         self._best_pipeline = None
         self._searched = False
 
-        if self._holdout_set_size > 0 and self.passed_holdout_set is False:
-            if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS:
-                self.X_train = infer_feature_types(X_train)
-                self.y_train = infer_feature_types(y_train)
-                self.X_train, self.X_holdout, self.y_train, self.y_holdout = split_data(
-                    self.X_train,
-                    self.y_train,
-                    problem_type=self.problem_type,
-                    problem_configuration=self.problem_configuration,
-                    test_size=self._holdout_set_size,
-                    random_seed=self.random_seed,
-                )
-                self.logger.info(
-                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows. AutoMLSearch will use the holdout set to score and rank pipelines.",
-                )
-            else:
-                self.X_train = X_train
-                self.y_train = y_train
-                self.X_holdout = None
-                self.y_holdout = None
-                self.logger.info(
-                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. AutoMLSearch will use mean CV score to rank pipelines.",
-                )
-        elif self._holdout_set_size < 0:
+        if self._holdout_set_size < 0:
             raise ValueError(
                 "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation.",
             )
+        if (
+            self.passed_holdout_set is False
+            and len(X_train) >= self._HOLDOUT_SET_MIN_ROWS
+        ):
+            self.X_train, self.X_holdout, self.y_train, self.y_holdout = split_data(
+                X_train,
+                y_train,
+                problem_type=self.problem_type,
+                problem_configuration=self.problem_configuration,
+                test_size=self._holdout_set_size,
+                random_seed=self.random_seed,
+            )
         else:
-            self.X_train = X_train
-            self.y_train = y_train
+            self.X_train = infer_feature_types(X_train)
+            self.y_train = infer_feature_types(y_train)
             self.X_holdout = (
                 infer_feature_types(X_holdout) if X_holdout is not None else None
             )
             self.y_holdout = (
                 infer_feature_types(y_holdout) if y_holdout is not None else None
             )
+        if self.X_holdout is None and self.y_holdout is None:
+            # Holdout set enabled but not enough rows
+            if len(X_train) < self._HOLDOUT_SET_MIN_ROWS and self._holdout_set_size > 0:
+                self.logger.info(
+                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. Holdout set evaluation is disabled.",
+                )
+            self.logger.info(
+                f"AutoMLSearch will use mean CV score to rank pipelines.",
+            )
+        else:
             if self.passed_holdout_set is False:
                 self.logger.info(
-                    f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines.",
+                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows.",
                 )
-        self.X_train = infer_feature_types(self.X_train)
-        self.y_train = infer_feature_types(self.y_train)
+            self.logger.info(
+                "AutoMLSearch will use the holdout set to score and rank pipelines.",
+            )
+
         default_data_splitter = make_data_splitter(
             self.X_train,
             self.y_train,

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -473,7 +473,6 @@ class AutoMLSearch:
             self.logger = logging.getLogger(__name__)
         self.timing = timing
         if X_train is not None or y_train is not None:
-            self.passed_holdout_set = False
             if X_train is None:
                 raise ValueError(
                     "Must specify training data as a 2d array using the X_train argument"
@@ -486,9 +485,13 @@ class AutoMLSearch:
             self.passed_holdout_set = True
         elif X_holdout is None and y_holdout is None:
             self.passed_holdout_set = False
-        else:
+        elif X_holdout is None and y_holdout is not None:
             raise ValueError(
-                "When specifying holdout data, all of X_train, y_train, X_holdout, and y_holdout must be passed in"
+                "Must specify holdout data as a 2d array using the X_holdout argument"
+            )
+        elif X_holdout is not None and y_holdout is None:
+            raise ValueError(
+                "Must specify training data target values as a 1d vector using the y_holdout argument"
             )
 
         try:
@@ -654,7 +657,7 @@ class AutoMLSearch:
                     random_seed=self.random_seed,
                 )
                 self.logger.info(
-                    f"Created holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows. AutoMLSearch will use holdout set to score and rank pipelines."
+                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows. AutoMLSearch will use the holdout set to score and rank pipelines."
                 )
             else:
                 self.X_train = X_train
@@ -664,7 +667,10 @@ class AutoMLSearch:
                 self.logger.info(
                     f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. AutoMLSearch will use mean CV score to rank pipelines."
                 )
-
+        elif self._holdout_set_size < 0:
+            raise ValueError(
+                "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation."
+            )
         else:
             self.X_train = X_train
             self.y_train = y_train

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -657,7 +657,7 @@ class AutoMLSearch:
                 "Holdout set size must be greater than 0 and less than 1. Set holdout set size to 0 to disable holdout set evaluation.",
             )
         if self.passed_holdout_set is False:
-            if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS:
+            if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS and self.holdout_set_size > 0:
                 # Create holdout set from X_train and y_train data because X_train above or at row threshold
                 X_train, X_holdout, y_train, y_holdout = split_data(
                     X_train,

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -671,6 +671,8 @@ class AutoMLSearch:
                     f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows.",
                 )
             else:
+                self.X_holdout = None
+                self.y_holdout = None
                 self.logger.info(
                     f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X_train)} rows. Holdout set evaluation is disabled.",
                 )

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -672,7 +672,7 @@ class AutoMLSearch:
                 )
             else:
                 self.logger.info(
-                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(self.X_train)} rows. Holdout set evaluation is disabled.",
+                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X_train)} rows. Holdout set evaluation is disabled.",
                 )
         else:
             # Set holdout data in AutoML search if provided as parameter

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -659,7 +659,7 @@ class AutoMLSearch:
         if self.passed_holdout_set is False:
             if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS:
                 # Create holdout set from X_train and y_train data because X_train above or at row threshold
-                self.X_train, self.X_holdout, self.y_train, self.y_holdout = split_data(
+                X_train, X_holdout, y_train, y_holdout = split_data(
                     X_train,
                     y_train,
                     problem_type=self.problem_type,
@@ -671,22 +671,18 @@ class AutoMLSearch:
                     f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows.",
                 )
             else:
-                self.X_holdout = None
-                self.y_holdout = None
                 self.logger.info(
                     f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X_train)} rows. Holdout set evaluation is disabled.",
                 )
-        else:
-            # Set holdout data in AutoML search if provided as parameter
-            self.X_train = infer_feature_types(X_train)
-            self.y_train = infer_feature_types(y_train)
-            self.X_holdout = (
-                infer_feature_types(X_holdout) if X_holdout is not None else None
-            )
-            self.y_holdout = (
-                infer_feature_types(y_holdout) if y_holdout is not None else None
-            )
-
+        # Set holdout data in AutoML search if provided as parameter
+        self.X_train = infer_feature_types(X_train)
+        self.y_train = infer_feature_types(y_train)
+        self.X_holdout = (
+            infer_feature_types(X_holdout) if X_holdout is not None else None
+        )
+        self.y_holdout = (
+            infer_feature_types(y_holdout) if y_holdout is not None else None
+        )
         if self.X_holdout is None and self.y_holdout is None:
             # Holdout set enabled but not enough rows
             self.logger.info(

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -668,7 +668,7 @@ class AutoMLSearch:
                     random_seed=self.random_seed,
                 )
                 self.logger.info(
-                    f"Created a holdout dataset with {len(self.X_holdout)} rows. Training dataset has {len(self.X_train)} rows.",
+                    f"Created a holdout dataset with {len(X_holdout)} rows. Training dataset has {len(X_train)} rows.",
                 )
             else:
                 self.logger.info(

--- a/evalml/automl/engine/cf_engine.py
+++ b/evalml/automl/engine/cf_engine.py
@@ -105,7 +105,9 @@ class CFEngine(EngineBase):
         self.client = client
         self._data_futures_cache = {}
 
-    def submit_evaluation_job(self, automl_config, pipeline, X, y):
+    def submit_evaluation_job(
+        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+    ):
         """Send evaluation job to cluster.
 
         Args:
@@ -113,6 +115,8 @@ class CFEngine(EngineBase):
             pipeline (pipeline.PipelineBase): Pipeline to evaluate.
             X (pd.DataFrame): Input data for modeling.
             y (pd.Series): Target data for modeling.
+            X_holdout (pd.Series): Holdout input data for holdout scoring.
+            y_holdout (pd.Series): Holdout target data for holdout scoring.
 
         Returns:
             CFComputation: An object wrapping a reference to a future-like computation
@@ -125,6 +129,8 @@ class CFEngine(EngineBase):
             automl_config=automl_config,
             X=X,
             y=y,
+            X_holdout=X_holdout,
+            y_holdout=y_holdout,
             logger=logger,
         )
         return CFComputation(future)

--- a/evalml/automl/engine/cf_engine.py
+++ b/evalml/automl/engine/cf_engine.py
@@ -106,7 +106,13 @@ class CFEngine(EngineBase):
         self._data_futures_cache = {}
 
     def submit_evaluation_job(
-        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+        self,
+        automl_config,
+        pipeline,
+        X,
+        y,
+        X_holdout=None,
+        y_holdout=None,
     ):
         """Send evaluation job to cluster.
 

--- a/evalml/automl/engine/dask_engine.py
+++ b/evalml/automl/engine/dask_engine.py
@@ -98,7 +98,9 @@ class DaskEngine(EngineBase):
         )
         return self._data_futures_cache[data_hash]
 
-    def submit_evaluation_job(self, automl_config, pipeline, X, y):
+    def submit_evaluation_job(
+        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+    ):
         """Send evaluation job to cluster.
 
         Args:
@@ -106,6 +108,8 @@ class DaskEngine(EngineBase):
             pipeline (pipeline.PipelineBase): Pipeline to evaluate.
             X (pd.DataFrame): Input data for modeling.
             y (pd.Series): Target data for modeling.
+            X_holdout (pd.Series): Holdout input data for holdout scoring.
+            y_holdout (pd.Series): Holdout target data for holdout scoring.
 
         Returns:
             DaskComputation: An object wrapping a reference to a future-like computation
@@ -119,6 +123,8 @@ class DaskEngine(EngineBase):
             automl_config=automl_config,
             X=X,
             y=y,
+            X_holdout=X_holdout,
+            y_holdout=y_holdout,
             logger=logger,
         )
         return DaskComputation(dask_future)

--- a/evalml/automl/engine/dask_engine.py
+++ b/evalml/automl/engine/dask_engine.py
@@ -99,7 +99,13 @@ class DaskEngine(EngineBase):
         return self._data_futures_cache[data_hash]
 
     def submit_evaluation_job(
-        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+        self,
+        automl_config,
+        pipeline,
+        X,
+        y,
+        X_holdout=None,
+        y_holdout=None,
     ):
         """Send evaluation job to cluster.
 

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -219,7 +219,7 @@ def train_and_score_pipeline(
         }
         full_y_train = ww.init_series(full_y_train.map(train_y_mapping))
 
-        if y_holdout is not None:
+        if use_holdout:
             holdout_y_mapping = {
                 original_target: encoded_target
                 for (encoded_target, original_target) in enumerate(
@@ -376,7 +376,7 @@ def train_and_score_pipeline(
                 y_train=full_y_train,
             )
             logger.debug(
-                f"\t\t\tFull data pipeline: {automl_config.objective.name} score: {holdout_scores[automl_config.objective.name]:.3f}"
+                f"\t\t\tFull training data pipeline: {automl_config.objective.name} score: {holdout_scores[automl_config.objective.name]:.3f}"
             )
             holdout_score = holdout_scores[automl_config.objective.name]
             pipeline_cache[hashes] = full_pipeline.component_graph.component_instances

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -90,13 +90,25 @@ class EngineBase(ABC):
 
     @abstractmethod
     def submit_evaluation_job(
-        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+        self,
+        automl_config,
+        pipeline,
+        X,
+        y,
+        X_holdout=None,
+        y_holdout=None,
     ):
         """Submit job for pipeline evaluation during AutoMLSearch."""
 
     @abstractmethod
     def submit_training_job(
-        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+        self,
+        automl_config,
+        pipeline,
+        X,
+        y,
+        X_holdout=None,
+        y_holdout=None,
     ):
         """Submit job for pipeline training."""
 
@@ -223,7 +235,7 @@ def train_and_score_pipeline(
             holdout_y_mapping = {
                 original_target: encoded_target
                 for (encoded_target, original_target) in enumerate(
-                    y_holdout.value_counts().index
+                    y_holdout.value_counts().index,
                 )
             }
             y_holdout = ww.init_series(y_holdout.map(holdout_y_mapping))
@@ -339,7 +351,7 @@ def train_and_score_pipeline(
     cv_scores = pd.Series([fold["mean_cv_score"] for fold in cv_data])
     cv_score_mean = cv_scores.mean()
     logger.info(
-        f"\tFinished cross validation - mean {automl_config.objective.name}: {cv_score_mean:.3f}"
+        f"\tFinished cross validation - mean {automl_config.objective.name}: {cv_score_mean:.3f}",
     )
 
     holdout_score = np.NaN
@@ -365,7 +377,7 @@ def train_and_score_pipeline(
                 and full_pipeline.threshold is not None
             ):
                 logger.debug(
-                    f"\t\t\tFull data pipeline: Optimal threshold found ({full_pipeline.threshold:.3f})"
+                    f"\t\t\tFull data pipeline: Optimal threshold found ({full_pipeline.threshold:.3f})",
                 )
             logger.debug(f"\t\t\tScoring trained full training data pipeline")
             holdout_scores = full_pipeline.score(
@@ -376,7 +388,7 @@ def train_and_score_pipeline(
                 y_train=full_y_train,
             )
             logger.debug(
-                f"\t\t\tFull training data pipeline: {automl_config.objective.name} score: {holdout_scores[automl_config.objective.name]:.3f}"
+                f"\t\t\tFull training data pipeline: {automl_config.objective.name} score: {holdout_scores[automl_config.objective.name]:.3f}",
             )
             holdout_score = holdout_scores[automl_config.objective.name]
             pipeline_cache[hashes] = full_pipeline.component_graph.component_instances
@@ -397,7 +409,7 @@ def train_and_score_pipeline(
                         o.name: holdout_scores[o.name]
                         for o in [automl_config.objective]
                         + automl_config.additional_objectives
-                    }
+                    },
                 )
                 holdout_score = holdout_scores[automl_config.objective.name]
             else:
@@ -406,10 +418,10 @@ def train_and_score_pipeline(
                     zip(
                         [n.name for n in automl_config.additional_objectives],
                         [np.nan] * len(automl_config.additional_objectives),
-                    )
+                    ),
                 )
         logger.info(
-            f"\tFinished holdout set scoring - {automl_config.objective.name}: {holdout_score:.3f}"
+            f"\tFinished holdout set scoring - {automl_config.objective.name}: {holdout_score:.3f}",
         )
 
     training_time = time.time() - start
@@ -429,7 +441,13 @@ def train_and_score_pipeline(
 
 
 def evaluate_pipeline(
-    pipeline, automl_config, X, y, logger, X_holdout=None, y_holdout=None
+    pipeline,
+    automl_config,
+    X,
+    y,
+    logger,
+    X_holdout=None,
+    y_holdout=None,
 ):
     """Function submitted to the submit_evaluation_job engine method.
 

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -207,6 +207,7 @@ def train_and_score_pipeline(
     """
     start = time.time()
     cv_data = []
+    use_holdout = X_holdout is not None and y_holdout is not None
     logger.info("\tStarting cross validation")
     # Encode target for classification problems so that we can support float targets. This is okay because we only use split to get the indices to split on
     if is_classification(automl_config.problem_type):
@@ -343,7 +344,7 @@ def train_and_score_pipeline(
 
     holdout_score = np.NaN
     holdout_scores = np.NaN
-    if X_holdout is not None and y_holdout is not None:
+    if use_holdout:
         logger.info("\tStarting holdout set scoring")
         logger.debug(f"\t\tTraining and scoring entire dataset")
         try:
@@ -418,12 +419,8 @@ def train_and_score_pipeline(
             "training_time": training_time,
             "cv_scores": cv_scores,
             "cv_score_mean": cv_score_mean,
-            "holdout_score": None
-            if X_holdout is None and y_holdout is None
-            else holdout_score,
-            "holdout_scores": None
-            if X_holdout is None and y_holdout is None
-            else holdout_scores,
+            "holdout_score": None if not use_holdout else holdout_score,
+            "holdout_scores": None if not use_holdout else holdout_scores,
         },
         "cached_data": pipeline_cache,
         "pipeline": stored_pipeline,

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -217,60 +217,25 @@ def train_and_score_pipeline(
         tuple of three items: First - A dict containing cv_score_mean, cv_scores, training_time and a cv_data structure with details.
             Second - The pipeline class we trained and scored. Third - the job logger instance with all the recorded messages.
     """
-    start = time.time()
-    cv_data = []
-    use_holdout = X_holdout is not None and y_holdout is not None
-    logger.info("\tStarting cross validation")
-    # Encode target for classification problems so that we can support float targets. This is okay because we only use split to get the indices to split on
-    if is_classification(automl_config.problem_type):
-        train_y_mapping = {
+
+    def _encode_classification_target(y):
+        y_mapping = {
             original_target: encoded_target
             for (encoded_target, original_target) in enumerate(
-                full_y_train.value_counts().index,
+                y.value_counts().index,
             )
         }
-        full_y_train = ww.init_series(full_y_train.map(train_y_mapping))
+        return ww.init_series(y.map(y_mapping))
 
-        if use_holdout:
-            holdout_y_mapping = {
-                original_target: encoded_target
-                for (encoded_target, original_target) in enumerate(
-                    y_holdout.value_counts().index,
-                )
-            }
-            y_holdout = ww.init_series(y_holdout.map(holdout_y_mapping))
-
-    pipeline_cache = {}
-    for i, (train, valid) in enumerate(
-        automl_config.data_splitter.split(full_X_train, full_y_train),
-    ):
-        logger.debug(f"\t\tTraining and scoring on fold {i}")
-        X_train, X_valid = full_X_train.ww.iloc[train], full_X_train.ww.iloc[valid]
-        y_train, y_valid = full_y_train.ww.iloc[train], full_y_train.ww.iloc[valid]
-        if handle_problem_types(automl_config.problem_type) in [
-            ProblemTypes.BINARY,
-            ProblemTypes.MULTICLASS,
-        ]:
-            diff_train = set(np.setdiff1d(full_y_train, y_train))
-            diff_valid = set(np.setdiff1d(full_y_train, y_valid))
-            diff_string = (
-                f"Missing target values in the training set after data split: {diff_train}. "
-                if diff_train
-                else ""
-            )
-            diff_string += (
-                f"Missing target values in the validation set after data split: {diff_valid}."
-                if diff_valid
-                else ""
-            )
-            if diff_string:
-                raise Exception(diff_string)
+    def _train_and_score(X_train, X_score, y_train, y_score, fold_num=None):
+        fitted_pipeline = pipeline
+        prefix = f"Fold {i}" if i is not None else "Full training data pipeline"
         objectives_to_score = [
             automl_config.objective,
         ] + automl_config.additional_objectives
         try:
-            logger.debug(f"\t\t\tFold {i}: starting training")
-            cv_pipeline, hashes = train_pipeline(
+            logger.debug(f"\t\t\t{prefix}: starting training")
+            fitted_pipeline, hashes = train_pipeline(
                 pipeline,
                 X_train,
                 y_train,
@@ -278,29 +243,28 @@ def train_and_score_pipeline(
                 schema=False,
                 get_hashes=True,
             )
-            logger.debug(f"\t\t\tFold {i}: finished training")
+            logger.debug(f"\t\t\t{prefix}: finished training")
             if (
                 automl_config.optimize_thresholds
                 and is_binary(automl_config.problem_type)
-                and cv_pipeline.threshold is not None
+                and fitted_pipeline.threshold is not None
             ):
                 logger.debug(
-                    f"\t\t\tFold {i}: Optimal threshold found ({cv_pipeline.threshold:.3f})",
+                    f"\t\t\t{prefix}: Optimal threshold found ({fitted_pipeline.threshold:.3f})",
                 )
-            logger.debug(f"\t\t\tFold {i}: Scoring trained pipeline")
-            scores = cv_pipeline.score(
-                X_valid,
-                y_valid,
+            logger.debug(f"\t\t\t{prefix}: Scoring trained pipeline")
+            scores = fitted_pipeline.score(
+                X_score,
+                y_score,
                 objectives=objectives_to_score,
                 X_train=X_train,
                 y_train=y_train,
             )
             logger.debug(
-                f"\t\t\tFold {i}: {automl_config.objective.name} score: {scores[automl_config.objective.name]:.3f}",
+                f"\t\t\t{prefix}: {automl_config.objective.name} score: {scores[automl_config.objective.name]:.3f}",
             )
             score = scores[automl_config.objective.name]
-            pipeline_cache[hashes] = cv_pipeline.component_graph.component_instances
-            stored_pipeline = cv_pipeline
+            pipeline_cache[hashes] = fitted_pipeline.component_graph.component_instances
         except Exception as e:
             if automl_config.error_callback is not None:
                 automl_config.error_callback(
@@ -329,6 +293,52 @@ def train_and_score_pipeline(
                         [np.nan] * len(automl_config.additional_objectives),
                     ),
                 )
+        return score, scores, fitted_pipeline
+
+    start = time.time()
+    cv_data = []
+    use_holdout = X_holdout is not None and y_holdout is not None
+    logger.info("\tStarting cross validation")
+    # Encode target for classification problems so that we can support float targets. This is okay because we only use split to get the indices to split on
+    if is_classification(automl_config.problem_type):
+        full_y_train = _encode_classification_target(full_y_train)
+        if use_holdout:
+            y_holdout = _encode_classification_target(y_holdout)
+
+    pipeline_cache = {}
+    stored_pipeline = pipeline
+
+    for i, (train, valid) in enumerate(
+        automl_config.data_splitter.split(full_X_train, full_y_train),
+    ):
+        logger.debug(f"\t\tTraining and scoring on fold {i}")
+        X_train, X_valid = full_X_train.ww.iloc[train], full_X_train.ww.iloc[valid]
+        y_train, y_valid = full_y_train.ww.iloc[train], full_y_train.ww.iloc[valid]
+        if is_binary(automl_config.problem_type) or is_multiclass(
+            automl_config.problem_type,
+        ):
+            diff_train = set(np.setdiff1d(full_y_train, y_train))
+            diff_valid = set(np.setdiff1d(full_y_train, y_valid))
+            diff_string = (
+                f"Missing target values in the training set after data split: {diff_train}. "
+                if diff_train
+                else ""
+            )
+            diff_string += (
+                f"Missing target values in the validation set after data split: {diff_valid}."
+                if diff_valid
+                else ""
+            )
+            if diff_string:
+                raise Exception(diff_string)
+
+        score, scores, stored_pipeline = _train_and_score(
+            X_train=X_train,
+            X_score=X_valid,
+            y_train=y_train,
+            y_score=y_valid,
+            fold_num=i,
+        )
 
         ordered_scores = OrderedDict()
         ordered_scores.update({automl_config.objective.name: score})
@@ -343,10 +353,12 @@ def train_and_score_pipeline(
         }
         if (
             is_binary(automl_config.problem_type)
-            and cv_pipeline is not None
-            and cv_pipeline.threshold is not None
+            and stored_pipeline is not None
+            and stored_pipeline.threshold is not None
         ):
-            evaluation_entry["binary_classification_threshold"] = cv_pipeline.threshold
+            evaluation_entry[
+                "binary_classification_threshold"
+            ] = stored_pipeline.threshold
         cv_data.append(evaluation_entry)
     cv_scores = pd.Series([fold["mean_cv_score"] for fold in cv_data])
     cv_score_mean = cv_scores.mean()
@@ -359,67 +371,12 @@ def train_and_score_pipeline(
     if use_holdout:
         logger.info("\tStarting holdout set scoring")
         logger.debug(f"\t\tTraining and scoring entire dataset")
-        try:
-            logger.debug(f"\t\t\tFull training data pipeline: starting training")
-            full_pipeline, hashes = train_pipeline(
-                pipeline,
-                full_X_train,
-                full_y_train,
-                automl_config,
-                schema=False,
-                get_hashes=True,
-            )
-            stored_pipeline = full_pipeline
-            logger.debug(f"\t\t\tFull training data pipeline: finished training")
-            if (
-                automl_config.optimize_thresholds
-                and is_binary(automl_config.problem_type)
-                and full_pipeline.threshold is not None
-            ):
-                logger.debug(
-                    f"\t\t\tFull data pipeline: Optimal threshold found ({full_pipeline.threshold:.3f})",
-                )
-            logger.debug(f"\t\t\tScoring trained full training data pipeline")
-            holdout_scores = full_pipeline.score(
-                X_holdout,
-                y_holdout,
-                objectives=objectives_to_score,
-                X_train=full_X_train,
-                y_train=full_y_train,
-            )
-            logger.debug(
-                f"\t\t\tFull training data pipeline: {automl_config.objective.name} score: {holdout_scores[automl_config.objective.name]:.3f}",
-            )
-            holdout_score = holdout_scores[automl_config.objective.name]
-            pipeline_cache[hashes] = full_pipeline.component_graph.component_instances
-        except Exception as e:
-            if automl_config.error_callback is not None:
-                automl_config.error_callback(
-                    exception=e,
-                    traceback=traceback.format_tb(sys.exc_info()[2]),
-                    automl=automl_config,
-                    fold_num=i,
-                    pipeline=pipeline,
-                )
-            if isinstance(e, PipelineScoreError):
-                nan_scores = {objective: np.nan for objective in e.exceptions}
-                holdout_scores = {**nan_scores, **e.scored_successfully}
-                holdout_scores = OrderedDict(
-                    {
-                        o.name: holdout_scores[o.name]
-                        for o in [automl_config.objective]
-                        + automl_config.additional_objectives
-                    },
-                )
-                holdout_score = holdout_scores[automl_config.objective.name]
-            else:
-                holdout_score = np.nan
-                holdout_scores = OrderedDict(
-                    zip(
-                        [n.name for n in automl_config.additional_objectives],
-                        [np.nan] * len(automl_config.additional_objectives),
-                    ),
-                )
+        holdout_score, holdout_scores, stored_pipeline = _train_and_score(
+            X_train=full_X_train,
+            X_score=X_holdout,
+            y_train=full_y_train,
+            y_score=y_holdout,
+        )
         logger.info(
             f"\tFinished holdout set scoring - {automl_config.objective.name}: {holdout_score:.3f}",
         )

--- a/evalml/automl/engine/engine_base.py
+++ b/evalml/automl/engine/engine_base.py
@@ -314,9 +314,10 @@ def train_and_score_pipeline(
         logger.debug(f"\t\tTraining and scoring on fold {i}")
         X_train, X_valid = full_X_train.ww.iloc[train], full_X_train.ww.iloc[valid]
         y_train, y_valid = full_y_train.ww.iloc[train], full_y_train.ww.iloc[valid]
-        if is_binary(automl_config.problem_type) or is_multiclass(
-            automl_config.problem_type,
-        ):
+        if handle_problem_types(automl_config.problem_type) in [
+            ProblemTypes.BINARY,
+            ProblemTypes.MULTICLASS,
+        ]:
             diff_train = set(np.setdiff1d(full_y_train, y_train))
             diff_valid = set(np.setdiff1d(full_y_train, y_valid))
             diff_string = (

--- a/evalml/automl/engine/sequential_engine.py
+++ b/evalml/automl/engine/sequential_engine.py
@@ -57,7 +57,13 @@ class SequentialEngine(EngineBase):
     """
 
     def submit_evaluation_job(
-        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+        self,
+        automl_config,
+        pipeline,
+        X,
+        y,
+        X_holdout=None,
+        y_holdout=None,
     ):
         """Submit a job to evaluate a pipeline.
 

--- a/evalml/automl/engine/sequential_engine.py
+++ b/evalml/automl/engine/sequential_engine.py
@@ -56,7 +56,9 @@ class SequentialEngine(EngineBase):
     Trains and scores pipelines locally and sequentially.
     """
 
-    def submit_evaluation_job(self, automl_config, pipeline, X, y):
+    def submit_evaluation_job(
+        self, automl_config, pipeline, X, y, X_holdout=None, y_holdout=None
+    ):
         """Submit a job to evaluate a pipeline.
 
         Args:
@@ -64,6 +66,8 @@ class SequentialEngine(EngineBase):
             pipeline (pipeline.PipelineBase): Pipeline to evaluate.
             X (pd.DataFrame): Input data for modeling.
             y (pd.Series): Target data for modeling.
+            X_holdout (pd.Series): Holdout input data for holdout scoring.
+            y_holdout (pd.Series): Holdout target data for holdout scoring.
 
         Returns:
             SequentialComputation: Computation result.
@@ -75,6 +79,8 @@ class SequentialEngine(EngineBase):
             automl_config=automl_config,
             X=X,
             y=y,
+            X_holdout=X_holdout,
+            y_holdout=y_holdout,
             logger=logger,
         )
 

--- a/evalml/automl/pipeline_search_plots.py
+++ b/evalml/automl/pipeline_search_plots.py
@@ -39,7 +39,7 @@ class SearchIterationPlot:
         layout = {
             "title": title,
             "xaxis": {"title": "Iteration", "rangemode": "tozero"},
-            "yaxis": {"title": "Score"},
+            "yaxis": {"title": "Validation Score"},
         }
         self.best_score_by_iter_fig = self._go.FigureWidget(data, layout)
         self.best_score_by_iter_fig.update_layout(showlegend=False)
@@ -51,7 +51,7 @@ class SearchIterationPlot:
         if len(results["search_order"]) > 0 and len(results["pipeline_results"]) > 0:
             iter_idx = results["search_order"]
             pipeline_res = results["pipeline_results"]
-            iter_scores = [pipeline_res[i]["mean_cv_score"] for i in iter_idx]
+            iter_scores = [pipeline_res[i]["validation_score"] for i in iter_idx]
 
             iter_score_pairs = zip(iter_idx, iter_scores)
             iter_score_pairs = sorted(iter_score_pairs, key=lambda value: value[0])

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -144,7 +144,7 @@ class ComponentGraph:
             if (
                 len(
                     list(
-                        filter(check_all_inputs_have_correct_syntax, component_inputs)
+                        filter(check_all_inputs_have_correct_syntax, component_inputs),
                     ),
                 )
                 != 0

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -363,7 +363,7 @@ def make_balancing_dictionary(y, sampling_ratio):
     if sampling_ratio <= 0 or sampling_ratio > 1:
         raise ValueError(
             "Sampling ratio must be in range (0, 1], received {}".format(
-                sampling_ratio
+                sampling_ratio,
             ),
         )
     if len(y) == 0:

--- a/evalml/preprocessing/utils.py
+++ b/evalml/preprocessing/utils.py
@@ -93,6 +93,9 @@ def split_data(
     X = infer_feature_types(X)
     y = infer_feature_types(y)
 
+    if test_size == 0:
+        return X, None, y, None
+
     data_splitter = None
     if is_time_series(problem_type):
         data_splitter = TrainingValidationSplit(

--- a/evalml/preprocessing/utils.py
+++ b/evalml/preprocessing/utils.py
@@ -93,9 +93,6 @@ def split_data(
     X = infer_feature_types(X)
     y = infer_feature_types(y)
 
-    if test_size == 0:
-        return X, None, y, None
-
     data_splitter = None
     if is_time_series(problem_type):
         data_splitter = TrainingValidationSplit(

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -66,11 +66,7 @@ from evalml.pipelines.utils import (
     _get_pipeline_base_class,
     _make_stacked_ensemble_pipeline,
 )
-from evalml.preprocessing import (
-    TimeSeriesSplit,
-    TrainingValidationSplit,
-    split_data,
-)
+from evalml.preprocessing import TimeSeriesSplit, TrainingValidationSplit, split_data
 from evalml.problem_types import (
     ProblemTypes,
     handle_problem_types,
@@ -758,7 +754,7 @@ def test_invalid_data_splitter(X_y_binary):
 
 def test_large_dataset_binary(AutoMLTestEnv):
     X = pd.DataFrame(
-        {"col_0": range(111113)}
+        {"col_0": range(111113)},
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series([i % 2 for i in range(111113)])
 
@@ -793,13 +789,13 @@ def test_large_dataset_binary(AutoMLTestEnv):
             automl.results["pipeline_results"][pipeline_id]["validation_score"] == 1.234
         )
         assert np.isnan(
-            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"]
+            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"],
         )
 
 
 def test_large_dataset_multiclass(AutoMLTestEnv):
     X = pd.DataFrame(
-        {"col_0": range(111113)}
+        {"col_0": range(111113)},
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series([i % 4 for i in range(111113)])
 
@@ -829,13 +825,13 @@ def test_large_dataset_multiclass(AutoMLTestEnv):
             automl.results["pipeline_results"][pipeline_id]["validation_score"] == 1.234
         )
         assert np.isnan(
-            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"]
+            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"],
         )
 
 
 def test_large_dataset_regression(AutoMLTestEnv):
     X = pd.DataFrame(
-        {"col_0": [i for i in range(200000)]}
+        {"col_0": [i for i in range(200000)]},
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series([i for i in range(200000)])
 
@@ -865,7 +861,7 @@ def test_large_dataset_regression(AutoMLTestEnv):
             automl.results["pipeline_results"][pipeline_id]["validation_score"] == 1.234
         )
         assert np.isnan(
-            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"]
+            automl.results["pipeline_results"][pipeline_id]["mean_cv_score"],
         )
 
 
@@ -1171,7 +1167,7 @@ def test_add_to_rankings_regression_large(
     example_regression_graph,
 ):
     X = pd.DataFrame(
-        {"col_0": range(111113)}
+        {"col_0": range(111113)},
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series(range(111113))
 
@@ -4611,7 +4607,11 @@ def test_cv_validation_scores(
     AutoMLTestEnv,
 ):
     X, y = datasets.make_classification(
-        n_samples=500, n_features=20, n_informative=2, n_redundant=2, random_state=0
+        n_samples=500,
+        n_features=20,
+        n_informative=2,
+        n_redundant=2,
+        random_state=0,
     )
     data_splitter = data_splitter()
     automl = AutoMLSearch(
@@ -5057,7 +5057,10 @@ def test_init_holdout_set(X_y_binary):
         match=match_text,
     ):
         AutoMLSearch(
-            X_train=X_train, y_train=y_train, X_holdout=X_holdout, problem_type="binary"
+            X_train=X_train,
+            y_train=y_train,
+            X_holdout=X_holdout,
+            problem_type="binary",
         )
     match_text = "Must specify holdout data as a 2d array using the X_holdout argument"
     with pytest.raises(
@@ -5065,7 +5068,10 @@ def test_init_holdout_set(X_y_binary):
         match=match_text,
     ):
         AutoMLSearch(
-            X_train=X_train, y_train=y_train, y_holdout=y_holdout, problem_type="binary"
+            X_train=X_train,
+            y_train=y_train,
+            y_holdout=y_holdout,
+            problem_type="binary",
         )
 
     automl = AutoMLSearch(
@@ -5083,7 +5089,8 @@ def test_init_holdout_set(X_y_binary):
 def test_init_create_holdout_set(caplog):
     caplog.clear()
     X, y = datasets.make_classification(
-        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS - 1, random_state=0
+        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS - 1,
+        random_state=0,
     )
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", verbose=True)
     out = caplog.text
@@ -5098,7 +5105,8 @@ def test_init_create_holdout_set(caplog):
 
     caplog.clear()
     X, y = datasets.make_classification(
-        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS, random_state=0
+        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS,
+        random_state=0,
     )
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", verbose=True)
     out = caplog.text
@@ -5115,10 +5123,15 @@ def test_init_create_holdout_set(caplog):
 
     caplog.clear()
     X, y = datasets.make_classification(
-        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS, random_state=0
+        n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS,
+        random_state=0,
     )
     automl = AutoMLSearch(
-        X_train=X, y_train=y, problem_type="binary", verbose=True, _holdout_set_size=0
+        X_train=X,
+        y_train=y,
+        problem_type="binary",
+        verbose=True,
+        _holdout_set_size=0,
     )
     out = caplog.text
 
@@ -5136,5 +5149,8 @@ def test_init_create_holdout_set(caplog):
         match=match_text,
     ):
         AutoMLSearch(
-            X_train=X, y_train=y, problem_type="binary", _holdout_set_size=-0.1
+            X_train=X,
+            y_train=y,
+            problem_type="binary",
+            _holdout_set_size=-0.1,
         )

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5117,8 +5117,8 @@ def test_init_create_holdout_set(caplog):
     automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", verbose=True)
     out = caplog.text
 
-    expected_holdout_size = int(automl._holdout_set_size * len(X))
-    expected_train_size = int((1 - automl._holdout_set_size) * len(X))
+    expected_holdout_size = int(automl.holdout_set_size * len(X))
+    expected_train_size = int((1 - automl.holdout_set_size) * len(X))
     match_text = f"Created a holdout dataset with {expected_holdout_size} rows. Training dataset has {expected_train_size} rows."
     assert match_text in out
     assert "AutoMLSearch will use the holdout set to score and rank pipelines." in out
@@ -5138,7 +5138,7 @@ def test_init_create_holdout_set(caplog):
         y_train=y,
         problem_type="binary",
         verbose=True,
-        _holdout_set_size=0,
+        holdout_set_size=0,
     )
     out = caplog.text
 
@@ -5159,7 +5159,7 @@ def test_init_create_holdout_set(caplog):
             X_train=X,
             y_train=y,
             problem_type="binary",
-            _holdout_set_size=-0.1,
+            holdout_set_size=-0.1,
         )
 
 

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -758,7 +758,7 @@ def test_invalid_data_splitter(X_y_binary):
 
 def test_large_dataset_binary(AutoMLTestEnv):
     X = pd.DataFrame(
-        {"col_0": [i for i in range(111113)]}
+        {"col_0": range(111113)}
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series([i % 2 for i in range(111113)])
 
@@ -799,7 +799,7 @@ def test_large_dataset_binary(AutoMLTestEnv):
 
 def test_large_dataset_multiclass(AutoMLTestEnv):
     X = pd.DataFrame(
-        {"col_0": [i for i in range(111113)]}
+        {"col_0": range(111113)}
     )  # Reaches just over max row threshold after holdout set
     y = pd.Series([i % 4 for i in range(111113)])
 
@@ -1171,9 +1171,9 @@ def test_add_to_rankings_regression_large(
     example_regression_graph,
 ):
     X = pd.DataFrame(
-        {"col_0": [i for i in range(111113)]}
+        {"col_0": range(111113)}
     )  # Reaches just over max row threshold after holdout set
-    y = pd.Series([i for i in range(111113)])
+    y = pd.Series(range(111113))
 
     automl = AutoMLSearch(
         X_train=X,
@@ -5121,8 +5121,6 @@ def test_init_create_holdout_set(caplog):
     )
     out = caplog.text
 
-    expected_holdout_size = int(automl._holdout_set_size * len(X))
-    expected_train_size = int((1 - automl._holdout_set_size) * len(X))
     match_text = f"Holdout set evaluation is disabled. AutoMLSearch will use mean CV score to rank pipelines."
     assert match_text in out
     assert len(automl.X_train) == len(X)

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5150,7 +5150,7 @@ def test_init_create_holdout_set(caplog):
     assert automl.y_holdout is None
     assert automl.passed_holdout_set is False
 
-    match_text = "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation."
+    match_text = "Holdout set size must be greater than 0 and less than 1. Set holdout set size to 0 to disable holdout set evaluation."
     with pytest.raises(
         ValueError,
         match=match_text,
@@ -5161,44 +5161,3 @@ def test_init_create_holdout_set(caplog):
             problem_type="binary",
             holdout_set_size=-0.1,
         )
-
-
-# def test_holdout_scoring_error(
-#     X_y_binary,
-#     dummy_classifier_estimator_class,
-#     AutoMLTestEnv,
-#     caplog,
-# ):
-#     X, y = X_y_binary
-#     X_train, X_holdout, y_train, y_holdout = split_data(X, y, "binary")
-
-#     def raise_error_on_holdout(*args, **kwargs):
-#         # Raise a PipelineScoreError on holdout scoring, but not on the CV scoring
-#         score_X_input = args[0]
-#         if len(score_X_input) == len(X_holdout):
-#             return PipelineScoreError(
-#                 exceptions={"Log Loss Binary": (Exception(), [])},
-#                 scored_successfully={},
-#             )
-#         else:
-#             return {"Log Loss Binary": 3.12}
-
-
-#     automl = AutoMLSearch(
-#         X_train=X_train,
-#         y_train=y_train,
-#         X_holdout=X_holdout,
-#         y_holdout=y_holdout,
-#         problem_type="binary",
-#         max_iterations=2,
-#         allowed_component_graphs={
-#             "Mock Binary Classification Pipeline": [dummy_classifier_estimator_class],
-#         },
-#         optimize_thresholds=False,
-#     )
-#     env = AutoMLTestEnv("binary")
-
-#     with env.test_context(mock_score_side_effect=raise_error_on_holdout):
-#         automl.search()
-
-#     automl.rankings

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5051,7 +5051,7 @@ def test_init_holdout_set(X_y_binary):
     X, y = X_y_binary
     X_train, X_holdout, y_train, y_holdout = split_data(X, y, "binary")
 
-    match_text = "When specifying holdout data, all of X_train, y_train, X_holdout, and y_holdout must be passed in"
+    match_text = "Must specify training data target values as a 1d vector using the y_holdout argument"
     with pytest.raises(
         ValueError,
         match=match_text,
@@ -5059,6 +5059,7 @@ def test_init_holdout_set(X_y_binary):
         AutoMLSearch(
             X_train=X_train, y_train=y_train, X_holdout=X_holdout, problem_type="binary"
         )
+    match_text = "Must specify holdout data as a 2d array using the X_holdout argument"
     with pytest.raises(
         ValueError,
         match=match_text,
@@ -5104,7 +5105,7 @@ def test_init_create_holdout_set(caplog):
 
     expected_holdout_size = int(automl._holdout_set_size * len(X))
     expected_train_size = int((1 - automl._holdout_set_size) * len(X))
-    match_text = f"Created holdout dataset with {expected_holdout_size} rows. Training dataset has {expected_train_size} rows. AutoMLSearch will use holdout set to score and rank pipelines."
+    match_text = f"Created a holdout dataset with {expected_holdout_size} rows. Training dataset has {expected_train_size} rows. AutoMLSearch will use the holdout set to score and rank pipelines."
     assert match_text in out
     assert len(automl.X_train) == expected_train_size
     assert len(automl.y_train) == expected_train_size
@@ -5128,3 +5129,12 @@ def test_init_create_holdout_set(caplog):
     assert automl.X_holdout is None
     assert automl.y_holdout is None
     assert automl.passed_holdout_set is False
+
+    match_text = "Holdout set size must be greater than 0. Set holdout set size to 0 to disable holdout set evaluation."
+    with pytest.raises(
+        ValueError,
+        match=match_text,
+    ):
+        AutoMLSearch(
+            X_train=X, y_train=y, problem_type="binary", _holdout_set_size=-0.1
+        )

--- a/evalml/tests/automl_tests/test_automl_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_automl_iterative_algorithm.py
@@ -1045,7 +1045,7 @@ def test_automl_respects_pipeline_order(X_y_binary, AutoMLTestEnv):
     automl = AutoMLSearch(
         X,
         y,
-        "binary",
+        problem_type="binary",
         engine="sequential",
         max_iterations=5,
         automl_algorithm="iterative",

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -991,10 +991,10 @@ def test_automl_search_ratio_overrides_sampler_ratio(
 @pytest.mark.parametrize(
     "problem_type,sampling_ratio_dict,length",
     [
-        ("binary", {0: 0.5, 1: 1}, 600),
-        ("binary", {0: 0.2, 1: 1}, 800),
-        ("multiclass", {0: 0.5, 1: 1, 2: 1}, 400),
-        ("multiclass", {0: 0.75, 1: 1, 2: 1}, 333),
+        ("binary", {0: 0.5, 1: 1}, 810),
+        ("binary", {0: 0.2, 1: 1}, 1080),
+        ("multiclass", {0: 0.5, 1: 1, 2: 1}, 540),
+        ("multiclass", {0: 0.75, 1: 1, 2: 1}, 450),
     ],
 )
 @patch("evalml.pipelines.components.estimators.Estimator.fit")
@@ -1044,10 +1044,10 @@ def test_automl_search_dictionary_undersampler(
 @pytest.mark.parametrize(
     "problem_type,sampling_ratio_dict,length",
     [
-        ("binary", {0: 1, 1: 0.5}, 900),
-        ("binary", {0: 1, 1: 0.8}, 1080),
-        ("multiclass", {0: 1, 1: 0.5, 2: 0.5}, 1200),
-        ("multiclass", {0: 1, 1: 0.8, 2: 0.8}, 1560),
+        ("binary", {0: 1, 1: 0.5}, 1215),
+        ("binary", {0: 1, 1: 0.8}, 1458),
+        ("multiclass", {0: 1, 1: 0.5, 2: 0.5}, 1620),
+        ("multiclass", {0: 1, 1: 0.8, 2: 0.8}, 2106),
     ],
 )
 @patch("evalml.pipelines.components.estimators.Estimator.fit")
@@ -1261,8 +1261,8 @@ def test_automl_passes_allow_long_running_models(
     allow_long_running_models,
     caplog,
 ):
-    X = pd.DataFrame([i for i in range(unique)] * 5)
-    y = pd.Series([i for i in range(unique)] * 5)
+    X = pd.DataFrame([i for i in range(unique)] * 10)
+    y = pd.Series([i for i in range(unique)] * 10)
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,
@@ -1292,7 +1292,7 @@ def test_automl_threshold_score(fraud_100):
     automl = AutoMLSearch(
         X_train,
         y_train,
-        "binary",
+        problem_type="binary",
         max_batches=4,
         ensembling=True,
         verbose=False,

--- a/evalml/tests/automl_tests/test_automl_search_classification_iterative.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification_iterative.py
@@ -429,7 +429,7 @@ def test_automl_oversampler_selection():
     automl = AutoMLSearch(
         X,
         y,
-        "binary",
+        problem_type="binary",
         allowed_component_graphs={"pipeline": allowed_component_graph},
         search_parameters={"DropCols": {"columns": ["a"]}},
         error_callback=raise_error_callback,

--- a/evalml/tests/automl_tests/test_pipeline_search_plots.py
+++ b/evalml/tests/automl_tests/test_pipeline_search_plots.py
@@ -17,13 +17,13 @@ def test_search_iteration_plot_class():
             self.objective = MockObjective()
             self.results = {
                 "pipeline_results": {
-                    2: {"mean_cv_score": 0.50},
-                    0: {"mean_cv_score": 0.60},
-                    1: {"mean_cv_score": 0.75},
+                    2: {"mean_cv_score": 0.75, "validation_score": 0.50},
+                    0: {"mean_cv_score": 0.50, "validation_score": 0.60},
+                    1: {"mean_cv_score": 0.60, "validation_score": 0.75},
                 },
                 "search_order": [1, 2, 0],
             }
-            self.rankings = pd.DataFrame({"mean_cv_score": [0.75, 0.60, 0.50]})
+            self.rankings = pd.DataFrame({"validation_score": [0.75, 0.60, 0.50]})
 
     mock_data = MockResults()
     plot = SearchIterationPlot(mock_data.results, mock_data.objective)

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -95,7 +95,7 @@ all_requirements_set = set(
 not_supported_in_conda = set(
     [
         "Prophet Regressor",
-    ]
+    ],
 )
 
 # Keeping here in case we need to add to it when a new component is added

--- a/evalml/tests/integration_tests/test_time_series_integration.py
+++ b/evalml/tests/integration_tests/test_time_series_integration.py
@@ -134,7 +134,6 @@ def test_can_run_automl_for_time_series_known_in_advance(
         ),
     )
     automl.search()
-    automl.best_pipeline.fit(X, y)
     X_valid = pd.DataFrame(
         {
             "date": pd.date_range(

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -370,7 +370,7 @@ def test_transform_all_but_final_for_time_series(
     drop_nan_rows_transformer = DropNaNRowsTransformer()
     expected_features = drop_nan_rows_transformer.fit_transform(
         date_featurizer.fit_transform(
-            delayer.fit_transform(X_validation, y_validation)
+            delayer.fit_transform(X_validation, y_validation),
         ),
     )[0]
     assert_frame_equal(features, expected_features)


### PR DESCRIPTION
Summary of changes:
- Holdout set is taken by default when dataset exceeds row minimum (currently set at 500 rows)
   - If it does not meet row minimum, then no holdout set is taken 
   - Score of holdout set is represented as `validation_score` column. Previously this row repeated the results of the `mean_cv_score` column unless only one CV fold is used (then `mean_cv_score` shows as `NaN`)
- Holdout set can also be specified and passed through `AutoMLSearch`
- `validation_score` column is moved before `mean_cv_score` in results table 
- Additional tests + test updates (typically to specify `problem_type` parameter)

TODO:
- Update docs:
   - Update start page to indicate holdout set is used 