### PR TITLE
Cap sklearn at 1.1.0

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -28,7 +28,7 @@ outputs:
         - pandas >=1.4.0
         - dask >=2021.10.0
         - scipy >=1.5.0
-        - scikit-learn >=0.24.0
+        - scikit-learn >=0.24.0,<1.1.0
         - scikit-optimize >=0.8.1
         - statsmodels >=0.12.2
         - colorama >=0.4.4

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.21.0
 pandas>=1.4.0
 scipy>=1.5.0
-scikit-learn>=0.24.0
+scikit-learn>=0.24.0,<1.1.0
 scikit-optimize>=0.8.1
 pyzmq>=20.0.0
 colorama>=0.4.4

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Changed ``NoVarianceDataCheck`` to only output warnings :pr:`3506`
         * Updated ``roc_curve()`` and ``conf_matrix()`` to work with IntegerNullable and BooleanNullable types. :pr:`3465`
         * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` instead of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
+        * Capped ``sklearn`` at version 1.1.0 :pr:`3518`
     * Documentation Changes
         * Updated to install prophet extras in Read the Docs. :pr:`3509`
     * Testing Changes


### PR DESCRIPTION
### Pull Request Description
Cap sklearn <1.1.0 because of some breaking changes. 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
