### PR TITLE
All tests don't skip python 3.9

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,11 +3,12 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Updated the `load_diabetes()` method to account for scikit-learn 1.1.1 changes to the dataset :pr:`3591`
+        * Updated the ``load_diabetes()`` method to account for scikit-learn 1.1.1 changes to the dataset :pr:`3591`
     * Changes
     * Documentation Changes
     * Testing Changes
         * Pinned GraphViz version for Windows CI Test :pr:`3596`
+        * Removed ``pytest.mark.skip_if_39`` pytest marker :pr:`3602`
 
 .. warning::
 

--- a/evalml/tests/component_tests/test_arima_regressor.py
+++ b/evalml/tests/component_tests/test_arima_regressor.py
@@ -10,7 +10,6 @@ from evalml.problem_types import ProblemTypes
 
 pytestmark = [
     pytest.mark.skip_during_conda,
-    pytest.mark.skip_if_39,
 ]
 
 

--- a/evalml/tests/component_tests/test_exponential_smoothing_regressor.py
+++ b/evalml/tests/component_tests/test_exponential_smoothing_regressor.py
@@ -10,7 +10,6 @@ from evalml.problem_types import ProblemTypes
 
 pytestmark = [
     pytest.mark.skip_during_conda,
-    pytest.mark.skip_if_39,
 ]
 
 

--- a/evalml/tests/component_tests/test_polynomial_detrender.py
+++ b/evalml/tests/component_tests/test_polynomial_detrender.py
@@ -7,8 +7,6 @@ from sklearn.preprocessing import PolynomialFeatures
 
 from evalml.pipelines.components import PolynomialDetrender
 
-pytestmark = pytest.mark.skip_if_39
-
 
 def test_polynomial_detrender_init():
     delayed_features = PolynomialDetrender(degree=3)

--- a/evalml/tests/component_tests/test_prophet_regressor.py
+++ b/evalml/tests/component_tests/test_prophet_regressor.py
@@ -8,7 +8,6 @@ from evalml.problem_types import ProblemTypes
 
 pytestmark = [
     pytest.mark.skip_during_conda,
-    pytest.mark.skip_if_39,
 ]
 
 

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -92,50 +92,14 @@ all_requirements_set = set(
         "XGBoost Regressor",
     ]
 )
-not_supported_in_conda = set(
-    [
-        "Prophet Regressor",
-    ]
-)
-not_supported_in_windows = set(
-    [
-        "Prophet Regressor",
-    ]
-)
-not_supported_in_windows_py39 = set(
-    [
-        "Prophet Regressor",
-    ]
-)
 # Keeping here in case we need to add to it when a new component is added
 not_supported_in_linux_py39 = set()
+not_supported_in_conda = set()
+not_supported_in_windows = set()
+not_supported_in_windows_py39 = set()
 
-
-def test_all_components(
-    is_running_py_39_or_above,
-    is_using_conda,
-    is_using_windows,
-):
-    if is_using_conda:
-        # No prophet, ARIMA, and vowpalwabbit
-        expected_components = all_requirements_set.difference(not_supported_in_conda)
-
-    elif is_using_windows and not is_running_py_39_or_above:
-        # No prophet
-        expected_components = all_requirements_set.difference(not_supported_in_windows)
-
-    elif is_using_windows and is_running_py_39_or_above:
-        # No detrender, no ARIMA, no prophet
-        expected_components = all_requirements_set.difference(
-            not_supported_in_windows_py39
-        )
-    elif not is_using_windows and is_running_py_39_or_above:
-        # No detrender or ARIMA
-        expected_components = all_requirements_set.difference(
-            not_supported_in_linux_py39
-        )
-    else:
-        expected_components = all_requirements_set
+def test_all_components():
+    expected_components = all_requirements_set
     all_component_names = [component.name for component in all_components()]
     assert set(all_component_names) == expected_components
 

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -98,6 +98,7 @@ not_supported_in_conda = set()
 not_supported_in_windows = set()
 not_supported_in_windows_py39 = set()
 
+
 def test_all_components():
     expected_components = all_requirements_set
     all_component_names = [component.name for component in all_components()]

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -55,10 +55,6 @@ def pytest_configure(config):
         "markers",
         "skip_during_conda: mark test to be skipped if running during conda build",
     )
-    config.addinivalue_line(
-        "markers",
-        "skip_if_39: mark test to be skipped if running during conda build",
-    )
 
 
 @pytest.fixture(scope="session")
@@ -386,11 +382,6 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "skip_during_conda" in item.keywords:
                 item.add_marker(skip_conda)
-    if sys.version_info >= (3, 9):
-        skip_39 = pytest.mark.skip(reason="Test dependency not supported in python 3.9")
-        for item in items:
-            if "skip_if_39" in item.keywords:
-                item.add_marker(skip_39)
 
 
 @pytest.fixture
@@ -401,11 +392,6 @@ def is_using_conda(pytestconfig):
 @pytest.fixture
 def is_using_windows(pytestconfig):
     return sys.platform in ["win32", "cygwin"]
-
-
-@pytest.fixture
-def is_running_py_39_or_above():
-    return sys.version_info >= (3, 9)
 
 
 @pytest.fixture

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -3,7 +3,7 @@ click==8.1.3
 cloudpickle==2.1.0
 colorama==0.4.5
 dask==2022.6.1
-featuretools==1.11.0
+featuretools==1.11.1
 graphviz==0.20
 imbalanced-learn==0.9.1
 ipywidgets==7.7.1

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1359,7 +1359,6 @@ def test_time_series_pipeline_fit_with_transformed_target(
     pd.testing.assert_series_equal(mock_to_check.call_args[0][1], y + 2)
 
 
-@pytest.mark.skip_if_39
 def test_time_series_pipeline_with_detrender(ts_data):
     X, y = ts_data
     component_graph = {


### PR DESCRIPTION
### Pull Request Description
Removed `pytest.mark.skip_if_39` from all tests as testing them in python 3.9, none of them failed.

Did `conda create -n evalml_py_39 python=3.9` then did `make installdeps-dev`.

After that, did a search using ctrl-f and looked for `pytest.mark.skip_if_39` from all files, removed them from the files that had them and ran each tests. None of the tests that previous were skipped failed.

Only issue was two of the tests complained about not having prophet and cmdstanpy installed, but those were easily rectified by doing `pip install prophet` and `pip install cmdstanpy`.

Closes #3600 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
