### PR TITLE
Fix test after update to postal code validation in woodwork

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
     * Testing Changes
         * Rename yml to yaml for GitHub Actions :pr:`3522`
         * Remove ``noncore_dependency`` pytest marker :pr:`3541`
+        * Changed ``test_smotenc_category_features`` to use valid postal code values in response to new woodwork type validation :pr:`3544`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -282,6 +282,11 @@ def test_smotenc_category_features(X_y_binary):
     X, y = X_y_binary
     X = pd.DataFrame(X).rename({0: "postal", 1: "country"}, axis="columns")
     X[2] = [i % 2 for i in range(X.shape[0])]
+
+    # Replace postal and country features with plausible postal/country codes
+    X["postal"] = np.arange(10001, 10001 + X.shape[0])
+    X["country"] = np.arange(20001, 20001 + X.shape[0])
+
     X_ww = infer_feature_types(
         X,
         feature_types={"postal": "PostalCode", "country": "CountryCode", 2: "Boolean"},


### PR DESCRIPTION
### Pull Request Description
Fix failure here: https://github.com/alteryx/evalml/runs/6760125434?check_suite_focus=true

Successful run here: https://github.com/alteryx/evalml/actions/runs/2449725492

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
