### PR TITLE
Release 0.54.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,22 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.54.0 June. 23, 2022**
+    * Enhancements
+        * Added clustering as a problem type :pr:`3368`
+        * Added clustering models ``DBSCAN``, ``KMeans``, ``KModes``, and ``KPrototypes`` :pr:`3379`
+        * Added clustering objectives ``Silhouette Coefficient`` and ``Adjusted Rand Score`` :pr:`3396`
+        * Added ``MinMaxScaler`` for normalization in clustering problems :pr:`3399`
+    * Fixes
         * Updated the Imputer and SimpleImputer to work with scikit-learn 1.1.1. :pr:`3525`
         * Bumped the minimum versions of scikit-learn to 1.1.1 and imbalanced-learn to 0.9.1. :pr:`3525`
         * Added a clearer error message when ``describe`` is called on an un-instantiated ComponentGraph :pr:`3569`
@@ -14,11 +30,6 @@ Release Notes
     * Documentation Changes
         * Fix typo in ``long_description`` field in ``setup.cfg`` :pr:`3553`
         * Update install page to remove Python 3.7 mention :pr:`3567`
-    * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.53.1 June. 9, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.53.1"
+__version__ = "0.54.0"


### PR DESCRIPTION
# v0.54.0 Jun. 23, 2022
### Enhancements
- Added clustering as a problem type #3368
- Added clustering models ``DBSCAN``, ``KMeans``, ``KModes``, and ``KPrototypes`` #3379
- Added clustering objectives ``Silhouette Coefficient`` and ``Adjusted Rand Score`` #3396
- Added ``MinMaxScaler`` for normalization in clustering problems #3399
### Fixes
- Updated the Imputer and SimpleImputer to work with scikit-learn 1.1.1. #3525
- Bumped the minimum versions of scikit-learn to 1.1.1 and imbalanced-learn to 0.9.1. #3525
- Added a clearer error message when ``describe`` is called on an un-instantiated ComponentGraph #3569
- Added a clearer error message when time series' ``predict`` is called with its X_train or y_train parameter set as None #3579
### Changes
- Don't pass ``time_index`` as kwargs to sktime ARIMA implementation for compatibility with latest version #3564
- Remove incompatible ``nlp-primitives`` version 2.6.0 from accepted dependency versions #3572, #3574
- Updated evalml authors #3581
### Documentation Changes
- Fix typo in ``long_description`` field in ``setup.cfg`` #3553
- Update install page to remove Python 3.7 mention #3567
