### PR TITLE
Fix holdout warning message showing when using default parameters

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Fix holdout warning message showing when using default parameters :pr:`3727`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -661,8 +661,8 @@ class AutoMLSearch:
             raise ValueError(
                 "Holdout set size must be greater than 0 and less than 1. Set holdout set size to 0 to disable holdout set evaluation.",
             )
-        if self.passed_holdout_set is False:
-            if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS and self.holdout_set_size > 0:
+        if self.passed_holdout_set is False and self.holdout_set_size > 0:
+            if len(X_train) >= self._HOLDOUT_SET_MIN_ROWS:
                 # Create holdout set from X_train and y_train data because X_train above or at row threshold
                 X_train, X_holdout, y_train, y_holdout = split_data(
                     X_train,
@@ -677,7 +677,7 @@ class AutoMLSearch:
                 )
             else:
                 self.logger.info(
-                    f"Dataset size is too small to create holdout set. Mininum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X_train)} rows. Holdout set evaluation is disabled.",
+                    f"Dataset size is too small to create holdout set. Minimum dataset size is {self._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X_train)} rows. Holdout set evaluation is disabled.",
                 )
         # Set holdout data in AutoML search if provided as parameter
         self.X_train = infer_feature_types(X_train)
@@ -760,14 +760,14 @@ class AutoMLSearch:
                 and "TimeSeriesFeaturizer" not in exclude_featurizers
             ):
                 raise ValueError(
-                    "For time series problems, if DatetimeFeaturizer is excluded, must also exclude TimeSeriesFeaturizer"
+                    "For time series problems, if DatetimeFeaturizer is excluded, must also exclude TimeSeriesFeaturizer",
                 )
             elif (
                 "TimeSeriesFeaturizer" in exclude_featurizers
                 and "DatetimeFeaturizer" not in exclude_featurizers
             ):
                 raise ValueError(
-                    "For time series problems, if TimeSeriesFeaturizer is excluded, must also exclude DatetimeFeaturizer"
+                    "For time series problems, if TimeSeriesFeaturizer is excluded, must also exclude DatetimeFeaturizer",
                 )
         self.exclude_featurizers = exclude_featurizers or []
 

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -5228,11 +5228,22 @@ def test_init_create_holdout_set(caplog):
         y_train=y,
         problem_type="binary",
         verbose=True,
+    )
+    out = caplog.text
+
+    match_text = f"Dataset size is too small to create holdout set. Minimum dataset size is {AutoMLSearch._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X)} rows. Holdout set evaluation is disabled."
+    assert match_text not in out
+
+    automl = AutoMLSearch(
+        X_train=X,
+        y_train=y,
+        problem_type="binary",
+        verbose=True,
         holdout_set_size=0.1,
     )
     out = caplog.text
 
-    match_text = f"Dataset size is too small to create holdout set. Mininum dataset size is {AutoMLSearch._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X)} rows. Holdout set evaluation is disabled."
+    match_text = f"Dataset size is too small to create holdout set. Minimum dataset size is {AutoMLSearch._HOLDOUT_SET_MIN_ROWS} rows, X_train has {len(X)} rows. Holdout set evaluation is disabled."
     assert match_text in out
     assert "AutoMLSearch will use mean CV score to rank pipelines." in out
     assert len(automl.X_train) == len(X)


### PR DESCRIPTION
Currently, we show our warning that AutoML search will not be evaluated with a holdout set even when `holdout_set_size=0` (which is the default). This PR fixes this and a typo in the error message.  