### PR TITLE
Surpress warnings in target encoder

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Fixed github workflows for featuretools and woodwork to test their main branch against evalml. :pr:`3517`
+        * Supress warnings in ``TargetEncoder`` raised by a coming change to default parameters :pr:`3540`
     * Changes
         * Transitioned to use pyproject.toml and setup.cfg away from setup.py :pr:`3494`, :pr:`3536`
     * Documentation Changes

--- a/evalml/pipelines/components/transformers/encoders/target_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/target_encoder.py
@@ -1,4 +1,6 @@
 """A transformer that encodes categorical features into target encodings."""
+import warnings
+
 import pandas as pd
 
 from ..transformer import Transformer
@@ -31,7 +33,7 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
     def __init__(
         self,
         cols=None,
-        smoothing=1.0,
+        smoothing=1,
         handle_unknown="value",
         handle_missing="value",
         random_seed=0,
@@ -65,9 +67,14 @@ class TargetEncoder(Transformer, metaclass=OneHotEncoderMeta):
             "category_encoders",
             error_msg="category_encoders not installed. Please install using `pip install category_encoders`",
         )
+        # Supress warnings for now due to problems discussion here:
+        # https://github.com/scikit-learn-contrib/category_encoders/issues/327
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            encoder = category_encode.target_encoder.TargetEncoder(**parameters)
         super().__init__(
             parameters=parameters,
-            component_obj=category_encode.target_encoder.TargetEncoder(**parameters),
+            component_obj=encoder,
             random_seed=random_seed,
         )
 


### PR DESCRIPTION
### Pull Request Description
Fix nightlies. Surpress warnings in target encoder due to https://github.com/scikit-learn-contrib/category_encoders/issues/327

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
