### PR TITLE
exclude stackoverflow from broken link check

### DIFF
--- a/.github/workflows/broken_link_checker.yaml
+++ b/.github/workflows/broken_link_checker.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://evalml.alteryx.com/en/latest/index.html
-          cmd_params: '--max-connections=10 --color=always --ignore-fragments --buffer-size=8192 --exclude="(twitter|github|cloudflare|evalml\\.alteryx\\.com\\/en\\/(stable|main|v.+).*)"'
+          cmd_params: '--max-connections=10 --color=always --ignore-fragments --buffer-size=8192 --exclude="(twitter|github|stackoverflow|cloudflare|evalml\\.alteryx\\.com\\/en\\/(stable|main|v.+).*)"'
       - name: Notify on Slack
         uses: 8398a7/action-slack@v3
         env:

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Updated broken link checker to exclude stackoverflow domain :pr:`3633`
     * Testing Changes
 
 .. warning::


### PR DESCRIPTION
### Pull Request Description
We are receiving a 403 status code when following the link to https://stackoverflow.com/questions/tagged/evalml so just going to exclude that domain.

https://github.com/alteryx/evalml/runs/7626204325?check_suite_focus=true

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
