### PR TITLE
Cap Featuretools at < 1.15.0

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -38,8 +38,8 @@ outputs:
         - shap >=0.40.0
         - texttable >=1.6.2
         - woodwork >=0.19.0
-        - featuretools>=1.7.0
-        - nlp-primitives>=2.1.0,!=2.6.0
+        - featuretools>=1.7.0, <1.16.0
+        - nlp-primitives>=2.1.0,!=2.6.0, <2.9.0
         - python >=3.8.*
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Cap Featuretools at < 1.15.0 :pr:`3775`
     * Documentation Changes
     * Testing Changes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ install_requires =
     texttable >= 1.6.2
     woodwork >= 0.19.0
     dask >= 2021.10.0
-    nlp-primitives >= 2.1.0,!=2.6.0, < 2.8.0
-    featuretools >= 1.7.0, < 1.15.0
+    nlp-primitives >= 2.1.0,!=2.6.0, < 2.9.0
+    featuretools >= 1.7.0, < 1.16.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0
     kaleido >= 0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     texttable >= 1.6.2
     woodwork >= 0.19.0
     dask >= 2021.10.0
-    nlp-primitives >= 2.1.0,!=2.6.0
+    nlp-primitives >= 2.1.0,!=2.6.0, < 2.8.0
     featuretools >= 1.7.0, < 1.15.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     woodwork >= 0.19.0
     dask >= 2021.10.0
     nlp-primitives >= 2.1.0,!=2.6.0
-    featuretools >= 1.7.0
+    featuretools >= 1.7.0, < 1.15.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0
     kaleido >= 0.1.0


### PR DESCRIPTION
Cap featuretools at < 1.15.0 until we can address the failures in https://github.com/alteryx/evalml/pull/3774 due do dependency incompatibility.