### PR TITLE
Disable holdout set in AutoML search by default

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Add ``exclude_featurizers`` parameter to ``AutoMLSearch`` to specify featurizers that should be excluded from all pipelines :pr:`3631`
     * Fixes
     * Changes
+        * Disable holdout set in AutoML search by default :pr:`3659`
     * Documentation Changes
         * Updated broken link checker to exclude stackoverflow domain :pr:`3633`
         * Add instructions to add new users to evalml-core-feedstock :pr:`3636`

--- a/docs/source/user_guide/automl.ipynb
+++ b/docs/source/user_guide/automl.ipynb
@@ -148,13 +148,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For datasets that have more than 500 rows, AutoMLSearch will automatically create a holdout set from 10% of the training data. Alternatively, a holdout set can be manually specified by using the `X_holdout` and `y_holdout` parameters in `AutoMLSearch()`. In this example, the holdout set created previously will be used by AutoML search.\n",
+    "If the `holdout_set_size` parameter is set and the input dataset has more than 500 rows, AutoMLSearch will create a holdout set from `holdout_set_size` of the training data. Alternatively, a holdout set can be manually specified by using the `X_holdout` and `y_holdout` parameters in `AutoMLSearch()`. In this example, the holdout set created previously will be used by AutoML search.\n",
     "\n",
     "During the AutoML search process, the mean of the objective scores of all cross validation folds (shown the \"mean_cv_score\" column in the pipeline rankings), is calculated. This score is passed to the AutoML search tuner to further optimize the hyperparameters of the next batch of pipelines.\n",
     "\n",
     "After, the pipeline will be fitted on the entire training dataset and scored on this new holdout set. This score is represented under the \"validation_score\" column on the pipeline rankings board and is used to rank pipeline performance.\n",
     "\n",
-    "If a dataset has less than 500 rows or `holdout_set_size=0`, the \"mean_cv_score\" will be used as the validation_score instead."
+    "If a dataset has less than 500 rows or `holdout_set_size=0` (which is the default setting), the \"mean_cv_score\" will be used as the validation_score instead."
    ]
   },
   {

--- a/docs/source/user_guide/data_check_actions.ipynb
+++ b/docs/source/user_guide/data_check_actions.ipynb
@@ -124,9 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "automl = AutoMLSearch(\n",
-    "    X_train=X_train, y_train=y_train, problem_type=\"binary\", holdout_set_size=0\n",
-    ")\n",
+    "automl = AutoMLSearch(X_train=X_train, y_train=y_train, problem_type=\"binary\")\n",
     "try:\n",
     "    automl.search()\n",
     "except ValueError as e:\n",

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -474,7 +474,7 @@ class AutoMLSearch:
         verbose=False,
         timing=False,
         exclude_featurizers=None,
-        holdout_set_size=0.1,
+        holdout_set_size=0,
     ):
         self.verbose = verbose
         if verbose:
@@ -749,7 +749,7 @@ class AutoMLSearch:
         ]
         if exclude_featurizers and (set(exclude_featurizers) - set(featurizer_names)):
             raise ValueError(
-                f"Invalid value provided for exclude_featurizers. Must be one of: {', '.join(featurizer_names)}"
+                f"Invalid value provided for exclude_featurizers. Must be one of: {', '.join(featurizer_names)}",
             )
         self.exclude_featurizers = exclude_featurizers or []
 
@@ -1724,6 +1724,7 @@ class AutoMLSearch:
             if computation.done():
                 try:
                     fitted_pipeline = computation.get_result()[0]
+                    self.logger.info(fitted_pipeline.name)
                     fitted_pipelines[fitted_pipeline.name] = fitted_pipeline
                 except Exception as e:
                     self.logger.error(f"Train error for {pipeline.name}: {str(e)}")

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -1724,7 +1724,6 @@ class AutoMLSearch:
             if computation.done():
                 try:
                     fitted_pipeline = computation.get_result()[0]
-                    self.logger.info(fitted_pipeline.name)
                     fitted_pipelines[fitted_pipeline.name] = fitted_pipeline
                 except Exception as e:
                     self.logger.error(f"Train error for {pipeline.name}: {str(e)}")

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5074,7 +5074,9 @@ def test_exclude_featurizers(
         }
 
     X, y = get_test_data_from_configuration(
-        input_type, problem_type, column_names=["dates", "text", "email", "url"]
+        input_type,
+        problem_type,
+        column_names=["dates", "text", "email", "url"],
     )
 
     automl = AutoMLSearch(
@@ -5107,25 +5109,25 @@ def test_exclude_featurizers(
         [
             DateTimeFeaturizer.name in pl.component_graph.compute_order
             for pl in pipelines
-        ]
+        ],
     )
     assert not any(
-        [EmailFeaturizer.name in pl.component_graph.compute_order for pl in pipelines]
+        [EmailFeaturizer.name in pl.component_graph.compute_order for pl in pipelines],
     )
     assert not any(
-        [URLFeaturizer.name in pl.component_graph.compute_order for pl in pipelines]
+        [URLFeaturizer.name in pl.component_graph.compute_order for pl in pipelines],
     )
     assert not any(
         [
             NaturalLanguageFeaturizer.name in pl.component_graph.compute_order
             for pl in pipelines
-        ]
+        ],
     )
     assert not any(
         [
             TimeSeriesFeaturizer.name in pl.component_graph.compute_order
             for pl in pipelines
-        ]
+        ],
     )
 
 
