### PR TITLE
Release v.0.52.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,8 +4,19 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.52.0 May. 12, 2022**
+    * Enhancements
+    * Fixes
+    * Changes
         * Added github workflows for featuretools and woodwork to test their main branch against evalml. :pr:`3504`
-        * Reverted XGBoost Classifier/Regressor patch for all boolean columns needing to be converted to int. :pr:`3503`
         * Added pmdarima to conda recipe. :pr:`3505`
         * Added a threshold for ``NullDataCheck`` before a warning is issued for null values :pr:`3507`
         * Changed ``NoVarianceDataCheck`` to only output warnings :pr:`3506`
@@ -15,10 +26,6 @@ Release Notes
         * Updated to install prophet extras in Read the Docs. :pr:`3509`
     * Testing Changes
         * Moved vowpal wabbit in test recipe to ``evalml`` package from ``evalml-core`` :pr:`3502`
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.51.0 Apr. 28, 2022**

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,6 +20,7 @@ Release Notes
         * Added pmdarima to conda recipe. :pr:`3505`
         * Added a threshold for ``NullDataCheck`` before a warning is issued for null values :pr:`3507`
         * Changed ``NoVarianceDataCheck`` to only output warnings :pr:`3506`
+        * Reverted XGBoost Classifier/Regressor patch for all boolean columns needing to be converted to int. :pr:`3503`
         * Updated ``roc_curve()`` and ``conf_matrix()`` to work with IntegerNullable and BooleanNullable types. :pr:`3465`
         * Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` instead of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. :pr:`3497`
         * Capped ``sklearn`` at version 1.1.0 :pr:`3518`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='evalml',
-    version='0.51.0',
+    version='0.52.0',
     author='Alteryx, Inc.',
     author_email='open_source_support@alteryx.com',
     description='EvalML is an AutoML library that builds, optimizes, and evaluates machine learning pipelines using domain-specific objective functions.',


### PR DESCRIPTION
# v0.52.0 May. 12, 2022
### Changes
- Added github workflows for featuretools and woodwork to test their main branch against evalml. #3504
- Added pmdarima to conda recipe. #3505
- Added a threshold for ``NullDataCheck`` before a warning is issued for null values #3507
- Changed ``NoVarianceDataCheck`` to only output warnings #3506
- Updated ``roc_curve()`` and ``conf_matrix()`` to work with IntegerNullable and BooleanNullable types. #3465
- Changed ``ComponentGraph._transform_features`` to raise a ``PipelineError`` instead of a ``ValueError``. This is not a breaking change because ``PipelineError`` is a subclass of ``ValueError``. #3497
### Documentation Changes
- Updated to install prophet extras in Read the Docs. #3509
### Testing Changes
- Moved vowpal wabbit in test recipe to ``evalml`` package from ``evalml-core`` #3502
