### PR TITLE
Cap nlp-primitives at 2.5.0

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -39,7 +39,7 @@ outputs:
         - texttable >=1.6.2
         - woodwork >=0.16.2
         - featuretools>=1.7.0
-        - nlp-primitives>=2.1.0
+        - nlp-primitives>=2.1.0,<=2.5.0
         - python >=3.8.*
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -13,6 +13,6 @@ statsmodels>=0.12.2
 texttable>=1.6.2
 woodwork>=0.16.2
 dask>=2021.10.0
-nlp-primitives>=2.1.0
+nlp-primitives>=2.1.0,<=2.5.0
 featuretools>=1.7.0
 networkx>=2.5,<2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Fixes
     * Changes
         * Don't pass ``time_index`` as kwargs to sktime ARIMA implementation for compatibility with latest version :pr:`3564`
+        * Capped ``nlp-primitives`` at version 2.5.0 :pr:`3571`
     * Documentation Changes
         * Fix typo in ``long_description`` field in ``setup.cfg`` :pr:`3553`
         * Update install page to remove Python 3.7 mention :pr:`3567`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,7 +5,7 @@ Release Notes
     * Fixes
     * Changes
         * Don't pass ``time_index`` as kwargs to sktime ARIMA implementation for compatibility with latest version :pr:`3564`
-        * Capped ``nlp-primitives`` at version 2.5.0 :pr:`3571`
+        * Capped ``nlp-primitives`` at version 2.5.0 :pr:`3572`
     * Documentation Changes
         * Fix typo in ``long_description`` field in ``setup.cfg`` :pr:`3553`
         * Update install page to remove Python 3.7 mention :pr:`3567`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,7 +1,7 @@
 catboost==1.0.6
 click==8.1.3
 cloudpickle==2.1.0
-colorama==0.4.4
+colorama==0.4.5
 dask==2022.6.0
 featuretools==1.9.2
 graphviz==0.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     texttable >= 1.6.2
     woodwork >= 0.16.2
     dask >= 2021.10.0
-    nlp-primitives >= 2.1.0
+    nlp-primitives >= 2.1.0,<=2.5.0
     featuretools >= 1.7.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0


### PR DESCRIPTION
Cap nlp-primitives at <2.6.0 because of breaking changes with nltk