@@ -5199,7 +5201,13 @@ def test_init_create_holdout_set(caplog):
         n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS - 1,
         random_state=0,
     )
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", verbose=True)
+    automl = AutoMLSearch(
+        X_train=X,
+        y_train=y,
+        problem_type="binary",
+        verbose=True,
+        holdout_set_size=0.1,
+    )
     out = caplog.text
 
     match_text = f"Dataset size is too small to create holdout set. Mininum dataset size is {AutoMLSearch._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X)} rows. Holdout set evaluation is disabled."
@@ -5216,7 +5224,13 @@ def test_init_create_holdout_set(caplog):
         n_samples=AutoMLSearch._HOLDOUT_SET_MIN_ROWS,
         random_state=0,
     )
-    automl = AutoMLSearch(X_train=X, y_train=y, problem_type="binary", verbose=True)
+    automl = AutoMLSearch(
+        X_train=X,
+        y_train=y,
+        problem_type="binary",
+        verbose=True,
+        holdout_set_size=0.1,
+    )
     out = caplog.text
 
     expected_holdout_size = int(automl.holdout_set_size * len(X))

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -894,10 +894,10 @@ def test_large_dataset_split_size(X_y_binary):
     )
     assert isinstance(automl.data_splitter, StratifiedKFold)
 
-    under_max_rows = (
-        _LARGE_DATA_ROW_THRESHOLD + int(ceil(_LARGE_DATA_ROW_THRESHOLD * 0.1 / 0.9)) - 1
-    )  # Should be under threshold even after taking out holdout set
-    X, y = generate_fake_dataset(under_max_rows)
+    # under_max_rows = (
+    #     _LARGE_DATA_ROW_THRESHOLD + int(ceil(_LARGE_DATA_ROW_THRESHOLD * 0.1 / 0.9)) - 1
+    # )  # Should be under threshold even after taking out holdout set
+    X, y = generate_fake_dataset(_LARGE_DATA_ROW_THRESHOLD)
     automl = AutoMLSearch(
         X_train=X,
         y_train=y,

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -991,10 +991,10 @@ def test_automl_search_ratio_overrides_sampler_ratio(
 @pytest.mark.parametrize(
     "problem_type,sampling_ratio_dict,length",
     [
-        ("binary", {0: 0.5, 1: 1}, 810),
-        ("binary", {0: 0.2, 1: 1}, 1080),
-        ("multiclass", {0: 0.5, 1: 1, 2: 1}, 540),
-        ("multiclass", {0: 0.75, 1: 1, 2: 1}, 450),
+        ("binary", {0: 0.5, 1: 1}, 600),
+        ("binary", {0: 0.2, 1: 1}, 800),
+        ("multiclass", {0: 0.5, 1: 1, 2: 1}, 400),
+        ("multiclass", {0: 0.75, 1: 1, 2: 1}, 333),
     ],
 )
 @patch("evalml.pipelines.components.estimators.Estimator.fit")
@@ -1044,10 +1044,10 @@ def test_automl_search_dictionary_undersampler(
 @pytest.mark.parametrize(
     "problem_type,sampling_ratio_dict,length",
     [
-        ("binary", {0: 1, 1: 0.5}, 1215),
-        ("binary", {0: 1, 1: 0.8}, 1458),
-        ("multiclass", {0: 1, 1: 0.5, 2: 0.5}, 1620),
-        ("multiclass", {0: 1, 1: 0.8, 2: 0.8}, 2106),
+        ("binary", {0: 1, 1: 0.5}, 900),
+        ("binary", {0: 1, 1: 0.8}, 1080),
+        ("multiclass", {0: 1, 1: 0.5, 2: 0.5}, 1200),
+        ("multiclass", {0: 1, 1: 0.8, 2: 0.8}, 1560),
     ],
 )
 @patch("evalml.pipelines.components.estimators.Estimator.fit")


### PR DESCRIPTION
Unblocking next EvalML release, will need to renable once we investigate why it is erroring out with the oversampler.