### PR TITLE
Remove noncore-dependency-marker

### DIFF
--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -4621,7 +4621,6 @@ def test_automl_accepts_features(
 
 
 @pytest.mark.skip_during_conda
-@pytest.mark.noncore_dependency
 def test_automl_with_iterative_algorithm_puts_ts_estimators_first(
     ts_data, AutoMLTestEnv, is_using_windows
 ):
@@ -4671,7 +4670,6 @@ def test_automl_with_iterative_algorithm_puts_ts_estimators_first(
 
 
 @pytest.mark.skip_during_conda
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("automl_algo", ["iterative", "default"])
 @pytest.mark.parametrize(
     "hyperparams",
@@ -4717,7 +4715,6 @@ def test_automl_restricts_use_covariates_for_arima(
 
 
 @pytest.mark.skip_during_conda
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("automl_algo", ["iterative", "default"])
 @pytest.mark.parametrize(
     "hyperparams",

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -579,7 +579,6 @@ def test_max_time_units(X_y_binary):
         )
 
 
-@pytest.mark.noncore_dependency
 def test_plot_iterations_max_iterations(X_y_binary, go):
 
     X, y = X_y_binary
@@ -605,7 +604,6 @@ def test_plot_iterations_max_iterations(X_y_binary, go):
     assert len(y) == 3
 
 
-@pytest.mark.noncore_dependency
 def test_plot_iterations_max_time(AutoMLTestEnv, X_y_binary, go):
     X, y = X_y_binary
 
@@ -633,7 +631,6 @@ def test_plot_iterations_max_time(AutoMLTestEnv, X_y_binary, go):
     assert len(y) > 0
 
 
-@pytest.mark.noncore_dependency
 @patch("IPython.display.display")
 def test_plot_iterations_ipython_mock(mock_ipython_display, X_y_binary):
     X, y = X_y_binary
@@ -652,7 +649,6 @@ def test_plot_iterations_ipython_mock(mock_ipython_display, X_y_binary):
     mock_ipython_display.assert_called_with(plot.best_score_by_iter_fig)
 
 
-@pytest.mark.noncore_dependency
 @patch("IPython.display.display")
 def test_plot_iterations_ipython_mock_import_failure(
     mock_ipython_display, X_y_binary, go
@@ -1002,7 +998,6 @@ def test_automl_search_dictionary_undersampler(
     assert len(mock_est_fit.call_args[0][0]) == length
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize(
     "problem_type,sampling_ratio_dict,length",
     [

--- a/evalml/tests/automl_tests/test_automl_search_regression.py
+++ b/evalml/tests/automl_tests/test_automl_search_regression.py
@@ -142,7 +142,6 @@ def test_categorical_regression(X_y_categorical_regression):
     assert not automl.rankings["mean_cv_score"].isnull().any()
 
 
-@pytest.mark.noncore_dependency
 def test_plot_iterations_max_iterations(X_y_regression, go):
 
     X, y = X_y_regression
@@ -163,7 +162,6 @@ def test_plot_iterations_max_iterations(X_y_regression, go):
     assert len(y) == 3
 
 
-@pytest.mark.noncore_dependency
 def test_plot_iterations_max_time(AutoMLTestEnv, X_y_regression, go):
 
     X, y = X_y_regression

--- a/evalml/tests/automl_tests/test_automl_utils.py
+++ b/evalml/tests/automl_tests/test_automl_utils.py
@@ -296,7 +296,6 @@ def test_get_best_sampler_for_data_sampler_method(
         assert name_output == "Oversampler"
 
 
-@pytest.mark.noncore_dependency
 def test_get_best_sampler_for_data_nonnumeric_noncategorical_columns(X_y_binary):
     X, y = X_y_binary
     X = pd.DataFrame(X)

--- a/evalml/tests/automl_tests/test_iterative_algorithm.py
+++ b/evalml/tests/automl_tests/test_iterative_algorithm.py
@@ -351,7 +351,6 @@ def test_iterative_algorithm_passes_njobs(
                 algo.add_result(score, pipeline, {"id": algo.pipeline_number})
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("is_regression", [True, False])
 @pytest.mark.parametrize("estimator", ["XGBoost", "CatBoost"])
 @patch("evalml.tuners.skopt_tuner.Optimizer.tell")

--- a/evalml/tests/automl_tests/test_pipeline_search_plots.py
+++ b/evalml/tests/automl_tests/test_pipeline_search_plots.py
@@ -6,7 +6,6 @@ import pytest
 from evalml.automl.pipeline_search_plots import SearchIterationPlot
 
 
-@pytest.mark.noncore_dependency
 def test_search_iteration_plot_class():
     class MockObjective:
         def __init__(self):
@@ -48,7 +47,6 @@ def test_search_iteration_plot_class():
     assert y == [0.60, 0.75, 0.50]
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.automl.pipeline_search_plots.jupyter_check")
 @patch("evalml.automl.pipeline_search_plots.import_or_raise")
 def test_jupyter(import_check, jupyter_check):

--- a/evalml/tests/component_tests/test_arima_regressor.py
+++ b/evalml/tests/component_tests/test_arima_regressor.py
@@ -9,7 +9,6 @@ from evalml.pipelines.components import ARIMARegressor
 from evalml.problem_types import ProblemTypes
 
 pytestmark = [
-    pytest.mark.noncore_dependency,
     pytest.mark.skip_during_conda,
     pytest.mark.skip_if_39,
 ]

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -6,8 +6,6 @@ import pytest
 from evalml.pipelines.components import CatBoostClassifier
 from evalml.utils import SEED_BOUNDS
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_catboost_classifier_random_seed_bounds_seed(X_y_binary):
     """ensure catboost's RNG doesn't fail for the min/max bounds we support on user-inputted random seeds"""

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -6,8 +6,6 @@ import pytest
 from evalml.pipelines.components import CatBoostRegressor
 from evalml.utils import SEED_BOUNDS
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_catboost_regressor_random_seed_bounds_seed(X_y_regression):
     """ensure catboost's RNG doesn't fail for the min/max bounds we support on user-inputted random seeds"""

--- a/evalml/tests/component_tests/test_exponential_smoothing_regressor.py
+++ b/evalml/tests/component_tests/test_exponential_smoothing_regressor.py
@@ -9,7 +9,6 @@ from evalml.pipelines.components import ExponentialSmoothingRegressor
 from evalml.problem_types import ProblemTypes
 
 pytestmark = [
-    pytest.mark.noncore_dependency,
     pytest.mark.skip_during_conda,
     pytest.mark.skip_if_39,
 ]

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -10,8 +10,6 @@ from evalml.pipelines import LightGBMClassifier
 from evalml.problem_types import ProblemTypes
 from evalml.utils import SEED_BOUNDS
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_model_family():
     assert LightGBMClassifier.model_family == ModelFamily.LIGHTGBM

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -10,8 +10,6 @@ from evalml.pipelines import LightGBMRegressor
 from evalml.problem_types import ProblemTypes
 from evalml.utils import SEED_BOUNDS
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_model_family():
     assert LightGBMRegressor.model_family == ModelFamily.LIGHTGBM

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -9,8 +9,6 @@ from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import Oversampler
 from evalml.utils.woodwork_utils import infer_feature_types
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_init():
     parameters = {

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -7,7 +7,7 @@ from sklearn.preprocessing import PolynomialFeatures
 
 from evalml.pipelines.components import PolynomialDetrender
 
-pytestmark = [pytest.mark.noncore_dependency, pytest.mark.skip_if_39]
+pytestmark = pytest.mark.skip_if_39
 
 
 def test_polynomial_detrender_init():

--- a/evalml/tests/component_tests/test_prophet_regressor.py
+++ b/evalml/tests/component_tests/test_prophet_regressor.py
@@ -7,7 +7,6 @@ from evalml.pipelines.components import ProphetRegressor
 from evalml.problem_types import ProblemTypes
 
 pytestmark = [
-    pytest.mark.noncore_dependency,
     pytest.mark.skip_during_conda,
     pytest.mark.skip_if_39,
 ]

--- a/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
+++ b/evalml/tests/component_tests/test_stacked_ensemble_classifier.py
@@ -217,7 +217,6 @@ def test_ensembler_str_and_classes():
     check_for_components(ensemble_pipeline)
 
 
-@pytest.mark.noncore_dependency
 def test_stacked_ensemble_nondefault_y():
     X, y = datasets.make_classification(
         n_samples=100, n_features=20, weights={0: 0.1, 1: 0.9}, random_state=0

--- a/evalml/tests/component_tests/test_target_encoder.py
+++ b/evalml/tests/component_tests/test_target_encoder.py
@@ -17,8 +17,6 @@ from woodwork.logical_types import (
 from evalml.exceptions import ComponentNotYetFittedError
 from evalml.pipelines.components import TargetEncoder
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_init():
     parameters = {

--- a/evalml/tests/component_tests/test_vowpal_wabbit_binary_classifier.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_binary_classifier.py
@@ -7,8 +7,6 @@ from evalml.pipelines.components.estimators.classifiers import (
 )
 from evalml.problem_types import ProblemTypes
 
-pytestmark = [pytest.mark.noncore_dependency]
-
 
 def test_model_family():
     assert VowpalWabbitBinaryClassifier.model_family == ModelFamily.VOWPAL_WABBIT

--- a/evalml/tests/component_tests/test_vowpal_wabbit_multiclass_classifier.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_multiclass_classifier.py
@@ -7,8 +7,6 @@ from evalml.pipelines.components.estimators.classifiers import (
 )
 from evalml.problem_types import ProblemTypes
 
-pytestmark = [pytest.mark.noncore_dependency]
-
 
 def test_vw_model_family():
     assert VowpalWabbitMulticlassClassifier.model_family == ModelFamily.VOWPAL_WABBIT

--- a/evalml/tests/component_tests/test_vowpal_wabbit_regressor.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_regressor.py
@@ -7,8 +7,6 @@ from evalml.pipelines.components.estimators.regressors import (
 )
 from evalml.problem_types import ProblemTypes
 
-pytestmark = [pytest.mark.noncore_dependency]
-
 
 def test_vw_model_family():
     assert VowpalWabbitRegressor.model_family == ModelFamily.VOWPAL_WABBIT

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -9,8 +9,6 @@ from evalml.pipelines.components import XGBoostClassifier
 from evalml.problem_types import ProblemTypes
 from evalml.utils import SEED_BOUNDS, get_random_state
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 @pytest.mark.parametrize("metric", ["error", "logloss"])
 def test_xgboost_classifier_default_evaluation_metric(metric):

--- a/evalml/tests/component_tests/test_xgboost_regressor.py
+++ b/evalml/tests/component_tests/test_xgboost_regressor.py
@@ -7,8 +7,6 @@ import pytest
 from evalml.pipelines.components import XGBoostRegressor
 from evalml.utils import SEED_BOUNDS, get_random_state
 
-pytestmark = pytest.mark.noncore_dependency
-
 
 def test_xgboost_regressor_random_seed_bounds_seed(X_y_regression):
     """ensure xgboost's RNG doesn't fail for the min/max bounds we support on user-inputted random seeds"""

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_algorithms.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_algorithms.py
@@ -281,7 +281,6 @@ def test_explainers(
             ), f"A SHAP value must be computed for every data point to explain!"
 
 
-@pytest.mark.noncore_dependency
 def test_lime_xgboost(X_y_multi):
 
     from evalml.pipelines.components import XGBoostClassifier

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -1710,7 +1710,6 @@ def test_explain_predictions_stacked_ensemble(
         assert set(entry["explanations"][0]["feature_names"]) == exp_feature_names
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize(
     "estimator,algorithm",
     product(
@@ -1762,7 +1761,6 @@ def test_explain_predictions_oversampler(estimator, algorithm, fraud_100):
     assert report["feature_values"].isnull().sum() == 0
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("problem_type", [ProblemTypes.MULTICLASS, ProblemTypes.BINARY])
 def test_explain_predictions_class_name_matches_class_name_in_y(
     problem_type, fraud_100
@@ -2174,7 +2172,6 @@ def test_explain_predictions_invalid_algorithm():
         )
 
 
-@pytest.mark.noncore_dependency
 def test_explain_predictions_lime_catboost(X_y_binary):
     pl = BinaryClassificationPipeline(
         {

--- a/evalml/tests/model_understanding_tests/test_metrics.py
+++ b/evalml/tests/model_understanding_tests/test_metrics.py
@@ -266,7 +266,6 @@ def test_precision_recall_curve_pos_label_idx_error(make_data_type):
         precision_recall_curve(y_true, y_predict_proba, pos_label_idx=9001)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_precision_recall_curve(X_y_binary, data_type, make_data_type, go):
 
@@ -294,7 +293,6 @@ def test_graph_precision_recall_curve(X_y_binary, data_type, make_data_type, go)
     )
 
 
-@pytest.mark.noncore_dependency
 def test_graph_precision_recall_curve_title_addition(X_y_binary, go):
 
     X, y_true = X_y_binary
@@ -404,7 +402,6 @@ def test_roc_curve_multiclass(data_type, make_data_type):
         assert isinstance(roc_curve_data[i]["thresholds"], np.ndarray)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_roc_curve_binary(X_y_binary, data_type, make_data_type, go):
 
@@ -434,7 +431,6 @@ def test_graph_roc_curve_binary(X_y_binary, data_type, make_data_type, go):
     assert fig_dict["data"][1]["name"] == "Trivial Model (AUC 0.5)"
 
 
-@pytest.mark.noncore_dependency
 def test_graph_roc_curve_nans(go):
 
     one_val_y_zero = np.array([0])
@@ -455,7 +451,6 @@ def test_graph_roc_curve_nans(go):
     assert fig1 == fig2
 
 
-@pytest.mark.noncore_dependency
 def test_graph_roc_curve_multiclass(binarized_ys, go):
 
     y_true, y_tr, y_pred_proba = binarized_ys
@@ -486,7 +481,6 @@ def test_graph_roc_curve_multiclass(binarized_ys, go):
         graph_roc_curve(y_true, y_pred_proba, custom_class_names=["one", "two"])
 
 
-@pytest.mark.noncore_dependency
 def test_graph_roc_curve_multiclass_custom_class_names(binarized_ys, go):
 
     y_true, y_tr, y_pred_proba = binarized_ys
@@ -507,7 +501,6 @@ def test_graph_roc_curve_multiclass_custom_class_names(binarized_ys, go):
     assert fig_dict["data"][3]["name"] == "Trivial Model (AUC 0.5)"
 
 
-@pytest.mark.noncore_dependency
 def test_graph_roc_curve_title_addition(X_y_binary, go):
 
     X, y_true = X_y_binary
@@ -522,7 +515,6 @@ def test_graph_roc_curve_title_addition(X_y_binary, go):
     )
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_confusion_matrix_default(X_y_binary, data_type, make_data_type, go):
 
@@ -561,7 +553,6 @@ def test_graph_confusion_matrix_default(X_y_binary, data_type, make_data_type, g
         assert "text" in annotations[i]
 
 
-@pytest.mark.noncore_dependency
 def test_graph_confusion_matrix_norm_disabled(X_y_binary, go):
 
     X, y_true = X_y_binary
@@ -589,7 +580,6 @@ def test_graph_confusion_matrix_norm_disabled(X_y_binary, go):
     )
 
 
-@pytest.mark.noncore_dependency
 def test_graph_confusion_matrix_title_addition(X_y_binary, go):
 
     X, y_true = X_y_binary
@@ -604,7 +594,6 @@ def test_graph_confusion_matrix_title_addition(X_y_binary, go):
     )
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.model_understanding.metrics.jupyter_check")
 @patch("evalml.model_understanding.metrics.import_or_raise")
 def test_jupyter_graph_check(

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -605,7 +605,6 @@ def test_partial_dependence_ensemble_pipeline(problem_type, X_y_binary, X_y_regr
     assert not part_dep.isnull().all().all()
 
 
-@pytest.mark.noncore_dependency
 def test_graph_partial_dependence(
     breast_cancer_local, logistic_regression_binary_pipeline, go
 ):
@@ -636,7 +635,6 @@ def test_graph_partial_dependence(
     )
 
 
-@pytest.mark.noncore_dependency
 @patch(
     "evalml.pipelines.BinaryClassificationPipeline.predict_proba",
     side_effect=lambda X: np.array([[0.2, 0.8]] * X.shape[0]),
@@ -674,7 +672,6 @@ def test_graph_partial_dependence_ww_categories(
         )
 
 
-@pytest.mark.noncore_dependency
 def test_graph_two_way_partial_dependence(
     breast_cancer_local, logistic_regression_binary_pipeline, go
 ):
@@ -708,7 +705,6 @@ def test_graph_two_way_partial_dependence(
     assert np.array_equal(fig_dict["data"][0]["z"], part_dep_data.values)
 
 
-@pytest.mark.noncore_dependency
 @patch(
     "evalml.pipelines.BinaryClassificationPipeline.predict_proba",
     side_effect=lambda X: np.array([[0.2, 0.8]] * X.shape[0]),
@@ -776,7 +772,6 @@ def test_graph_two_way_partial_dependence_ww_categories(
     assert np.array_equal(fig_dict["data"][0]["z"], part_dep_data.values)
 
 
-@pytest.mark.noncore_dependency
 def test_graph_partial_dependence_multiclass(
     wine_local, logistic_regression_multiclass_pipeline, go
 ):
@@ -993,7 +988,6 @@ def test_partial_dependence_percentile_errors(
     assert not part_dep.isnull().any(axis=None)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("problem_type", ["binary", "regression"])
 def test_graph_partial_dependence_regression_and_binary_categorical(
     problem_type,
@@ -1057,7 +1051,6 @@ def test_graph_partial_dependence_regression_and_binary_categorical(
     )
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("class_label", [None, "class_1"])
 def test_partial_dependence_multiclass_categorical(
     wine_local, class_label, logistic_regression_multiclass_pipeline
@@ -1275,7 +1268,6 @@ def test_partial_dependence_datetime(
     assert e.value.code == PartialDependenceErrorCode.TWO_WAY_REQUESTED_FOR_DATES
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("problem_type", ["binary", "regression"])
 def test_graph_partial_dependence_regression_and_binary_datetime(
     problem_type, X_y_regression, X_y_binary
@@ -1321,7 +1313,6 @@ def test_graph_partial_dependence_regression_and_binary_datetime(
     assert list(plot_data["x"]) == list(pd.date_range("20200101", periods=5))
 
 
-@pytest.mark.noncore_dependency
 def test_graph_partial_dependence_regression_date_order(X_y_binary):
 
     X, y = X_y_binary
@@ -1372,7 +1363,6 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
     assert dep.shape[0] != max(X.ww.select("categorical").describe().loc["unique"]) + 1
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("problem_type", [ProblemTypes.BINARY, ProblemTypes.MULTICLASS])
 def test_graph_partial_dependence_ice_plot(
     problem_type,
@@ -1813,7 +1803,6 @@ def test_partial_dependence_does_not_return_all_nan_grid():
     assert not dep.partial_dependence.isna().any()
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.model_understanding.partial_dependence_functions.jupyter_check")
 @patch("evalml.model_understanding.partial_dependence_functions.import_or_raise")
 def test_partial_dependence_jupyter_graph_check(

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -571,7 +571,6 @@ def test_get_permutation_importance_correlated_features(
     assert correlated_importance_val > not_correlated_importance_val
 
 
-@pytest.mark.noncore_dependency
 def test_permutation_importance_oversampler(fraud_100):
     X, y = fraud_100
     pipeline = BinaryClassificationPipeline(
@@ -695,7 +694,6 @@ def test_permutation_importance_standard_scaler(fraud_100):
     calculate_permutation_importance(pipeline, X, y, objective="log loss binary")
 
 
-@pytest.mark.noncore_dependency
 def test_graph_permutation_importance(
     X_y_binary, logistic_regression_binary_pipeline, go
 ):
@@ -726,7 +724,6 @@ def test_graph_permutation_importance(
     )
 
 
-@pytest.mark.noncore_dependency
 @patch(
     "evalml.model_understanding.permutation_importance.calculate_permutation_importance"
 )
@@ -750,7 +747,6 @@ def test_graph_permutation_importance_show_all_features(
     assert np.any(data["x"] == 0.0)
 
 
-@pytest.mark.noncore_dependency
 @patch(
     "evalml.model_understanding.permutation_importance.calculate_permutation_importance"
 )
@@ -786,7 +782,6 @@ def test_graph_permutation_importance_threshold(
     assert np.all(data["x"] >= 0.5)
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.model_understanding.permutation_importance.jupyter_check")
 @patch("evalml.model_understanding.permutation_importance.import_or_raise")
 def test_jupyter_graph_check(

--- a/evalml/tests/model_understanding_tests/test_visualizations.py
+++ b/evalml/tests/model_understanding_tests/test_visualizations.py
@@ -108,7 +108,6 @@ def test_binary_objective_vs_threshold_steps(
     assert cost_benefit_df.shape == (235, 2)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 @patch("evalml.model_understanding.visualizations.binary_objective_vs_threshold")
 def test_graph_binary_objective_vs_threshold(
@@ -143,7 +142,6 @@ def test_graph_binary_objective_vs_threshold(
     assert np.array_equal(data["y"], mock_cb_thresholds.return_value["score"])
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.model_understanding.visualizations.jupyter_check")
 @patch("evalml.model_understanding.visualizations.import_or_raise")
 def test_jupyter_graph_check(
@@ -208,7 +206,6 @@ def test_get_prediction_vs_actual_data(data_type, make_data_type):
     assert (results["outlier"] == "#0000ff").all()
 
 
-@pytest.mark.noncore_dependency
 def test_graph_prediction_vs_actual_default(go):
 
     y_true = [1, 2, 3000, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -230,7 +227,6 @@ def test_graph_prediction_vs_actual_default(go):
     assert fig_dict["data"][1]["name"] == "Values"
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["pd", "ww"])
 def test_graph_prediction_vs_actual(data_type, go):
 
@@ -300,7 +296,6 @@ def test_get_prediction_vs_actual_over_time_data(ts_data):
     assert list(results.columns) == ["dates", "target", "prediction"]
 
 
-@pytest.mark.noncore_dependency
 def test_graph_prediction_vs_actual_over_time(ts_data, go):
 
     X, y = ts_data
@@ -342,7 +337,6 @@ def test_graph_prediction_vs_actual_over_time(ts_data, go):
     assert not np.isnan(fig_dict["data"][1]["y"]).all()
 
 
-@pytest.mark.noncore_dependency
 def test_graph_prediction_vs_actual_over_time_value_error():
     class NotTSPipeline:
         problem_type = ProblemTypes.REGRESSION
@@ -490,7 +484,6 @@ def test_decision_tree_data_from_pipeline(X_y_categorical_regression):
     )
 
 
-@pytest.mark.noncore_dependency
 def test_visualize_decision_trees_filepath(fitted_tree_estimators, tmpdir):
     import graphviz
 
@@ -508,7 +501,6 @@ def test_visualize_decision_trees_filepath(fitted_tree_estimators, tmpdir):
     assert isinstance(src, graphviz.Source)
 
 
-@pytest.mark.noncore_dependency
 def test_visualize_decision_trees_wrong_format(fitted_tree_estimators, tmpdir):
     import graphviz
 
@@ -553,7 +545,6 @@ def test_visualize_decision_trees_not_fitted(tree_estimators, tmpdir):
         visualize_decision_tree(estimator=est_class, max_depth=3, filepath=filepath)
 
 
-@pytest.mark.noncore_dependency
 def test_visualize_decision_trees(fitted_tree_estimators, tmpdir):
     import graphviz
 
@@ -650,7 +641,6 @@ def test_t_sne(data_type):
     assert isinstance(output_, np.ndarray)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("marker_line_width", [-2, -1.2])
 def test_t_sne_errors_marker_line_width(marker_line_width):
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
@@ -661,7 +651,6 @@ def test_t_sne_errors_marker_line_width(marker_line_width):
         graph_t_sne(X, marker_line_width=marker_line_width)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("marker_size", [-2, -1.2])
 def test_t_sne_errors_marker_size(marker_size):
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
@@ -672,7 +661,6 @@ def test_t_sne_errors_marker_size(marker_size):
         graph_t_sne(X, marker_size=marker_size)
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 @pytest.mark.parametrize("perplexity", [0, 4.6, 100])
 @pytest.mark.parametrize("learning_rate", [100.0, 0.1])

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1510,7 +1510,6 @@ def test_component_graph_dataset_with_target_imputer():
     assert not pd.isnull(predictions).any()
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.pipelines.components.estimators.LogisticRegressionClassifier.fit")
 def test_component_graph_sampler_y_passes(mock_estimator_fit):
     # makes sure the y value from oversampler gets passed to the estimator
@@ -2581,7 +2580,6 @@ def test_component_graph_handles_engineered_features(
     )
 
 
-@pytest.mark.noncore_dependency
 def test_get_component_input_logical_types():
 
     X = pd.DataFrame(

--- a/evalml/tests/pipeline_tests/test_graphs.py
+++ b/evalml/tests/pipeline_tests/test_graphs.py
@@ -40,7 +40,6 @@ def test_component_graph(example_graph):
     return component_graph
 
 
-@pytest.mark.noncore_dependency
 def test_backend(test_pipeline, graphviz):
 
     with patch("graphviz.Digraph.pipe") as mock_func:
@@ -50,7 +49,6 @@ def test_backend(test_pipeline, graphviz):
             clf.graph()
 
 
-@pytest.mark.noncore_dependency
 def test_returns_digraph_object(test_pipeline, graphviz):
 
     clf = test_pipeline
@@ -58,7 +56,6 @@ def test_returns_digraph_object(test_pipeline, graphviz):
     assert isinstance(graph, graphviz.Digraph)
 
 
-@pytest.mark.noncore_dependency
 def test_backend_comp_graph(test_component_graph, graphviz):
 
     with patch("graphviz.Digraph.pipe") as mock_func:
@@ -68,7 +65,6 @@ def test_backend_comp_graph(test_component_graph, graphviz):
             comp.graph()
 
 
-@pytest.mark.noncore_dependency
 def test_saving_png_file(tmpdir, test_pipeline):
     filepath = os.path.join(str(tmpdir), "pipeline.png")
     pipeline = test_pipeline
@@ -76,7 +72,6 @@ def test_saving_png_file(tmpdir, test_pipeline):
     assert os.path.isfile(filepath)
 
 
-@pytest.mark.noncore_dependency
 def test_returns_digraph_object_comp_graph(test_component_graph, graphviz):
 
     comp = test_component_graph
@@ -84,7 +79,6 @@ def test_returns_digraph_object_comp_graph(test_component_graph, graphviz):
     assert isinstance(graph, graphviz.Digraph)
 
 
-@pytest.mark.noncore_dependency
 def test_returns_digraph_object_comp_graph_with_params(test_component_graph, graphviz):
 
     comp = test_component_graph
@@ -101,7 +95,6 @@ def test_returns_digraph_object_comp_graph_with_params(test_component_graph, gra
     assert "max_iter : 100" in graph.source
 
 
-@pytest.mark.noncore_dependency
 def test_missing_file_extension(tmpdir, test_pipeline):
     filepath = os.path.join(str(tmpdir), "test1")
     pipeline = test_pipeline
@@ -109,7 +102,6 @@ def test_missing_file_extension(tmpdir, test_pipeline):
         pipeline.graph(filepath=filepath)
 
 
-@pytest.mark.noncore_dependency
 def test_invalid_format(tmpdir, test_pipeline):
     filepath = os.path.join(str(tmpdir), "test1.xyz")
     pipeline = test_pipeline
@@ -117,7 +109,6 @@ def test_invalid_format(tmpdir, test_pipeline):
         pipeline.graph(filepath=filepath)
 
 
-@pytest.mark.noncore_dependency
 def test_invalid_path(tmpdir, test_pipeline):
     filepath = os.path.join(str(tmpdir), "invalid", "path", "pipeline.png")
     assert not os.path.exists(filepath)
@@ -127,7 +118,6 @@ def test_invalid_path(tmpdir, test_pipeline):
     assert not os.path.exists(filepath)
 
 
-@pytest.mark.noncore_dependency
 def test_graph_feature_importance(X_y_binary, test_pipeline, go):
     X, y = X_y_binary
     clf = test_pipeline
@@ -135,7 +125,6 @@ def test_graph_feature_importance(X_y_binary, test_pipeline, go):
     assert isinstance(clf.graph_feature_importance(), go.Figure)
 
 
-@pytest.mark.noncore_dependency
 def test_graph_feature_importance_show_all_features(X_y_binary, test_pipeline, go):
     X, y = X_y_binary
     clf = test_pipeline
@@ -148,7 +137,6 @@ def test_graph_feature_importance_show_all_features(X_y_binary, test_pipeline, g
     assert np.any(data["x"] == 0.0)
 
 
-@pytest.mark.noncore_dependency
 def test_graph_feature_importance_threshold(X_y_binary, test_pipeline, go):
     X, y = X_y_binary
     clf = test_pipeline
@@ -166,7 +154,6 @@ def test_graph_feature_importance_threshold(X_y_binary, test_pipeline, go):
     assert np.all(data["x"] >= 0.5)
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.pipelines.pipeline_base.jupyter_check")
 @patch("evalml.pipelines.pipeline_base.import_or_raise")
 def test_jupyter_graph_check(import_check, jupyter_check, X_y_binary, test_pipeline):

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2268,7 +2268,6 @@ def test_undersampler_component_in_pipeline_predict():
     assert len(preds) == 1000
 
 
-@pytest.mark.noncore_dependency
 @patch("evalml.pipelines.components.LogisticRegressionClassifier.fit")
 def test_oversampler_component_in_pipeline_fit(mock_fit):
 
@@ -2304,7 +2303,6 @@ def test_oversampler_component_in_pipeline_fit(mock_fit):
     assert len(mock_fit.call_args[0][0]) == 1000
 
 
-@pytest.mark.noncore_dependency
 def test_oversampler_component_in_pipeline_predict():
     X = pd.DataFrame(
         {

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1314,7 +1314,6 @@ def test_time_series_pipeline_fit_with_transformed_target(
 
 
 @pytest.mark.skip_if_39
-@pytest.mark.noncore_dependency
 def test_time_series_pipeline_with_detrender(ts_data):
     X, y = ts_data
     component_graph = {

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -599,7 +599,6 @@ def test_save_graphviz_different_filename_output(
     assert os.path.basename(output_) == "example_plot.png"
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize(
     "file_name,format,interactive",
     [
@@ -642,7 +641,6 @@ def test_save_matplotlib_default_format(
     assert os.path.basename(output_) == "test_plot.png"
 
 
-@pytest.mark.noncore_dependency
 @pytest.mark.parametrize(
     "file_name,format,interactive",
     [


### PR DESCRIPTION
### Pull Request Description
Remove the noncore_dependency pytest marker since it's no longer used

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
