### PR TITLE
Fix oversampler data typing error

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,8 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Fix holdout warning message showing when using default parameters :pr:`3727`
+        * Fixed holdout warning message showing when using default parameters :pr:`3727`
+        * Fixed bug in Oversampler where categorical dtypes would fail :pr:`3732`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -94,7 +94,17 @@ class BaseSampler(Transformer):
             pd.DataFrame, pd.Series: Transformed features and target.
         """
         X, y = self._prepare_data(X, y)
+
+        categorical_columns = X.ww.select("Categorical", return_schema=True).columns
+        if len(categorical_columns):
+            for col in categorical_columns:
+                X[col] = X[col].astype("object")
+
         X_new, y_new = self._component_obj.fit_resample(X, y)
+
+        if len(categorical_columns):
+            for col in categorical_columns:
+                X[col] = X[col].astype("category")
 
         X_new.ww.init(schema=X.ww.schema)
         y_new.ww.init(schema=y.ww.schema)

--- a/evalml/pipelines/components/transformers/samplers/base_sampler.py
+++ b/evalml/pipelines/components/transformers/samplers/base_sampler.py
@@ -96,15 +96,13 @@ class BaseSampler(Transformer):
         X, y = self._prepare_data(X, y)
 
         categorical_columns = X.ww.select("Categorical", return_schema=True).columns
-        if len(categorical_columns):
-            for col in categorical_columns:
-                X[col] = X[col].astype("object")
+        for col in categorical_columns:
+            X[col] = X[col].astype("object")
 
         X_new, y_new = self._component_obj.fit_resample(X, y)
 
-        if len(categorical_columns):
-            for col in categorical_columns:
-                X[col] = X[col].astype("category")
+        for col in categorical_columns:
+            X[col] = X[col].astype("category")
 
         X_new.ww.init(schema=X.ww.schema)
         y_new.ww.init(schema=y.ww.schema)

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -286,6 +286,12 @@ def test_smotenc_categorical_features(X_y_binary):
     _ = snc.fit_transform(X, y)
     assert snc.categorical_features == [0, 1]
 
+    X[0] = pd.Series(["A", "B", "C", "A", "C"] * 20, dtype="category")
+    X.ww.init()
+    snc = Oversampler()
+    _ = snc.fit_transform(X, y)
+    assert snc.categorical_features == [0, 1]
+
 
 def test_smotenc_category_features(X_y_binary):
     X, y = X_y_binary


### PR DESCRIPTION
Provides a workaround for an issue where categorical datatypes were causing the SMOTENC oversampler to fail. The SMOTENC oversampler can only handle `object` datatypes and not `categorical`. This was manifesting itself in CatBoost pipelines, since we don't one-hot encode the categorical features for CatBoost.