### PR TITLE
Partial Dependence Fast Mode

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 
 **Future Releases**
     * Enhancements
+        * Added fast mode to partial dependence :pr:`3753`
     * Fixes
         * Fixed bug where ``TimeSeriesFeaturizer`` could not encode Ordinal columns with non numeric categories :pr:`3812`
         * Update demo dataset links to point to new endpoint :pr:`3826`

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -13,6 +13,15 @@ def _get_cloned_feature_pipelines(
     pipeline,
     variable_has_features_passed_to_estimator,
 ):
+    # --> long term: put flag on the object
+
+    for component in pipeline.component_graph.component_instances.values():
+        X, pipeline_params = component._handle_partial_dependence_fast_mode(
+            X,
+            pipeline.parameters,
+        )
+        pass
+
     # --> add docstring - and maybe typehinting?
     # mock out y for pipeline fitting
     len_X = len(X)
@@ -30,7 +39,9 @@ def _get_cloned_feature_pipelines(
     if dfs_transformer is not None:
         dfs_features = dfs_transformer["features"]
         X_cols = set(X.columns)
-        if features is None or any(f.get_name() not in X_cols for f in dfs_features):
+        if dfs_features is None or any(
+            f.get_name() not in X_cols for f in dfs_features
+        ):
             # set_trace()
             raise ValueError(
                 "Cannot use fast mode with DFS Transformer when features are unspecified or not all present in X.",

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -13,10 +13,10 @@ def _get_cloned_feature_pipelines(
     """Clones and fits pipelines for partial dependence fast mode.
 
     Args:
-        pipeline (PipelineBase or subclass): Fitted pipeline that will be cloned.
-        features (string, tuple[int or string]): The target feature for which to create the partial dependence plot for.
+        features (list(str)): The target feature for which to create the partial dependence plot for.
             If features is a string, it must be a valid column name in X.
             If features is a tuple of int/strings, it must contain valid column integers/names in X.
+        pipeline (PipelineBase or subclass): Fitted pipeline that will be cloned.
         variable_has_features_passed_to_estimator (dict[str, bool]): Dictionary mapping variable names to whether or not
             the variable has an impact on predictions. Variables that do not have features passed to the estimator
             will not have an impact on predictions and therefore do not need to have pipelines fitted for them.
@@ -26,7 +26,7 @@ def _get_cloned_feature_pipelines(
             be used to train the cloned pipelines.
 
     Returns:
-        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
+        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline
             fit for it.
     """
     if X_train is None or y_train is None:
@@ -68,15 +68,15 @@ def _transform_single_feature(
     """Transforms single column using cloned pipeline and column that has been updated for partial dependence calculations.
 
     Args:
-        X_t (pd.DataFrame, np.ndarray): The transformed data into which we insert the transformed single column.
         X (pd.DataFrame, np.ndarray): The original data used for calculating partial dependence.
+        X_t (pd.DataFrame, np.ndarray): The transformed data into which we insert the transformed single column.
         feature_provenance (dict[str, set[str]]): Dictionary mapping base feature names to engineered feature names.
         variable (str): The name of the single column we're transforming.
         part_dep_column (pd.Series): The updated column that will be transformed by the fit pipeline.
         cloned_pipeline (PipelineBase or subclass): Fitted pipeline that will be used to transform a single feature.
 
     Returns:
-        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
+        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline
             fit for it.
     """
     changed_col_df = pd.DataFrame({variable: part_dep_column})

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -29,9 +29,6 @@ def _get_cloned_feature_pipelines(
         dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline
             fit for it.
     """
-    if X_train is None or y_train is None:
-        raise ValueError("Training data is required for partial dependence fast mode.")
-
     X_train = infer_feature_types(X_train)
 
     # Make sure that only components that are capable of handling fast mode are in the pipeline

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -7,8 +7,8 @@ def _get_cloned_feature_pipelines(
     features,
     pipeline,
     variable_has_features_passed_to_estimator,
-    X_training,
-    y_training,
+    X_train,
+    y_train,
 ):
     """Clones and fits pipelines for partial dependence fast mode.
 
@@ -17,25 +17,25 @@ def _get_cloned_feature_pipelines(
         features (string, tuple[int or string]): The target feature for which to create the partial dependence plot for.
             If features is a string, it must be a valid column name in X.
             If features is a tuple of int/strings, it must contain valid column integers/names in X.
-        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
             be used to train the cloned pipelines.
-        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
             be used to train the cloned pipelines.
 
     Returns:
         dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
             fit for it.
     """
-    if X_training is None or y_training is None:
+    if X_train is None or y_train is None:
         raise ValueError("Training data is required for partial dependence fast mode.")
 
-    X_training = infer_feature_types(X_training)
+    X_train = infer_feature_types(X_train)
 
     # Make sure that only components that are capable of handling fast mode are in the pipeline
     new_parameters = pipeline.parameters
     for component in pipeline.component_graph.component_instances.values():
         new_parameters = component._handle_partial_dependence_fast_mode(
-            X_training,
+            X_train,
             new_parameters,
         )
 
@@ -48,7 +48,7 @@ def _get_cloned_feature_pipelines(
         pipeline_copy = pipeline.new(
             parameters=new_parameters,
         )
-        pipeline_copy.fit(X_training.ww[[variable]], y_training)
+        pipeline_copy.fit(X_train.ww[[variable]], y_train)
         cloned_feature_pipelines[variable] = pipeline_copy
 
     return cloned_feature_pipelines

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -13,6 +13,19 @@ def _get_cloned_feature_pipelines(
     pipeline,
     variable_has_features_passed_to_estimator,
 ):
+    """Clones and fits pipelines for partial dependence fast mode.
+
+    Args:
+        pipeline (PipelineBase or subclass): Fitted pipeline that will be cloned.
+        X (pd.DataFrame, np.ndarray): The input data used to fit the cloned pipelines.
+        features (string, tuple[int or string]): The target feature for which to create the partial dependence plot for.
+            If features is a string, it must be a valid column name in X.
+            If features is a tuple of int/strings, it must contain valid column integers/names in X.
+
+    Returns:
+        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
+            fit for it.
+    """
     # Make sure that only components that are capable of handling fast mode are in the pipeline
     new_parameters = pipeline.parameters
     for component in pipeline.component_graph.component_instances.values():
@@ -21,7 +34,6 @@ def _get_cloned_feature_pipelines(
             new_parameters,
         )
 
-    # --> add docstring - and maybe typehinting?
     # mock out y for pipeline fitting
     len_X = len(X)
     if is_regression(pipeline.problem_type):
@@ -56,6 +68,21 @@ def _transform_single_feature(
     part_dep_column,
     cloned_pipeline,
 ):
+    """Transforms single column using cloned pipeline and column that has been updated
+        for partial dependence calculations.
+
+    Args:
+        X_t (pd.DataFrame, np.ndarray): The transformed data into which we insert the transformed single column.
+        X (pd.DataFrame, np.ndarray): The original data used for calculating partial dependence.
+        feature_provenance (dict[str, set[str]]): Dictionary mapping base feature names to engineered feature names.
+        variable (str): The name of the single column we're transforming.
+        part_dep_column (pd.Series): The updated column that will be transformed by the fit pipeline.
+        cloned_pipeline (PipelineBase or subclass): Fitted pipeline that will be used to transform a single feature.
+
+    Returns:
+        dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
+            fit for it.
+    """
     changed_col_df = pd.DataFrame({variable: part_dep_column})
     changed_col_df.ww.init(
         logical_types={variable: X.ww.logical_types[variable]},

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -13,6 +13,7 @@ def _get_cloned_feature_pipelines(
     pipeline,
     variable_has_features_passed_to_estimator,
 ):
+    # Make sure that only components that are capable of handling fast mode are in the pipeline
     new_parameters = pipeline.parameters
     for component in pipeline.component_graph.component_instances.values():
         new_parameters = component._handle_partial_dependence_fast_mode(

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -17,6 +17,9 @@ def _get_cloned_feature_pipelines(
         features (string, tuple[int or string]): The target feature for which to create the partial dependence plot for.
             If features is a string, it must be a valid column name in X.
             If features is a tuple of int/strings, it must contain valid column integers/names in X.
+        variable_has_features_passed_to_estimator (dict[str, bool]): Dictionary mapping variable names to whether or not
+            the variable has an impact on predictions. Variables that do not have features passed to the estimator
+            will not have an impact on predictions and therefore do not need to have pipelines fitted for them.
         X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
             be used to train the cloned pipelines.
         y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -64,8 +64,7 @@ def _transform_single_feature(
     part_dep_column,
     cloned_pipeline,
 ):
-    """Transforms single column using cloned pipeline and column that has been updated
-        for partial dependence calculations.
+    """Transforms single column using cloned pipeline and column that has been updated for partial dependence calculations.
 
     Args:
         X_t (pd.DataFrame, np.ndarray): The transformed data into which we insert the transformed single column.

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -10,6 +10,7 @@ def _get_cloned_feature_pipelines(
     pipeline,
     variable_has_features_passed_to_estimator,
     X_training,
+    y_training,
 ):
     """Clones and fits pipelines for partial dependence fast mode.
 
@@ -35,13 +36,14 @@ def _get_cloned_feature_pipelines(
         )
 
     # mock out y for pipeline fitting
-    len_X = len(X)
-    if is_regression(pipeline.problem_type):
-        mock_y = pd.Series(np.random.randint(0, 10, len_X))
-    elif is_binary(pipeline.problem_type):
-        mock_y = pd.Series(np.random.choice([True, False], size=len_X))
-    else:
-        mock_y = pd.Series(np.random.choice([0, 1, 2], size=len_X))
+    if y_training is None:
+        len_X = len(X)
+        if is_regression(pipeline.problem_type):
+            y_training = pd.Series(np.random.randint(0, 10, len_X))
+        elif is_binary(pipeline.problem_type):
+            y_training = pd.Series(np.random.choice([True, False], size=len_X))
+        else:
+            y_training = pd.Series(np.random.choice([0, 1, 2], size=len_X))
 
     # Create a fit pipeline for each feature
     cloned_feature_pipelines = {}
@@ -52,7 +54,7 @@ def _get_cloned_feature_pipelines(
         pipeline_copy = pipeline.new(
             parameters=new_parameters,
         )
-        pipeline_copy.fit(X.ww[[variable]], mock_y)
+        pipeline_copy.fit(X.ww[[variable]], y_training)
         cloned_feature_pipelines[variable] = pipeline_copy
 
     return cloned_feature_pipelines

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -35,7 +35,6 @@ def _get_cloned_feature_pipelines(
     # mock out y for pipeline fitting
     len_X = len(X)
     if is_regression(pipeline.problem_type):
-        # --> might want to use random seed here, though the mocked y shouldn't have an impact on PD
         mock_y = pd.Series(np.random.randint(0, 10, len_X))
     elif is_binary(pipeline.problem_type):
         mock_y = pd.Series(np.random.choice([True, False], size=len_X))
@@ -100,6 +99,5 @@ def _transform_single_feature(
     if len(cols_to_replace) != len(X_t_single_col.columns):
         X_t_single_col = X_t_single_col[cols_to_replace]
 
-    # --> not keeping in woodwork - problematic?
     X_t[cols_to_replace] = X_t_single_col
     return X_t

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -56,7 +56,6 @@ def _get_cloned_feature_pipelines(
         pipeline_copy.fit(X.ww[[variable]], mock_y)
         cloned_feature_pipelines[variable] = pipeline_copy
 
-    # --> maybe check if not passed to estimator earlier and return then
     return cloned_feature_pipelines
 
 
@@ -90,18 +89,19 @@ def _transform_single_feature(
 
     # Take the changed column and send it through transform by itself
     X_t_single_col = cloned_pipeline.transform_all_but_final(changed_col_df)
+
+    # Determine which columns in X_t we're replacing with the transform output
     cols_to_replace = [variable]
     if feature_provenance.get(variable):
         # cols to replace has to be in the same order as X_t
         cols_to_replace = [
             col for col in X_t if col in feature_provenance.get(variable)
         ]
-    # --> not keeping in woodwork - problematic?
-
-    # If some categories get dropped, they won't be in X_t, so don't include them
-    # --> might want to also confirm that this is bc off a selector not some oter reason
+    # If some categories got dropped during transform of the original X_t,
+    # they won't be in X_t_single_col, so don't include them
     if len(cols_to_replace) != len(X_t_single_col.columns):
-        X_t_single_col = X_t_single_col[list(cols_to_replace)]
+        X_t_single_col = X_t_single_col[cols_to_replace]
 
-    X_t[list(cols_to_replace)] = X_t_single_col
+    # --> not keeping in woodwork - problematic?
+    X_t[cols_to_replace] = X_t_single_col
     return X_t

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -24,6 +24,18 @@ def _get_cloned_feature_pipelines(
     else:
         mock_y = pd.Series(np.random.choice([0, 1, 2], size=len_X))
 
+    # If DFSTransformer is present, confirm features parameter is specified and all features are present
+    # in X
+    dfs_transformer = pipeline.parameters.get("DFS Transformer")
+    if dfs_transformer is not None:
+        dfs_features = dfs_transformer["features"]
+        X_cols = set(X.columns)
+        if features is None or any(f.get_name() not in X_cols for f in dfs_features):
+            # set_trace()
+            raise ValueError(
+                "Cannot use fast mode with DFS Transformer when features are unspecified or not all present in X.",
+            )
+
     # Handle components that use feature importance to remove some features before passing into estimator
     new_parameters = pipeline.parameters
     selector = None

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -9,6 +9,7 @@ def _get_cloned_feature_pipelines(
     X,
     pipeline,
     variable_has_features_passed_to_estimator,
+    X_training,
 ):
     """Clones and fits pipelines for partial dependence fast mode.
 
@@ -23,6 +24,8 @@ def _get_cloned_feature_pipelines(
         dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline
             fit for it.
     """
+    if X_training is not None:
+        X = X_training
     # Make sure that only components that are capable of handling fast mode are in the pipeline
     new_parameters = pipeline.parameters
     for component in pipeline.component_graph.component_instances.values():

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -36,6 +36,7 @@ def _get_cloned_feature_pipelines(
         # Feature selector's shouldn't drop any columns for the cloned pipeline
         new_parameters[selector]["percent_features"] = 1.0
         new_parameters[selector]["threshold"] = 0.0
+    # --> check if dfs transformer is present, and if all the features aren't in X, raise an error
 
     # Create a fit pipeline for each feature
     cloned_feature_pipelines = {}

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -11,15 +11,20 @@ def _get_cloned_feature_pipelines(
     variable_has_features_passed_to_estimator,
     X_training,
     y_training,
+    # --> maybe these should be required for fast mode? So error if they aren't there - also update docstring
 ):
     """Clones and fits pipelines for partial dependence fast mode.
 
     Args:
         pipeline (PipelineBase or subclass): Fitted pipeline that will be cloned.
-        X (pd.DataFrame, np.ndarray): The input data used to fit the cloned pipelines.
+        X (pd.DataFrame, np.ndarray): The input data that will be transformed by the cloned pipelines.
         features (string, tuple[int or string]): The target feature for which to create the partial dependence plot for.
             If features is a string, it must be a valid column name in X.
             If features is a tuple of int/strings, it must contain valid column integers/names in X.
+        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+            be used to train the cloned pipelines.
+        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+            be used to train the cloned pipelines.
 
     Returns:
         dict[str, PipelineBase or subclass]: Dictionary mapping feature name to the pipeline pipeline

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import woodwork as ww
 
 from evalml.problem_types import is_binary, is_regression
 

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -1,0 +1,84 @@
+from pdb import set_trace
+
+import numpy as np
+import pandas as pd
+import woodwork as ww
+
+from evalml.problem_types import is_binary, is_regression
+
+
+def _get_cloned_feature_pipelines(
+    features,
+    X,
+    pipeline,
+    variable_has_features_passed_to_estimator,
+):
+    # --> add docstring - and maybe typehinting?
+    # mock out y for pipeline fitting
+    len_X = len(X)
+    if is_regression(pipeline.problem_type):
+        # --> might want to use random seed here, though the mocked y shouldn't have an impact on PD
+        mock_y = pd.Series(np.random.randint(0, 10, len_X))
+    elif is_binary(pipeline.problem_type):
+        mock_y = pd.Series(np.random.choice([True, False], size=len_X))
+    else:
+        mock_y = pd.Series(np.random.choice([0, 1, 2], size=len_X))
+
+    # Handle components that use feature importance to remove some features before passing into estimator
+    new_parameters = pipeline.parameters
+    selector = None
+    if "RF Regressor Select From Model" in pipeline.parameters:
+        # --> can I be more generic and just look for any selector that does this kind of thing? Are there others than these two?
+        selector = "RF Regressor Select From Model"
+    elif "RF Classifier Select From Model" in pipeline.parameters:
+        selector = "RF Classifier Select From Model"
+    if selector is not None:
+        # Feature selector's shouldn't drop any columns for the cloned pipeline
+        new_parameters[selector]["percent_features"] = 1.0
+        new_parameters[selector]["threshold"] = 0.0
+
+    # Create a fit pipeline for each feature
+    cloned_feature_pipelines = {}
+    for variable in features:
+        # Don't fit pipelines if the feature has no impact on predictions
+        if not variable_has_features_passed_to_estimator[variable]:
+            continue
+        pipeline_copy = pipeline.new(
+            parameters=new_parameters,
+        )
+        pipeline_copy.fit(X.ww[[variable]], mock_y)
+        cloned_feature_pipelines[variable] = pipeline_copy
+    # --> maybe check if not passed to estimator earlier and return then
+    return cloned_feature_pipelines
+
+
+def _transform_single_feature(
+    X,
+    X_t,
+    feature_provenance,
+    variable,
+    part_dep_column,
+    cloned_pipeline,
+):
+    changed_col_df = pd.DataFrame({variable: part_dep_column})
+    changed_col_df.ww.init(
+        logical_types={variable: X.ww.logical_types[variable]},
+    )
+
+    # Take the changed column and send it through transform by itself
+    X_t_single_col = cloned_pipeline.transform_all_but_final(changed_col_df)
+    cols_to_replace = [variable]
+    if feature_provenance.get(variable):
+        # cols to replace has to be in the same order as X_t
+        cols_to_replace = [
+            col for col in X_t if col in feature_provenance.get(variable)
+        ]
+    # --> not keeping in woodwork - problematic?
+
+    # If some categories get dropped, they won't be in X_t, so don't include them
+    # --> might want to also confirm that this is bc off a selector not some oter reason
+    if len(cols_to_replace) != len(X_t_single_col.columns):
+        X_t_single_col = X_t_single_col[list(cols_to_replace)]
+
+    X_t[list(cols_to_replace)] = X_t_single_col
+    return X_t

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -1,5 +1,3 @@
-from pdb import set_trace
-
 import numpy as np
 import pandas as pd
 import woodwork as ww

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -231,6 +231,7 @@ def _partial_dependence_calculation(
     features,
     X,
     X_training,
+    y_training,
     fast_mode=False,
 ):
     """Do the partial dependence calculation once the grid is computed.
@@ -278,13 +279,13 @@ def _partial_dependence_calculation(
             pipeline,
             variable_has_features_passed_to_estimator,
             X_training,
+            y_training,
         )
 
     if is_regression(pipeline.problem_type):
         prediction_method = prediction_object.predict
     else:
         prediction_method = prediction_object.predict_proba
-
     if fast_mode and no_features_passed_to_estimator:
         original_predictions = prediction_method(X_eval)
         original_predictions_mean = np.mean(original_predictions, axis=0)
@@ -320,7 +321,6 @@ def _partial_dependence_calculation(
             predictions.append(pred)
             # average over samples
             averaged_predictions.append(np.mean(pred, axis=0))
-
     n_samples = X.shape[0]
 
     # reshape to (n_instances, n_points) for binary/regression
@@ -354,6 +354,7 @@ def _partial_dependence(
     custom_range=None,
     fast_mode=False,
     X_training=None,
+    y_training=None,
 ):
     """Compute the partial dependence for features of X.
 
@@ -404,8 +405,9 @@ def _partial_dependence(
         grid,
         features,
         X,
-        fast_mode=fast_mode,
         X_training=X_training,
+        y_training=y_training,
+        fast_mode=fast_mode,
     )
 
     # reshape predictions to

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -250,18 +250,17 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
         X_eval = pipeline.transform_all_but_final(X_eval)
         prediction_object = pipeline.estimator
 
-    # Some components may drop features, so we need to know whether the specified
-    # features actually have an impact on predictions
-    feature_provenance = pipeline._get_feature_provenance()
-    variable_has_features_passed_to_estimator = {
-        variable: variable in feature_provenance or variable in X_eval.columns
-        for variable in features
-    }
-    no_features_passed_to_estimator = not any(
-        variable_has_features_passed_to_estimator.values(),
-    )
+        # Some components may drop features, so we need to know whether the specified
+        # features actually have an impact on predictions
+        feature_provenance = pipeline._get_feature_provenance()
+        variable_has_features_passed_to_estimator = {
+            variable: variable in feature_provenance or variable in X_eval.columns
+            for variable in features
+        }
+        no_features_passed_to_estimator = not any(
+            variable_has_features_passed_to_estimator.values(),
+        )
 
-    if fast_mode:
         # Fit pipelines for each feature so that we can transform it with grid
         # values later
         cloned_feature_pipelines = _get_cloned_feature_pipelines(
@@ -276,7 +275,7 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
     else:
         prediction_method = prediction_object.predict_proba
 
-    if no_features_passed_to_estimator:
+    if fast_mode and no_features_passed_to_estimator:
         # --> maybe we need to also confirm a selector was used bc i dont want this to
         # silently set these values in any situation that doesn't look as expected - ex stacked ensembling
         original_predictions = prediction_method(X_eval)

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -280,8 +280,6 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
         prediction_method = prediction_object.predict_proba
 
     if fast_mode and no_features_passed_to_estimator:
-        # --> maybe we need to also confirm a selector was used bc i dont want this to
-        # silently set these values in any situation that doesn't look as expected - ex stacked ensembling
         original_predictions = prediction_method(X_eval)
         original_predictions_mean = np.mean(original_predictions, axis=0)
 
@@ -316,6 +314,7 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
             predictions.append(pred)
             # average over samples
             averaged_predictions.append(np.mean(pred, axis=0))
+        # set_trace()
 
     n_samples = X.shape[0]
 

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -241,6 +241,10 @@ def _partial_dependence_calculation(
         grid (pd.DataFrame): Grid of features to compute the partial dependence on.
         features (list(str)): Column names of input data
         X (pd.DataFrame): Input data.
+        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
+        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
         fast_mode (bool, optional): Whether or not performance optimizations should be
             used. Defaults to False. When True, copies of pipelines will be used to transform just the
             column(s) we're calculating partial dependence for. This means that any pipeline
@@ -377,6 +381,10 @@ def _partial_dependence(
             containing a component that relies on multiple columns for fit and transform should
             not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
             to determine which components cannot be used for fast mode.
+        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
+        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
 
     Returns:
         dict with 'average', 'individual', 'values' keys. 'values' is a list of

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -241,16 +241,16 @@ def _partial_dependence_calculation(
         grid (pd.DataFrame): Grid of features to compute the partial dependence on.
         features (list(str)): Column names of input data
         X (pd.DataFrame): Input data.
-        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
-        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
         fast_mode (bool, optional): Whether or not performance optimizations should be
             used. Defaults to False. When True, copies of pipelines will be used to transform just the
             column(s) we're calculating partial dependence for. This means that any pipeline
             containing a component that relies on multiple columns for fit and transform should
             not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
             to determine which components cannot be used for fast mode.
+        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
+        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
 
     Returns:
         Tuple (np.ndarray, np.ndarray): averaged and individual predictions for
@@ -381,9 +381,9 @@ def _partial_dependence(
             not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
             to determine which components cannot be used for fast mode.
         X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
+            be used in fast mode to train the cloned pipelines. Defaults to None.
         y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
+            be used in fast mode to train the cloned pipelines. Defaults to None.
 
     Returns:
         dict with 'average', 'individual', 'values' keys. 'values' is a list of

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -253,6 +253,7 @@ def _partial_dependence_calculation(pipeline, grid, features, X):
                 part_dep_column,
                 logical_type=X_eval.ww.logical_types[variable],
             )
+
         pred = prediction_method(X_eval)
 
         predictions.append(pred)

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -4,8 +4,6 @@ Implementation borrows from sklearn "brute" calculation but with our
 own modification to better handle mixed data types in the grid
 as well as EvalML pipelines.
 """
-from pdb import set_trace
-
 import numpy as np
 import pandas as pd
 import woodwork as ww
@@ -314,7 +312,6 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
             predictions.append(pred)
             # average over samples
             averaged_predictions.append(np.mean(pred, axis=0))
-        # set_trace()
 
     n_samples = X.shape[0]
 

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -235,8 +235,12 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
         grid (pd.DataFrame): Grid of features to compute the partial dependence on.
         features (list(str)): Column names of input data
         X (pd.DataFrame): Input data.
-
-        # --> update
+        fast_mode (bool, optional): Whether or not performance optimizations should be
+            used. Defaults to False. When True, copies of pipelines will be used to transform just the
+            column(s) we're calculating partial dependence for. This means that any pipeline
+            containing a component that relies on multiple columns for fit and transform should
+            not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
+            to determine which components cannot be used for fast mode.
 
     Returns:
         Tuple (np.ndarray, np.ndarray): averaged and individual predictions for
@@ -344,7 +348,7 @@ def _partial_dependence(
     grid_resolution=100,
     kind="average",
     custom_range=None,
-    use_new=False,
+    fast_mode=False,
 ):
     """Compute the partial dependence for features of X.
 
@@ -361,6 +365,12 @@ def _partial_dependence(
             range of values to use in partial dependence. If custom_range is specified,
             the percentile + interpolation procedure is skipped and the values in custom_range
             are used.
+        fast_mode (bool, optional): Whether or not performance optimizations should be
+            used. Defaults to False. When True, copies of pipelines will be used to transform just the
+            column(s) we're calculating partial dependence for. This means that any pipeline
+            containing a component that relies on multiple columns for fit and transform should
+            not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
+            to determine which components cannot be used for fast mode.
 
     Returns:
         dict with 'average', 'individual', 'values' keys. 'values' is a list of
@@ -389,7 +399,7 @@ def _partial_dependence(
         grid,
         features,
         X,
-        fast_mode=use_new,
+        fast_mode=fast_mode,
     )
 
     # reshape predictions to

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -230,8 +230,8 @@ def _partial_dependence_calculation(
     grid,
     features,
     X,
-    X_training,
-    y_training,
+    X_train,
+    y_train,
     fast_mode=False,
 ):
     """Do the partial dependence calculation once the grid is computed.
@@ -241,9 +241,9 @@ def _partial_dependence_calculation(
         grid (pd.DataFrame): Grid of features to compute the partial dependence on.
         features (list(str)): Column names of input data
         X (pd.DataFrame): Input data.
-        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
-        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
         fast_mode (bool, optional): Whether or not performance optimizations should be
             used. Defaults to False. When True, copies of pipelines will be used to transform just the
@@ -281,8 +281,8 @@ def _partial_dependence_calculation(
             features,
             pipeline,
             variable_has_features_passed_to_estimator,
-            X_training,
-            y_training,
+            X_train,
+            y_train,
         )
 
     if is_regression(pipeline.problem_type):
@@ -356,8 +356,8 @@ def _partial_dependence(
     kind="average",
     custom_range=None,
     fast_mode=False,
-    X_training=None,
-    y_training=None,
+    X_train=None,
+    y_train=None,
 ):
     """Compute the partial dependence for features of X.
 
@@ -380,9 +380,9 @@ def _partial_dependence(
             containing a component that relies on multiple columns for fit and transform should
             not be used. See the ``_can_be_used_for_fast_partial_dependence`` property on components
             to determine which components cannot be used for fast mode.
-        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
-        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
 
     Returns:
@@ -412,8 +412,8 @@ def _partial_dependence(
         grid,
         features,
         X,
-        X_training=X_training,
-        y_training=y_training,
+        X_train=X_train,
+        y_train=y_train,
         fast_mode=fast_mode,
     )
 

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -225,7 +225,14 @@ def _cartesian(arrays):
     return out
 
 
-def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False):
+def _partial_dependence_calculation(
+    pipeline,
+    grid,
+    features,
+    X,
+    X_training,
+    fast_mode=False,
+):
     """Do the partial dependence calculation once the grid is computed.
 
     Args:
@@ -270,6 +277,7 @@ def _partial_dependence_calculation(pipeline, grid, features, X, fast_mode=False
             X,
             pipeline,
             variable_has_features_passed_to_estimator,
+            X_training,
         )
 
     if is_regression(pipeline.problem_type):
@@ -345,6 +353,7 @@ def _partial_dependence(
     kind="average",
     custom_range=None,
     fast_mode=False,
+    X_training=None,
 ):
     """Compute the partial dependence for features of X.
 
@@ -396,6 +405,7 @@ def _partial_dependence(
         features,
         X,
         fast_mode=fast_mode,
+        X_training=X_training,
     )
 
     # reshape predictions to

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -279,7 +279,6 @@ def _partial_dependence_calculation(
         # values later
         cloned_feature_pipelines = _get_cloned_feature_pipelines(
             features,
-            X,
             pipeline,
             variable_has_features_passed_to_estimator,
             X_training,

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -35,7 +35,6 @@ def partial_dependence(
     grid_resolution=100,
     kind="average",
     use_new=False,
-    y=None,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -205,7 +204,6 @@ def partial_dependence(
                 kind=kind,
                 custom_range=custom_range,
                 use_new=use_new,
-                y=y,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -35,8 +35,8 @@ def partial_dependence(
     grid_resolution=100,
     kind="average",
     fast_mode=False,
-    X_training=None,
-    y_training=None,
+    X_train=None,
+    y_train=None,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -65,9 +65,9 @@ def partial_dependence(
             Note that user-specified components may not produce correct partial dependence results, so fast mode
             should only be used with EvalML-native components. Additionally, some components are not compatible
             with fast mode; in those cases, an error will be raised indicating that fast mode should not be used.
-        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+        X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
-        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+        y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
 
     Returns:
@@ -215,8 +215,8 @@ def partial_dependence(
                 kind=kind,
                 custom_range=custom_range,
                 fast_mode=fast_mode,
-                X_training=X_training,
-                y_training=y_training,
+                X_train=X_train,
+                y_train=y_train,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -34,6 +34,8 @@ def partial_dependence(
     percentiles=(0.05, 0.95),
     grid_resolution=100,
     kind="average",
+    use_new=False,
+    y=None,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -202,6 +204,8 @@ def partial_dependence(
                 grid_resolution=grid_resolution,
                 kind=kind,
                 custom_range=custom_range,
+                use_new=use_new,
+                y=y,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -36,6 +36,7 @@ def partial_dependence(
     kind="average",
     fast_mode=False,
     X_training=None,
+    y_training=None,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -211,6 +212,7 @@ def partial_dependence(
                 custom_range=custom_range,
                 fast_mode=fast_mode,
                 X_training=X_training,
+                y_training=y_training,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -69,6 +69,7 @@ def partial_dependence(
             be used in fast mode to train the cloned pipelines.
         y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
             be used in fast mode to train the cloned pipelines.
+
     Returns:
         pd.DataFrame, list(pd.DataFrame), or tuple(pd.DataFrame, list(pd.DataFrame)):
             When `kind='average'`: DataFrame with averaged predictions for all points in the grid averaged

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -35,6 +35,7 @@ def partial_dependence(
     grid_resolution=100,
     kind="average",
     fast_mode=False,
+    X_training=None,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -209,6 +210,7 @@ def partial_dependence(
                 kind=kind,
                 custom_range=custom_range,
                 fast_mode=fast_mode,
+                X_training=X_training,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -34,7 +34,7 @@ def partial_dependence(
     percentiles=(0.05, 0.95),
     grid_resolution=100,
     kind="average",
-    use_new=False,
+    fast_mode=False,
 ):
     """Calculates one or two-way partial dependence.
 
@@ -58,6 +58,11 @@ def partial_dependence(
         kind ({'average', 'individual', 'both'}): The type of predictions to return. 'individual' will return the predictions for
             all of the points in the grid for each sample in X. 'average' will return the predictions for all of the points in
             the grid but averaged over all of the samples in X.
+        fast_mode (bool, optional): Whether or not performance optimizations should be
+            used for partial dependence calculations. Defaults to False.
+            Note that user-specified components may not produce correct partial dependence results, so fast mode
+            should only be used with EvalML-native components. Additionally, some components are not compatible
+            with fast mode; in those cases, an error will be raised indicating that fast mode should not be used.
 
     Returns:
         pd.DataFrame, list(pd.DataFrame), or tuple(pd.DataFrame, list(pd.DataFrame)):
@@ -203,7 +208,7 @@ def partial_dependence(
                 grid_resolution=grid_resolution,
                 kind=kind,
                 custom_range=custom_range,
-                use_new=use_new,
+                fast_mode=fast_mode,
             )
         except ValueError as e:
             if "percentiles are too close to each other" in str(e):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -66,9 +66,9 @@ def partial_dependence(
             should only be used with EvalML-native components. Additionally, some components are not compatible
             with fast mode; in those cases, an error will be raised indicating that fast mode should not be used.
         X_train (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
+            be used in fast mode to train the cloned pipelines. Defaults to None.
         y_train (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
-            be used in fast mode to train the cloned pipelines.
+            be used in fast mode to train the cloned pipelines. Defaults to None.
 
     Returns:
         pd.DataFrame, list(pd.DataFrame), or tuple(pd.DataFrame, list(pd.DataFrame)):

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -65,7 +65,10 @@ def partial_dependence(
             Note that user-specified components may not produce correct partial dependence results, so fast mode
             should only be used with EvalML-native components. Additionally, some components are not compatible
             with fast mode; in those cases, an error will be raised indicating that fast mode should not be used.
-
+        X_training (pd.DataFrame, np.ndarray): The data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
+        y_training (pd.Series, np.ndarray): The target data that was used to train the original pipeline. Will
+            be used in fast mode to train the cloned pipelines.
     Returns:
         pd.DataFrame, list(pd.DataFrame), or tuple(pd.DataFrame, list(pd.DataFrame)):
             When `kind='average'`: DataFrame with averaged predictions for all points in the grid averaged

--- a/evalml/model_understanding/partial_dependence_functions.py
+++ b/evalml/model_understanding/partial_dependence_functions.py
@@ -163,6 +163,11 @@ def partial_dependence(
                 code=PartialDependenceErrorCode.INVALID_FEATURE_TYPE,
             )
 
+        if fast_mode and (X_train is None or y_train is None):
+            raise ValueError(
+                "Training data is required for partial dependence fast mode.",
+            )
+
         X_cats = X_features.ww.select("category")
         X_dt = X_features.ww.select("datetime")
 

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -107,6 +107,13 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
         return not cls.modifies_target
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        """Determines whether or not a component can be used with partial dependence's fast mode.
+
+        Args:
+            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+            pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
+                used in partial dependence fast mode.
+        """
         if self._can_be_used_for_fast_partial_dependence:
             return pipeline_parameters
 

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -20,9 +20,6 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     """
 
     _default_parameters = None
-    # --> this won't make custom components invalid for fast mode, but lets us opt into it.
-    # Given that fast mode isn't default behavior and we'll have proper warnings about not
-    # using it for custom components, (maybe we raise a warning if we find custom?), this makes the most sense
     _can_be_used_for_fast_partial_dependence = True
 
     def __init__(self, parameters=None, component_obj=None, random_seed=0, **kwargs):

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -20,6 +20,10 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     """
 
     _default_parameters = None
+    # --> this won't make custom components invalid for fast mode, but lets us opt into it
+    # given that fast mode isn't default behavior and we'll have proper warnings about not
+    # using it for custom components, (maybe we raise a warning if we find custom?), this makes the most sense
+    _can_be_used_for_fast_partial_dependence = True
 
     def __init__(self, parameters=None, component_obj=None, random_seed=0, **kwargs):
         """Base class for all components.
@@ -101,6 +105,14 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     @classproperty
     def _supported_by_list_API(cls):
         return not cls.modifies_target
+
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        if self._can_be_used_for_fast_partial_dependence:
+            return X, pipeline_parameters
+
+        raise TypeError(
+            f"Component {self.name} cannot run partial dependence fast mode.",
+        )
 
     def clone(self):
         """Constructs a new component with the same parameters and random state.

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -108,7 +108,7 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
         if self._can_be_used_for_fast_partial_dependence:
-            return X, pipeline_parameters
+            return pipeline_parameters
 
         raise TypeError(
             f"Component {self.name} cannot run partial dependence fast mode.",

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -20,8 +20,8 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     """
 
     _default_parameters = None
-    # --> this won't make custom components invalid for fast mode, but lets us opt into it
-    # given that fast mode isn't default behavior and we'll have proper warnings about not
+    # --> this won't make custom components invalid for fast mode, but lets us opt into it.
+    # Given that fast mode isn't default behavior and we'll have proper warnings about not
     # using it for custom components, (maybe we raise a warning if we find custom?), this makes the most sense
     _can_be_used_for_fast_partial_dependence = True
 

--- a/evalml/pipelines/components/ensemble/stacked_ensemble_base.py
+++ b/evalml/pipelines/components/ensemble/stacked_ensemble_base.py
@@ -24,6 +24,7 @@ class StackedEnsembleBase(Estimator):
     model_family = ModelFamily.ENSEMBLE
     """ModelFamily.ENSEMBLE"""
     _default_final_estimator = None
+    _can_be_used_for_fast_partial_dependence = False
 
     def __init__(
         self,

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -72,7 +72,19 @@ class FeatureSelector(Transformer):
         return self.fit(X, y).transform(X, y)
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        """Updates pipeline parameters to not drop any features based off of feature importance.
+            This is needed, because fast mode refits cloned pipelines on single columns,
+            so for categorical columns that have one-hot encoding applied may lose some
+            of their encoded columns with the default parameters.
+
+        Args:
+            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+            pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
+                used in partial dependence fast mode.
+        """
+        # Raise the percent of features we want to keep to not lose any
         pipeline_parameters[self.name]["percent_features"] = 1.0
+        # Lower the threshold for feature importance above which we keep features
         pipeline_parameters[self.name]["threshold"] = 0.0
 
         return pipeline_parameters

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -70,3 +70,9 @@ class FeatureSelector(Transformer):
             pd.DataFrame: Transformed data.
         """
         return self.fit(X, y).transform(X, y)
+
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        pipeline_parameters[self.name]["percent_features"] = 1.0
+        pipeline_parameters[self.name]["threshold"] = 0.0
+
+        return pipeline_parameters

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -73,8 +73,10 @@ class FeatureSelector(Transformer):
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
         """Updates pipeline parameters to not drop any features based off of feature importance.
+
+        Note:
             This is needed, because fast mode refits cloned pipelines on single columns,
-            so for categorical columns that have one-hot encoding applied may lose some
+            so categorical columns that have one-hot encoding applied may lose some
             of their encoded columns with the default parameters.
 
         Args:

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -74,10 +74,11 @@ class FeatureSelector(Transformer):
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
         """Updates pipeline parameters to not drop any features based off of feature importance.
 
-        Note:
             This is needed, because fast mode refits cloned pipelines on single columns,
             so categorical columns that have one-hot encoding applied may lose some
-            of their encoded columns with the default parameters.
+            of their encoded columns with the default parameters. Therefore, we update the
+            parameters here to not drop any columns, and use the original
+            pipeline to determine if that feature gets dropped or not.
 
         Args:
             X (pd.DataFrame): Holdout data being used for partial dependence calculations.
@@ -86,9 +87,7 @@ class FeatureSelector(Transformer):
 
         Return:
             pipeline_parameters (dict): Pipeline parameters updated to allow the FeatureSelector component
-                to not drop any features. This is needed because the cloned pipeline that uses these features
-                will be fit on a single column, and we do not want to drop that column. We can use the original
-                pipeline to determine if that feature gets dropped or not.
+                to not drop any features.
         """
         # Raise the percent of features we want to keep to not lose any
         pipeline_parameters[self.name]["percent_features"] = 1.0

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -83,6 +83,12 @@ class FeatureSelector(Transformer):
             X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
+
+        Return:
+            pipeline_parameters (dict): Pipeline parameters updated to allow the FeatureSelector component
+                to not drop any features. This is needed because the cloned pipeline that uses these features
+                will be fit on a single column, and we do not want to drop that column. We can use the original
+                pipeline to determine if that feature gets dropped or not.
         """
         # Raise the percent of features we want to keep to not lose any
         pipeline_parameters[self.name]["percent_features"] = 1.0

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -131,7 +131,10 @@ class DFSTransformer(Transformer):
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
         """Determines whether or not a DFSTransformer component can be used with partial dependence's fast mode.
-            It can be used only when all of the features present in the ``features`` parameter are present
+
+        Note:
+            This component can be used with partial dependence fast mode only when
+            all of the features present in the ``features`` parameter are present
             in the DataFrame.
 
         Args:

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -128,3 +128,19 @@ class DFSTransformer(Transformer):
         partial_schema.metadata = {}
         feature_matrix.ww.init(schema=partial_schema)
         return feature_matrix
+
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        # --> add more descriptive docstrings to all of these utils
+        # If DFSTransformer is present, confirm features parameter is specified and all features are present
+        # in X
+        dfs_transformer = pipeline_parameters.get("DFS Transformer")
+        if dfs_transformer is not None:
+            dfs_features = dfs_transformer["features"]
+            X_cols = set(X.columns)
+            if dfs_features is None or any(
+                f.get_name() not in X_cols for f in dfs_features
+            ):
+                raise ValueError(
+                    "Cannot use fast mode with DFS Transformer when features are unspecified or not all present in X.",
+                )
+        return pipeline_parameters

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -130,9 +130,16 @@ class DFSTransformer(Transformer):
         return feature_matrix
 
     def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
-        # --> add more descriptive docstrings to all of these utils
-        # If DFSTransformer is present, confirm features parameter is specified and all features are present
-        # in X
+        """Determines whether or not a DFSTransformer component can be used with partial dependence's fast mode.
+            It can be used only when all of the features present in the ``features`` parameter are present
+            in the DataFrame.
+
+        Args:
+            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+            pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
+                used in partial dependence fast mode.
+
+        """
         dfs_transformer = pipeline_parameters.get("DFS Transformer")
         if dfs_transformer is not None:
             dfs_features = dfs_transformer["features"]

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -137,3 +137,20 @@ class Oversampler(BaseSampler):
         self._parameters["k_neighbors"] = neighbors
         sampler = sampler_class(**sampler_params, random_state=self.random_seed)
         self._component_obj = sampler
+
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+        """Updates pipeline parameters to not have categorical_features parameter set.
+
+        Note:
+            This is needed, because fast mode refits cloned pipelines on single columns,
+            and the `categorical_features` parameter should not be present when fitting the Oversampler,
+            as it is added as a parameter during fit.
+
+        Args:
+            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+            pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
+                used in partial dependence fast mode.
+        """
+        pipeline_parameters[self.name].pop("categorical_features", None)
+
+        return pipeline_parameters

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -23,6 +23,7 @@ class Oversampler(BaseSampler):
 
     name = "Oversampler"
     hyperparameter_ranges = {}
+    _can_be_used_for_fast_partial_dependence = False
     """{}"""
 
     def __init__(
@@ -138,19 +139,20 @@ class Oversampler(BaseSampler):
         sampler = sampler_class(**sampler_params, random_state=self.random_seed)
         self._component_obj = sampler
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
-        """Updates pipeline parameters to not have categorical_features parameter set.
+    # --> remember to remove, but also include in issue to handle this
+    # def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+    #     """Updates pipeline parameters to not have categorical_features parameter set.
 
-        Note:
-            This is needed, because fast mode refits cloned pipelines on single columns,
-            and the `categorical_features` parameter should not be present when fitting the Oversampler,
-            as it is added as a parameter during fit.
+    #     Note:
+    #         This is needed, because fast mode refits cloned pipelines on single columns,
+    #         and the `categorical_features` parameter should not be present when fitting the Oversampler,
+    #         as it is added as a parameter during fit.
 
-        Args:
-            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
-            pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
-                used in partial dependence fast mode.
-        """
-        pipeline_parameters[self.name].pop("categorical_features", None)
+    #     Args:
+    #         X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+    #         pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
+    #             used in partial dependence fast mode.
+    #     """
+    #     pipeline_parameters[self.name].pop("categorical_features", None)
 
-        return pipeline_parameters
+    #     return pipeline_parameters

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -138,21 +138,3 @@ class Oversampler(BaseSampler):
         self._parameters["k_neighbors"] = neighbors
         sampler = sampler_class(**sampler_params, random_state=self.random_seed)
         self._component_obj = sampler
-
-    # --> remember to remove, but also include in issue to handle this
-    # def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
-    #     """Updates pipeline parameters to not have categorical_features parameter set.
-
-    #     Note:
-    #         This is needed, because fast mode refits cloned pipelines on single columns,
-    #         and the `categorical_features` parameter should not be present when fitting the Oversampler,
-    #         as it is added as a parameter during fit.
-
-    #     Args:
-    #         X (pd.DataFrame): Holdout data being used for partial dependence calculations.
-    #         pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
-    #             used in partial dependence fast mode.
-    #     """
-    #     pipeline_parameters[self.name].pop("categorical_features", None)
-
-    #     return pipeline_parameters

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -667,7 +667,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         Returns:
             A new instance of this pipeline with identical components.
         """
-        # --> why is there no sertting of the threshold for binary?
+        # --> why is there no setting of the threshold for binary like there is in clone?
         return self.__class__(
             self.component_graph,
             parameters=parameters,

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -667,6 +667,7 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         Returns:
             A new instance of this pipeline with identical components.
         """
+        # --> why is there no sertting of the threshold for binary?
         return self.__class__(
             self.component_graph,
             parameters=parameters,

--- a/evalml/pipelines/pipeline_base.py
+++ b/evalml/pipelines/pipeline_base.py
@@ -667,7 +667,6 @@ class PipelineBase(ABC, metaclass=PipelineBaseMeta):
         Returns:
             A new instance of this pipeline with identical components.
         """
-        # --> why is there no setting of the threshold for binary like there is in clone?
         return self.__class__(
             self.component_graph,
             parameters=parameters,

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -987,7 +987,11 @@ def test_components_can_be_used_for_partial_dependence_fast_mode():
 
     # Expected number is hardcoded so that this test will fail when new components are added
     # It should be len(all_native_components) - num_invalid_for_pd_fast_mode
-    assert num_valid_for_pd_fast_mode == 61
+    if ProphetRegressor not in all_native_components:
+        expected_num_valid_for_pd_fast_mode = 61
+    else:
+        expected_num_valid_for_pd_fast_mode = 62
+    assert num_valid_for_pd_fast_mode == expected_num_valid_for_pd_fast_mode
 
 
 def test_estimator_check_for_fit(X_y_binary):

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -982,11 +982,12 @@ def test_components_can_be_used_for_partial_dependence_fast_mode():
     assert invalid_for_pd_fast_mode == [
         "Stacked Ensemble Regressor",
         "Stacked Ensemble Classifier",
+        "Oversampler",
     ]
 
     # Expected number is hardcoded so that this test will fail when new components are added
     # It should be len(all_native_components) - len(invalid_for_pd_fast_mode)
-    assert num_valid_for_pd_fast_mode == 62
+    assert num_valid_for_pd_fast_mode == 61
 
 
 def test_estimator_check_for_fit(X_y_binary):

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -986,7 +986,7 @@ def test_components_can_be_used_for_partial_dependence_fast_mode():
     ]
 
     # Expected number is hardcoded so that this test will fail when new components are added
-    # It should be len(all_native_components) - len(invalid_for_pd_fast_mode)
+    # It should be len(all_native_components) - num_invalid_for_pd_fast_mode
     assert num_valid_for_pd_fast_mode == 61
 
 

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -961,6 +961,34 @@ def test_default_parameters_raise_no_warnings(cls):
         assert len(w) == 0
 
 
+def test_components_can_be_used_for_partial_dependence_fast_mode():
+    """This test is intended to fail when new components are added to remind developers
+    to decide whether or not partial dependence fast mode should be allowed for the new component."""
+    all_native_components = all_components()
+
+    invalid_for_pd_fast_mode = [
+        cls.name
+        for cls in all_native_components
+        if not cls._can_be_used_for_fast_partial_dependence
+    ]
+    num_valid_for_pd_fast_mode = len(
+        [
+            cls.name
+            for cls in all_native_components
+            if cls._can_be_used_for_fast_partial_dependence
+        ],
+    )
+
+    assert invalid_for_pd_fast_mode == [
+        "Stacked Ensemble Regressor",
+        "Stacked Ensemble Classifier",
+    ]
+
+    # Expected number is hardcoded so that this test will fail when new components are added
+    # It should be len(all_native_components) - len(invalid_for_pd_fast_mode)
+    assert num_valid_for_pd_fast_mode == 62
+
+
 def test_estimator_check_for_fit(X_y_binary):
     class MockEstimatorObj:
         def __init__(self):

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2266,9 +2266,6 @@ def test_partial_dependence_after_dropped_grid_value_classification(
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
 
 
-# --> test with Select Columns Transformer
-
-
 def test_pd_select_cols_transformer_specified_feature_not_selected():
     """Confirms that If a column isn't in the column selector but is the specified feature to
     calculate partial dependence for, that the results are as expected for the optimized implementation.
@@ -2384,3 +2381,5 @@ def test_pd_drop_cols_transformer_specified_feature_not_selected():
 #     # For each estimator, create a pipeline
 
 #     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
+
+# --> test case when one of the specified features (mult feats) isn't present but the other is

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2411,8 +2411,9 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
     )
     pipeline.fit(X, y)
 
-    # --> raise error or automatically fall back to slow mode?
-    error = "Cannot run fast mode with StackedEnsemble pipeline component."
+    error = re.escape(
+        f"cannot run partial dependence fast mode",
+    )
     with pytest.raises(
         PartialDependenceError,
         match=error,
@@ -2430,3 +2431,5 @@ def test_partial_dependence_with_invalid_components():
 
 
 # --> test case when one of the specified features (mult feats) isn't present but the other is
+# --> we need a test that will fail whenever a new component is added and it doesn't work with pd, so users have to handle it themselves or mark it incompatible with fast mode
+# --> test no features set for partial dependence

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2605,3 +2605,29 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
         match=error,
     ):
         partial_dependence(pipeline, X, features=0, grid_resolution=5, fast_mode=True)
+
+
+def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
+    # --> confirm oversampling isn't a thing with regression pipelines
+    X, y = X_y_binary
+    pipeline = BinaryClassificationPipeline(
+        component_graph={
+            "Oversampler": ["Oversampler", "X", "y"],
+            "Standard Scaler": ["Standard Scaler", "Oversampler.x", "Oversampler.y"],
+            "Logistic Regression Classifier": [
+                "Logistic Regression Classifier",
+                "Standard Scaler.x",
+                "Oversampler.y",
+            ],
+        },
+    )
+
+    pipeline.fit(X, y)
+    error = re.escape(
+        f"cannot run partial dependence fast mode",
+    )
+    with pytest.raises(
+        PartialDependenceError,
+        match=error,
+    ):
+        partial_dependence(pipeline, X, features=0, grid_resolution=5, fast_mode=True)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -1,5 +1,4 @@
 import re
-import timeit
 from pdb import set_trace
 from unittest.mock import patch
 
@@ -2222,10 +2221,7 @@ def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
         ],
     )
     pipeline.fit(X, y)
-    # set_trace()
 
-    # --> broken with "day" and "time" bc they're dropped or have dropped values
-    # --> works with "total_bill" bc it's not dropped
     old_part_dep = partial_dependence(pipeline, X, features="time")
     new_part_dep = partial_dependence(
         pipeline,
@@ -2237,7 +2233,9 @@ def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
 
 
-def test_partial_dependence_after_dropped_grid_value(X_y_categorical_regression):
+def test_partial_dependence_after_dropped_grid_value_regression(
+    X_y_categorical_regression,
+):
     X, y = X_y_categorical_regression
 
     pipeline = RegressionPipeline(
@@ -2249,15 +2247,39 @@ def test_partial_dependence_after_dropped_grid_value(X_y_categorical_regression)
         ],
     )
     pipeline.fit(X, y)
-    # set_trace()
 
-    # --> broken with "day" and "time" bc they're dropped or have dropped values
-    # --> works with "total_bill" bc it's not dropped
     old_part_dep = partial_dependence(pipeline, X, features="day")
     new_part_dep = partial_dependence(
         pipeline,
         X,
         features="day",
+        use_new=True,
+    )
+
+    pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
+
+
+def test_partial_dependence_after_dropped_grid_value_classification(
+    X_y_categorical_classification,
+):
+    # --> maybe this and test above should be one test with a fixture
+    X, y = X_y_categorical_classification
+
+    pipeline = BinaryClassificationPipeline(
+        [
+            "Imputer",
+            "One Hot Encoder",
+            "RF Classifier Select From Model",
+            "Random Forest Classifier",
+        ],
+    )
+    pipeline.fit(X, y)
+
+    old_part_dep = partial_dependence(pipeline, X, features="Cabin")
+    new_part_dep = partial_dependence(
+        pipeline,
+        X,
+        features="Cabin",
         use_new=True,
     )
 

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2716,9 +2716,7 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
     )
     pipeline.fit(X, y)
 
-    error = re.escape(
-        f"cannot run partial dependence fast mode",
-    )
+    error = "cannot run partial dependence fast mode"
     with pytest.raises(
         PartialDependenceError,
         match=error,
@@ -2749,9 +2747,7 @@ def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
     )
 
     pipeline.fit(X, y)
-    error = re.escape(
-        f"cannot run partial dependence fast mode",
-    )
+    error = "cannot run partial dependence fast mode"
     with pytest.raises(
         PartialDependenceError,
         match=error,

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -84,8 +84,8 @@ def test_partial_dependence_problem_types(
         features=0,
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -117,8 +117,8 @@ def test_partial_dependence_string_feature_name(
         features="mean radius",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -153,8 +153,8 @@ def test_partial_dependence_with_non_numeric_columns(
         X,
         features="numeric",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -169,8 +169,8 @@ def test_partial_dependence_with_non_numeric_columns(
         X,
         features="string",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -218,8 +218,8 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="store_id",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -256,8 +256,8 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="region",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -302,8 +302,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         X,
         features=("store_id", "country"),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -325,8 +325,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         features=("store_id", "amount"),
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -348,8 +348,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         features=("amount", "store_id"),
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -396,8 +396,8 @@ def test_partial_dependence_catboost(problem_type, X_y_binary, X_y_multi):
         features=0,
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -424,8 +424,8 @@ def test_partial_dependence_catboost(problem_type, X_y_binary, X_y_multi):
         X,
         features="string",
         fast_mode=True,
-        X_training=X,
-        y_training=y_small,
+        X_train=X,
+        y_train=y_small,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -472,8 +472,8 @@ def test_partial_dependence_xgboost_feature_names(
         features="<[0]",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -487,8 +487,8 @@ def test_partial_dependence_xgboost_feature_names(
         features=1,
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -524,8 +524,8 @@ def test_partial_dependence_multiclass(
         features="magnesium",
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, fast_part_dep)
 
@@ -547,8 +547,8 @@ def test_partial_dependence_multiclass(
         features=("magnesium", "alcohol"),
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
 
@@ -579,8 +579,8 @@ def test_partial_dependence_multiclass(
         grid_resolution=grid_resolution,
         kind="both",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
     for i, ice_df in enumerate(two_way_ice_data):
@@ -620,8 +620,8 @@ def test_partial_dependence_multiclass_numeric_labels(
         features=1,
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, fast_part_dep)
 
@@ -643,8 +643,8 @@ def test_partial_dependence_multiclass_numeric_labels(
         features=(1, 2),
         grid_resolution=grid_resolution,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
 
@@ -759,8 +759,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features / 2),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -780,8 +780,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -801,8 +801,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features * 2),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -826,8 +826,8 @@ def test_partial_dependence_ice_plot(logistic_regression_binary_pipeline):
         features="a",
         kind="both",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(avg_pred, fast_avg_pred)
     pd.testing.assert_frame_equal(ind_preds, fast_ind_preds)
@@ -843,8 +843,8 @@ def test_partial_dependence_ice_plot(logistic_regression_binary_pipeline):
         features="b",
         kind="individual",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(ind_preds, fast_ind_preds)
 
@@ -878,8 +878,8 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
         grid_resolution=5,
         kind="both",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(avg_pred, fast_avg_pred)
     for i, ice_df in enumerate(ind_preds):
@@ -907,8 +907,8 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
         grid_resolution=5,
         kind="individual",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     for i, ice_df in enumerate(ind_preds):
         new_ice_df = fast_ind_preds[i]
@@ -977,8 +977,8 @@ def test_graph_partial_dependence(
         features="mean radius",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
 
@@ -1063,8 +1063,8 @@ def test_graph_two_way_partial_dependence(
         features=("mean radius", "mean area"),
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1116,8 +1116,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "region"),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1143,8 +1143,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "lat"),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1170,8 +1170,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "lat"),
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1402,8 +1402,8 @@ def test_partial_dependence_percentile_errors(
         percentiles=(0.01, 0.96),
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1688,8 +1688,8 @@ def test_partial_dependence_datetime(
         features="dt_column",
         grid_resolution=grid,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1713,8 +1713,8 @@ def test_partial_dependence_datetime(
         features=20,
         grid_resolution=grid,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1831,8 +1831,8 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
         features="amount",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -1846,8 +1846,8 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
         features="provider",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -1946,8 +1946,8 @@ def test_graph_partial_dependence_ice_plot(
         grid_resolution=5,
         kind="both",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(avg_dep_data, fast_avg_dep_data)
     pd.testing.assert_frame_equal(ind_dep_data, fast_ind_dep_data)
@@ -2008,8 +2008,8 @@ def test_graph_partial_dependence_ice_plot(
         grid_resolution=5,
         kind="individual",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(ind_dep_data, fast_ind_dep_data)
 
@@ -2200,8 +2200,8 @@ def test_partial_dependence_datetime_extra(
         features="date_column",
         grid_resolution=10,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2220,8 +2220,8 @@ def test_partial_dependence_datetime_extra(
         features=20,
         grid_resolution=10,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2269,8 +2269,8 @@ def test_partial_dependence_not_allowed_types(types, cols, expected_cols):
         cols,
         grid_resolution=2,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
 
     pd.testing.assert_frame_equal(s, fast_s)
@@ -2307,8 +2307,8 @@ def test_partial_dependence_categorical_nan(fraud_100):
         features="provider",
         grid_resolution=GRID_RESOLUTION,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -2328,8 +2328,8 @@ def test_partial_dependence_categorical_nan(fraud_100):
         features=("amount", "provider"),
         grid_resolution=GRID_RESOLUTION,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(dep2way, fast_dep2way)
 
@@ -2384,8 +2384,8 @@ def test_partial_dependence_preserves_woodwork_schema(mock_predict_proba, fraud_
         "card_id",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
 
     assert all(
@@ -2427,8 +2427,8 @@ def test_partial_dependence_does_not_return_all_nan_grid():
         "a",
         grid_resolution=4,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -2489,8 +2489,8 @@ def test_partial_dependence_fast_mode_after_dropped_feature(X_y_categorical_regr
         X,
         features="time",
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -2544,8 +2544,8 @@ def test_partial_dependence_fast_mode_after_dropped_grid_value(
         X,
         features=feature,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -2585,8 +2585,8 @@ def test_pd_fast_mode_select_cols_transformer_specified_feature_not_selected():
         features="cats",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2625,8 +2625,8 @@ def test_pd_fast_mode_drop_cols_transformer_specified_feature_not_selected():
         features="cats",
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
-        y_training=y,
+        X_train=X,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2670,8 +2670,8 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
             features=1,
             grid_resolution=5,
             fast_mode=True,
-            X_training=X,
-            y_training=y,
+            X_train=X,
+            y_train=y,
         )
 
     # If we pass the feature matrix into the same pipeline, though, DFS transformer will be no op, so pd should match
@@ -2684,8 +2684,8 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
         features=1,
         grid_resolution=5,
         fast_mode=True,
-        X_training=X_fm,
-        y_training=y,
+        X_train=X_fm,
+        y_train=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2729,8 +2729,8 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
             features=0,
             grid_resolution=5,
             fast_mode=True,
-            X_training=X,
-            y_training=y,
+            X_train=X,
+            y_train=y,
         )
 
 
@@ -2762,12 +2762,12 @@ def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
             features=0,
             grid_resolution=5,
             fast_mode=True,
-            X_training=X,
-            y_training=y,
+            X_train=X,
+            y_train=y,
         )
 
 
-def test_partial_dependence_fast_mode_errors_if_training_data_not_passed(
+def test_partial_dependence_fast_mode_errors_if_train(
     X_y_regression,
     linear_regression_pipeline,
 ):
@@ -2784,7 +2784,7 @@ def test_partial_dependence_fast_mode_errors_if_training_data_not_passed(
             X,
             features=0,
             fast_mode=True,
-            X_training=X,
+            X_train=X,
         )
 
     with pytest.raises(
@@ -2796,5 +2796,5 @@ def test_partial_dependence_fast_mode_errors_if_training_data_not_passed(
             X,
             features=0,
             fast_mode=True,
-            y_training=y,
+            y_train=y,
         )

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2684,7 +2684,7 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
         features=1,
         grid_resolution=5,
         fast_mode=True,
-        X_training=X,
+        X_training=X_fm,
         y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -2735,7 +2735,6 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
 
 
 def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
-    # --> confirm oversampling isn't a thing with regression pipelines
     X, y = X_y_binary
     pipeline = BinaryClassificationPipeline(
         component_graph={

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2221,3 +2221,31 @@ def test_partial_dependence_jupyter_graph_check(
         )
         assert len(graph_valid) == 0
         import_check.assert_called_with("ipywidgets", warning=True)
+
+
+def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
+    X, y = X_y_categorical_regression
+
+    pipeline = RegressionPipeline(
+        [
+            "Imputer",
+            "One Hot Encoder",
+            "RF Regressor Select From Model",
+            "Random Forest Regressor",
+        ],
+    )
+    pipeline.fit(X, y)
+    # set_trace()
+
+    # --> broken with "day" and "time" bc they're dropped or have dropped values
+    # --> works with "total_bill" bc it's not dropped
+    old_part_dep = partial_dependence(pipeline, X, features="day")
+    new_part_dep = partial_dependence(
+        pipeline,
+        X,
+        features="day",
+        use_new=True,
+        y=y,
+    )
+
+    pd.testing.assert_frame_equal(old_part_dep, new_part_dep)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -116,7 +116,7 @@ def test_partial_dependence_optimized_problem_types(
         X,
         features=0,
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -148,7 +148,7 @@ def test_partial_dependence_string_feature_name(
         X,
         features="mean radius",
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
@@ -205,13 +205,13 @@ def test_partial_dependence_transform_X_fully_ahead_regression(
         linear_regression_pipeline,
         X,
         features="also numeric",
-        use_new=False,
+        fast_mode=False,
     )
     new_pd_results = partial_dependence(
         linear_regression_pipeline,
         X,
         features="also numeric",
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_pd_results, new_pd_results)
@@ -235,7 +235,7 @@ def test_partial_dependence_optimization_catboost(X_y_binary):
         X,
         features=0,
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -259,7 +259,7 @@ def test_partial_dependence_optimization_catboost(X_y_binary):
         pipeline,
         X,
         features="string",
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -307,7 +307,7 @@ def test_partial_dependence_with_ww_category_columns(
         logistic_regression_binary_pipeline,
         X,
         features="store_id",
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -343,7 +343,7 @@ def test_partial_dependence_with_ww_category_columns(
         logistic_regression_binary_pipeline,
         X,
         features="region",
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -499,7 +499,7 @@ def test_partial_dependence_xgboost_feature_names(
         X,
         features="<[0]",
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -512,7 +512,7 @@ def test_partial_dependence_xgboost_feature_names(
         X,
         features=1,
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -547,7 +547,7 @@ def test_partial_dependence_multiclass_ah(
         X,
         features="magnesium",
         grid_resolution=grid_resolution,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, new_part_dep)
 
@@ -568,7 +568,7 @@ def test_partial_dependence_multiclass_ah(
         X,
         features=("magnesium", "alcohol"),
         grid_resolution=grid_resolution,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, new_part_dep)
 
@@ -598,7 +598,7 @@ def test_partial_dependence_multiclass_ah(
         features=("magnesium", "alcohol"),
         grid_resolution=grid_resolution,
         kind="both",
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, new_part_dep)
     for i, ice_df in enumerate(two_way_ice_data):
@@ -861,7 +861,7 @@ def test_random_forests_optimized(
             X,
             features=0,
             grid_resolution=5,
-            use_new=True,
+            fast_mode=True,
         )
 
         pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -2207,7 +2207,7 @@ def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
         pipeline,
         X,
         features="time",
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -2233,7 +2233,7 @@ def test_partial_dependence_after_dropped_grid_value_regression(
         pipeline,
         X,
         features="day",
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -2260,7 +2260,7 @@ def test_partial_dependence_after_dropped_grid_value_classification(
         pipeline,
         X,
         features="Cabin",
-        use_new=True,
+        fast_mode=True,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -2290,7 +2290,7 @@ def test_pd_select_cols_transformer_specified_feature_not_selected():
         X,
         features="cats",
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
 
@@ -2319,7 +2319,7 @@ def test_pd_drop_cols_transformer_specified_feature_not_selected():
         X,
         features="cats",
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
 
@@ -2362,7 +2362,7 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
             X,
             features=1,
             grid_resolution=5,
-            use_new=True,
+            fast_mode=True,
         )
 
     # If we pass the feature matrix into the same pipeline, though, DFS transformer will be no op, so pd should match
@@ -2374,7 +2374,7 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
         X_fm,
         features=1,
         grid_resolution=5,
-        use_new=True,
+        fast_mode=True,
     )
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
 
@@ -2418,7 +2418,7 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
         PartialDependenceError,
         match=error,
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=5, use_new=True)
+        partial_dependence(pipeline, X, features=0, grid_resolution=5, fast_mode=True)
 
 
 def test_partial_dependence_blocked_with_custom_component():

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -111,7 +111,6 @@ def test_partial_dependence_optimized_problem_types(
         features=0,
         grid_resolution=5,
         use_new=True,
-        y=y,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -144,7 +143,6 @@ def test_partial_dependence_string_feature_name(
         features="mean radius",
         grid_resolution=5,
         use_new=True,
-        y=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
@@ -208,7 +206,6 @@ def test_partial_dependence_transform_X_fully_ahead_regression(
         X,
         features="also numeric",
         use_new=True,
-        y=y,
     )
 
     pd.testing.assert_frame_equal(old_pd_results, new_pd_results)
@@ -233,7 +230,6 @@ def test_partial_dependence_optimization_catboost(X_y_binary):
         features=0,
         grid_resolution=5,
         use_new=True,
-        y=y,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -258,7 +254,6 @@ def test_partial_dependence_optimization_catboost(X_y_binary):
         X,
         features="string",
         use_new=True,
-        y=y_small,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -307,7 +302,6 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="store_id",
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -344,7 +338,6 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="region",
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -501,7 +494,6 @@ def test_partial_dependence_xgboost_feature_names(
         features="<[0]",
         grid_resolution=5,
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -515,7 +507,6 @@ def test_partial_dependence_xgboost_feature_names(
         features=1,
         grid_resolution=5,
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(part_dep, new_part_dep)
 
@@ -551,7 +542,6 @@ def test_partial_dependence_multiclass_ah(
         features="magnesium",
         grid_resolution=grid_resolution,
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, new_part_dep)
 
@@ -573,7 +563,6 @@ def test_partial_dependence_multiclass_ah(
         features=("magnesium", "alcohol"),
         grid_resolution=grid_resolution,
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, new_part_dep)
 
@@ -604,7 +593,6 @@ def test_partial_dependence_multiclass_ah(
         grid_resolution=grid_resolution,
         kind="both",
         use_new=True,
-        y=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, new_part_dep)
     for i, ice_df in enumerate(two_way_ice_data):
@@ -868,7 +856,6 @@ def test_random_forests_optimized(
             features=0,
             grid_resolution=5,
             use_new=True,
-            y=y,
         )
 
         pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
@@ -2245,7 +2232,6 @@ def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
         X,
         features="day",
         use_new=True,
-        y=y,
     )
 
     pd.testing.assert_frame_equal(old_part_dep, new_part_dep)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -84,6 +84,8 @@ def test_partial_dependence_problem_types(
         features=0,
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -115,6 +117,8 @@ def test_partial_dependence_string_feature_name(
         features="mean radius",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -149,6 +153,8 @@ def test_partial_dependence_with_non_numeric_columns(
         X,
         features="numeric",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -163,6 +169,8 @@ def test_partial_dependence_with_non_numeric_columns(
         X,
         features="string",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -210,6 +218,8 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="store_id",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -246,6 +256,8 @@ def test_partial_dependence_with_ww_category_columns(
         X,
         features="region",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -290,6 +302,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         X,
         features=("store_id", "country"),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -311,6 +325,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         features=("store_id", "amount"),
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -332,6 +348,8 @@ def test_two_way_partial_dependence_with_ww_category_columns(
         features=("amount", "store_id"),
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -378,6 +396,8 @@ def test_partial_dependence_catboost(problem_type, X_y_binary, X_y_multi):
         features=0,
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -399,7 +419,14 @@ def test_partial_dependence_catboost(problem_type, X_y_binary, X_y_multi):
     check_partial_dependence_dataframe(pipeline, part_dep, grid_size=3)
     assert not part_dep.isnull().all().all()
 
-    fast_part_dep = partial_dependence(pipeline, X, features="string", fast_mode=True)
+    fast_part_dep = partial_dependence(
+        pipeline,
+        X,
+        features="string",
+        fast_mode=True,
+        X_training=X,
+        y_training=y_small,
+    )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
 
@@ -445,6 +472,8 @@ def test_partial_dependence_xgboost_feature_names(
         features="<[0]",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -458,6 +487,8 @@ def test_partial_dependence_xgboost_feature_names(
         features=1,
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -493,6 +524,8 @@ def test_partial_dependence_multiclass(
         features="magnesium",
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, fast_part_dep)
 
@@ -514,6 +547,8 @@ def test_partial_dependence_multiclass(
         features=("magnesium", "alcohol"),
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
 
@@ -544,6 +579,8 @@ def test_partial_dependence_multiclass(
         grid_resolution=grid_resolution,
         kind="both",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
     for i, ice_df in enumerate(two_way_ice_data):
@@ -583,6 +620,8 @@ def test_partial_dependence_multiclass_numeric_labels(
         features=1,
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(one_way_part_dep, fast_part_dep)
 
@@ -604,6 +643,8 @@ def test_partial_dependence_multiclass_numeric_labels(
         features=(1, 2),
         grid_resolution=grid_resolution,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(two_way_part_dep, fast_part_dep)
 
@@ -718,6 +759,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features / 2),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -737,6 +780,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -756,6 +801,8 @@ def test_partial_dependence_more_categories_than_grid_resolution(
         "currency",
         grid_resolution=round(num_cat_features * 2),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -779,6 +826,8 @@ def test_partial_dependence_ice_plot(logistic_regression_binary_pipeline):
         features="a",
         kind="both",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(avg_pred, fast_avg_pred)
     pd.testing.assert_frame_equal(ind_preds, fast_ind_preds)
@@ -794,6 +843,8 @@ def test_partial_dependence_ice_plot(logistic_regression_binary_pipeline):
         features="b",
         kind="individual",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(ind_preds, fast_ind_preds)
 
@@ -827,6 +878,8 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
         grid_resolution=5,
         kind="both",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(avg_pred, fast_avg_pred)
     for i, ice_df in enumerate(ind_preds):
@@ -854,6 +907,8 @@ def test_two_way_partial_dependence_ice_plot(logistic_regression_binary_pipeline
         grid_resolution=5,
         kind="individual",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     for i, ice_df in enumerate(ind_preds):
         new_ice_df = fast_ind_preds[i]
@@ -922,6 +977,8 @@ def test_graph_partial_dependence(
         features="mean radius",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
 
@@ -1006,6 +1063,8 @@ def test_graph_two_way_partial_dependence(
         features=("mean radius", "mean area"),
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1057,6 +1116,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "region"),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1082,6 +1143,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "lat"),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1107,6 +1170,8 @@ def test_graph_two_way_partial_dependence_ww_categories(
         X,
         features=("country", "lat"),
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     fast_part_dep_data.drop(columns=["class_label"], inplace=True)
     pd.testing.assert_frame_equal(part_dep_data, fast_part_dep_data)
@@ -1337,6 +1402,8 @@ def test_partial_dependence_percentile_errors(
         percentiles=(0.01, 0.96),
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1621,6 +1688,8 @@ def test_partial_dependence_datetime(
         features="dt_column",
         grid_resolution=grid,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1644,6 +1713,8 @@ def test_partial_dependence_datetime(
         features=20,
         grid_resolution=grid,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -1760,6 +1831,8 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
         features="amount",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -1773,6 +1846,8 @@ def test_partial_dependence_respect_grid_resolution(fraud_100):
         features="provider",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -1871,6 +1946,8 @@ def test_graph_partial_dependence_ice_plot(
         grid_resolution=5,
         kind="both",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(avg_dep_data, fast_avg_dep_data)
     pd.testing.assert_frame_equal(ind_dep_data, fast_ind_dep_data)
@@ -1931,6 +2008,8 @@ def test_graph_partial_dependence_ice_plot(
         grid_resolution=5,
         kind="individual",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(ind_dep_data, fast_ind_dep_data)
 
@@ -2121,6 +2200,8 @@ def test_partial_dependence_datetime_extra(
         features="date_column",
         grid_resolution=10,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2139,6 +2220,8 @@ def test_partial_dependence_datetime_extra(
         features=20,
         grid_resolution=10,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2180,7 +2263,16 @@ def test_partial_dependence_not_allowed_types(types, cols, expected_cols):
     s = partial_dependence(pl, X, cols, grid_resolution=2)
     assert not s.isnull().any().any()
 
-    fast_s = partial_dependence(pl, X, cols, grid_resolution=2, fast_mode=True)
+    fast_s = partial_dependence(
+        pl,
+        X,
+        cols,
+        grid_resolution=2,
+        fast_mode=True,
+        X_training=X,
+        y_training=y,
+    )
+
     pd.testing.assert_frame_equal(s, fast_s)
 
 
@@ -2215,6 +2307,8 @@ def test_partial_dependence_categorical_nan(fraud_100):
         features="provider",
         grid_resolution=GRID_RESOLUTION,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -2234,6 +2328,8 @@ def test_partial_dependence_categorical_nan(fraud_100):
         features=("amount", "provider"),
         grid_resolution=GRID_RESOLUTION,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(dep2way, fast_dep2way)
 
@@ -2282,7 +2378,16 @@ def test_partial_dependence_preserves_woodwork_schema(mock_predict_proba, fraud_
         for call_args in mock_predict_proba.call_args_list
     )
 
-    _ = partial_dependence(pl, X_test, "card_id", grid_resolution=5, fast_mode=True)
+    _ = partial_dependence(
+        pl,
+        X_test,
+        "card_id",
+        grid_resolution=5,
+        fast_mode=True,
+        X_training=X,
+        y_training=y,
+    )
+
     assert all(
         call_args[0][0].ww.schema == X_test.ww.schema
         for call_args in mock_predict_proba.call_args_list
@@ -2322,6 +2427,8 @@ def test_partial_dependence_does_not_return_all_nan_grid():
         "a",
         grid_resolution=4,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(dep, fast_dep)
 
@@ -2382,6 +2489,8 @@ def test_partial_dependence_fast_mode_after_dropped_feature(X_y_categorical_regr
         X,
         features="time",
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -2435,6 +2544,8 @@ def test_partial_dependence_fast_mode_after_dropped_grid_value(
         X,
         features=feature,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
 
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
@@ -2474,6 +2585,8 @@ def test_pd_fast_mode_select_cols_transformer_specified_feature_not_selected():
         features="cats",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2512,6 +2625,8 @@ def test_pd_fast_mode_drop_cols_transformer_specified_feature_not_selected():
         features="cats",
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2555,6 +2670,8 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
             features=1,
             grid_resolution=5,
             fast_mode=True,
+            X_training=X,
+            y_training=y,
         )
 
     # If we pass the feature matrix into the same pipeline, though, DFS transformer will be no op, so pd should match
@@ -2567,6 +2684,8 @@ def test_pd_dfs_transformer_fast_mode_works_only_when_features_present(X_y_binar
         features=1,
         grid_resolution=5,
         fast_mode=True,
+        X_training=X,
+        y_training=y,
     )
     pd.testing.assert_frame_equal(part_dep, fast_part_dep)
 
@@ -2604,7 +2723,15 @@ def test_partial_dependence_fast_mode_ensemble_pipeline_blocked(
         PartialDependenceError,
         match=error,
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=5, fast_mode=True)
+        partial_dependence(
+            pipeline,
+            X,
+            features=0,
+            grid_resolution=5,
+            fast_mode=True,
+            X_training=X,
+            y_training=y,
+        )
 
 
 def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
@@ -2630,4 +2757,45 @@ def test_partial_dependence_fast_mode_oversampler_blocked(X_y_binary):
         PartialDependenceError,
         match=error,
     ):
-        partial_dependence(pipeline, X, features=0, grid_resolution=5, fast_mode=True)
+        partial_dependence(
+            pipeline,
+            X,
+            features=0,
+            grid_resolution=5,
+            fast_mode=True,
+            X_training=X,
+            y_training=y,
+        )
+
+
+def test_partial_dependence_fast_mode_errors_if_training_data_not_passed(
+    X_y_regression,
+    linear_regression_pipeline,
+):
+    X, y = X_y_regression
+
+    linear_regression_pipeline.fit(X, y)
+    error = "Training data is required for partial dependence fast mode."
+    with pytest.raises(
+        PartialDependenceError,
+        match=error,
+    ):
+        partial_dependence(
+            linear_regression_pipeline,
+            X,
+            features=0,
+            fast_mode=True,
+            X_training=X,
+        )
+
+    with pytest.raises(
+        PartialDependenceError,
+        match=error,
+    ):
+        partial_dependence(
+            linear_regression_pipeline,
+            X,
+            features=0,
+            fast_mode=True,
+            y_training=y,
+        )

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2226,6 +2226,33 @@ def test_partial_dependence_after_dropped_feature(X_y_categorical_regression):
 
     # --> broken with "day" and "time" bc they're dropped or have dropped values
     # --> works with "total_bill" bc it's not dropped
+    old_part_dep = partial_dependence(pipeline, X, features="time")
+    new_part_dep = partial_dependence(
+        pipeline,
+        X,
+        features="time",
+        use_new=True,
+    )
+
+    pd.testing.assert_frame_equal(old_part_dep, new_part_dep)
+
+
+def test_partial_dependence_after_dropped_grid_value(X_y_categorical_regression):
+    X, y = X_y_categorical_regression
+
+    pipeline = RegressionPipeline(
+        [
+            "Imputer",
+            "One Hot Encoder",
+            "RF Regressor Select From Model",
+            "Random Forest Regressor",
+        ],
+    )
+    pipeline.fit(X, y)
+    # set_trace()
+
+    # --> broken with "day" and "time" bc they're dropped or have dropped values
+    # --> works with "total_bill" bc it's not dropped
     old_part_dep = partial_dependence(pipeline, X, features="day")
     new_part_dep = partial_dependence(
         pipeline,


### PR DESCRIPTION
Optimize partial dependence by avoiding the repeated transformations that come from running `pipeline.predict(X)` on the entire dataset for every grid value. This implementation transforms only the features whose partial dependence we are calculating by running `pipeline.transform_all_but_final(X[[single_col]])`, updating the transformed full X, and running `estimator.predict` on the updated transformed X. 

Has the following limitations:
- Fast mode cannot be used if the pipeline contains components that rely on more than one column to fit and transform data correctly.
  - If there is a way of handling such components for fast mode, it will exist in a `_handle_partial_dependence_fast_mode` method on the component itself.
  - Known components with this issue that have not been handled are `Oversampler`, `StackedEnsembleRegressor`, and `StackedEnsembleClassifier`. They are blocked with a `_can_be_used_for_fast_partial_dependence = False` property.
  - Known components that have handed this in some way are `DFSTransformer`, `RFClassifierSelectFromModel`, and `RFRegressorSelectFromModel`. 
- Requires that training X and y are passed in in order to properly refit cloned pipelines with the correct data. Spoke to @eccabay about how `X_train` is known to be needed in partial dependence parameters for future time series work. `y_train` is known to be needed for the oversampler, which is currently blocked, so we could in theory remove it for now, but I think keeping it is a good failsafe for any components that might use for fit and transform that we missed here.

Note that listed above are only the _known_ components with problems in fast mode. This implementation provides some great performance improvements, but there are risks, as it is not hard to accidentally add or change a component in such a way as to make it not compatible with fast mode. Therefore, it is an opt-in API. 