### PR TITLE
Release v0.58.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,17 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+**v0.58.0 Sept. 20, 2022**
+    * Enhancements
         * Defined `get_trend_df()` for PolynomialDecomposer to allow decomposition of target data into trend, seasonality and residual. :pr:`3720`
         * Updated to run with Woodwork >= 0.18.0 :pr:`3700`
         * Pass time index column to time series native estimators but drop otherwise :pr:`3691`
@@ -20,10 +31,6 @@ Release Notes
         * Added github workflow to run looking glass performance tests on merge to main :pr:`3690`
         * Fixed looking glass performance test script :pr:`3715`
         * Remove commit message from looking glass slack message :pr:`3719`
-
-.. warning::
-
-    **Breaking Changes**
 
 **v0.57.0 Sept. 6, 2022**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.57.0"
+__version__ = "0.58.0"


### PR DESCRIPTION
# v0.58.0 Sep. 20, 2022
### Enhancements
- Defined `get_trend_df()` for PolynomialDecomposer to allow decomposition of target data into trend, seasonality and residual. #3720
- Updated to run with Woodwork >= 0.18.0 #3700
- Pass time index column to time series native estimators but drop otherwise #3691
- Added ``errors`` attribute to ``AutoMLSearch`` for useful debugging #3702
### Fixes
- Removed multiple samplers occurring in pipelines generated by ``DefaultAlgorithm`` #3696
- Fix search order changing when using ``DefaultAlgorithm`` #3704
### Changes
- Bumped up minimum version of sktime to 0.12.0. #3720
- Added abstract Decomposer class as a parent to PolynomialDecomposer to support additional decomposers. #3720
- Pinned ``pmdarima`` < 2.0.0 #3679
- Added support for using ``downcast_nullable_types`` with Series as well as DataFrames #3697
### Testing Changes
- Updated pytest fixtures and brittle test files to explicitly set woodwork typing information #3697
- Added github workflow to run looking glass performance tests on merge to main #3690
- Fixed looking glass performance test script #3715
- Remove commit message from looking glass slack message #3719