### PR TITLE
Move vowpal wabbit to evalml instead of evalml-core

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -44,7 +44,6 @@ outputs:
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2
         - python-graphviz >=0.13
-        - vowpalwabbit >=8.11.0
     test:
       imports:
         - evalml
@@ -76,6 +75,7 @@ outputs:
         - python >=3.8.*
         - imbalanced-learn >=0.8.0
         - sktime >=0.7.0
+        - vowpalwabbit >=8.11.0
     test:
       imports:
         - evalml

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@
         * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` instead of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
     * Documentation Changes
     * Testing Changes
+        * Moved vowpal wabbit in test recipe to ``evalml`` package from ``evalml-core`` :pr:`3502`
 
 .. warning::
 


### PR DESCRIPTION
### Pull Request Description
So that we can fix the broken test in https://github.com/conda-forge/evalml-core-feedstock/pull/108. We'll get it in for the next release. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
