### PR TITLE
Release v0.61.1.

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,6 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Fixed bug where ``TimeSeriesBaselinePipeline`` wouldn't preserve index name of input features :pr:`3788`
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -12,6 +11,14 @@ Release Notes
 .. warning::
 
     **Breaking Changes**
+
+
+**v0.61.1 Oct. 27, 2022**
+    * Fixes
+        * Fixed bug where ``TimeSeriesBaselinePipeline`` wouldn't preserve index name of input features :pr:`3788`
+        * Fixed bug in ``TimeSeriesBaselinePipeline`` referencing a static string instead of time index var :pr:`3788`
+    * Documentation Changes
+        * Updated Release Notes :pr:`3788`
 
 
 **v0.61.0 Oct. 25, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.61.0"
+__version__ = "0.61.1"


### PR DESCRIPTION
# v0.61.1 Oct. 27, 2022
### Fixes
- Fixed bug where ``TimeSeriesBaselinePipeline`` wouldn't preserve index name of input features #3788
- Fixed bug in ``TimeSeriesBaselinePipeline`` referencing a static string instead of time index var #3788
### Documentation Changes
- Updated Release Notes #3788