### PR TITLE
Release v0.55.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.55.0 July. 24, 2022**
+    * Enhancements
         * Increased the amount of logical type information passed to Woodwork when calling ``ww.init()`` in transformers :pr:`3604`
         * Added ability to log how long each batch and pipeline take in ``automl.search()`` :pr:`3577`
         * Added the option to set the ``sp`` parameter for ARIMA models :pr:`3597`
@@ -13,14 +25,9 @@ Release Notes
         * Bump minimum scikit-optimize version to 0.9.0 `:pr:`3614`
     * Changes
         * Add pre-commit hooks for linting :pr:`3608`
-    * Documentation Changes
     * Testing Changes
         * Pinned GraphViz version for Windows CI Test :pr:`3596`
         * Removed ``pytest.mark.skip_if_39`` pytest marker :pr:`3602` :pr:`3607`
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.54.0 June. 23, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.54.0"
+__version__ = "0.55.0"


### PR DESCRIPTION
# v0.55.0 Jul. 24, 2022
### Enhancements
- Increased the amount of logical type information passed to Woodwork when calling ``ww.init()`` in transformers #3604
- Added ability to log how long each batch and pipeline take in ``automl.search()`` #3577
- Added the option to set the ``sp`` parameter for ARIMA models #3597
- Updated the CV split size of time series problems to match forecast horizon for improved performance #3616
### Fixes
- Fixed iterative graphs not appearing in documentation #3592
- Updated the ``load_diabetes()`` method to account for scikit-learn 1.1.1 changes to the dataset #3591
- Capped woodwork version at < 0.17.0 #3612
- Bump minimum scikit-optimize version to 0.9.0 `#3614
### Changes
- Add pre-commit hooks for linting #3608
### Testing Changes
- Pinned GraphViz version for Windows CI Test #3596
- Removed ``pytest.mark.skip_if_39`` pytest marker #3602 #3607