### PR TITLE
Release v0.53.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,6 +1,13 @@
 Release Notes
 -------------
 **Future Releases**
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.53.0 June. 9, 2022**
     * Enhancements
         * Pass ``n_jobs`` to default algorithm :pr:`3548`
     * Fixes
@@ -17,10 +24,6 @@ Release Notes
         * Rename yml to yaml for GitHub Actions :pr:`3522`
         * Remove ``noncore_dependency`` pytest marker :pr:`3541`
         * Changed ``test_smotenc_category_features`` to use valid postal code values in response to new woodwork type validation :pr:`3544`
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.52.0 May. 12, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.52.0"
+__version__ = "0.53.0"


### PR DESCRIPTION
# v0.53.0 Jun. 9, 2022
### Enhancements
- Pass ``n_jobs`` to default algorithm #3548
### Fixes
- Fixed github workflows for featuretools and woodwork to test their main branch against evalml. #3517
- Supress warnings in ``TargetEncoder`` raised by a coming change to default parameters #3540
- Fixed bug where schema was not being preserved in column renaming for XGBoost and LightGBM models #3496
### Changes
- Transitioned to use pyproject.toml and setup.cfg away from setup.py #3494, #3536
### Documentation Changes
- Updated the Time Series User Guide page to include known-in-advance features and fix typos #3521
- Add slack and stackoverflow icon to footer #3528
- Add install instructions for M1 Mac #3543
### Testing Changes
- Rename yml to yaml for GitHub Actions #3522
- Remove ``noncore_dependency`` pytest marker #3541
- Changed ``test_smotenc_category_features`` to use valid postal code values in response to new woodwork type validation #3544

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
