### PR TITLE
Update _get_decomposer to use stripped freq

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Fixed bug where invalid anchored or offset frequencies were including the ``STLDecomposer`` in pipelines :pr:`3794`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -231,10 +231,7 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
     components = []
     if is_time_series(problem_type) and is_regression(problem_type):
         time_index = get_time_index(X, y, None)
-        if time_index.freq.is_anchored:
-            freq = time_index.freq.name.split("-")[0]
-        else:
-            freq = time_index.freq.name
+        freq = time_index.freq.name.split("-")[0]
         if freq[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER:
             components.append(STLDecomposer)
     return components

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -231,8 +231,11 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
     components = []
     if is_time_series(problem_type) and is_regression(problem_type):
         time_index = get_time_index(X, y, None)
-        freq = time_index.freq
-        if freq not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER:
+        if time_index.freq.is_anchored:
+            freq = time_index.freq.name.split("-")[0]
+        else:
+            freq = time_index.freq.name
+        if freq[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER:
             components.append(STLDecomposer)
     return components
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -65,7 +65,7 @@ from evalml.problem_types import (
 from evalml.utils import get_time_index, infer_feature_types
 from evalml.utils.gen_utils import contains_all_ts_parameters
 
-_UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER = ["A", "T"]
+_UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER = ["A", "Y", "T", "AS", "YS"]
 
 
 def _get_label_encoder(X, y, problem_type, estimator_class, sampler_name=None):
@@ -232,7 +232,10 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
     if is_time_series(problem_type) and is_regression(problem_type):
         time_index = get_time_index(X, y, None)
         freq = time_index.freq.name.split("-")[0]
-        if freq[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER:
+        if (
+            freq[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER
+            and freq not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER
+        ):
             components.append(STLDecomposer)
     return components
 

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -208,7 +208,7 @@ def test_make_pipeline(
         ("YS", False),
     ],
 )
-def test_make_pipeline_controls_decomposer(
+def test_make_pipeline_controls_decomposer_time_series(
     problem_type,
     frequency,
     should_decomp,

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -197,7 +197,7 @@ def test_make_pipeline(
         ProblemTypes.TIME_SERIES_REGRESSION,
     ],
 )
-@pytest.mark.parametrize("frequency", ["D", "MS", "A", "T"])
+@pytest.mark.parametrize("frequency", ["D", "MS", "A", "T", "10T"])
 def test_make_pipeline_controls_decomposer(
     problem_type,
     frequency,
@@ -221,13 +221,12 @@ def test_make_pipeline_controls_decomposer(
     pipeline_class = _get_pipeline_base_class(problem_type)
     for estimator_class in estimators:
         if problem_type in estimator_class.supported_problem_types:
-
             pipeline = make_pipeline(X, y, estimator_class, problem_type, parameters)
             assert isinstance(pipeline, pipeline_class)
 
             if (
                 is_regression(problem_type)
-                and frequency not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER
+                and frequency[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER
             ):
                 assert "STL Decomposer" in pipeline.component_graph.compute_order
             else:

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -197,10 +197,22 @@ def test_make_pipeline(
         ProblemTypes.TIME_SERIES_REGRESSION,
     ],
 )
-@pytest.mark.parametrize("frequency", ["D", "MS", "A", "T", "10T"])
+@pytest.mark.parametrize(
+    "frequency, should_decomp",
+    [
+        ("D", True),
+        ("MS", True),
+        ("A", False),
+        ("T", False),
+        ("10T", False),
+        ("AS-JAN", False),
+        ("YS", False),
+    ],
+)
 def test_make_pipeline_controls_decomposer(
     problem_type,
     frequency,
+    should_decomp,
     get_test_data_from_configuration,
 ):
     X, y = get_test_data_from_configuration(
@@ -224,10 +236,7 @@ def test_make_pipeline_controls_decomposer(
             pipeline = make_pipeline(X, y, estimator_class, problem_type, parameters)
             assert isinstance(pipeline, pipeline_class)
 
-            if (
-                is_regression(problem_type)
-                and frequency[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER
-            ):
+            if is_regression(problem_type) and should_decomp:
                 assert "STL Decomposer" in pipeline.component_graph.compute_order
             else:
                 assert "STL Decomposer" not in pipeline.component_graph.compute_order

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -40,7 +40,6 @@ from evalml.pipelines.components.utils import (
     handle_component_class,
 )
 from evalml.pipelines.utils import (
-    _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER,
     _get_pipeline_base_class,
     _get_preprocessing_components,
     _make_pipeline_from_multiple_graphs,


### PR DESCRIPTION
Fixes bug where any invalid frequencies that were either offset (i.e. 10 minutes -> `10T`) or anchored (annually at the year end -> `A-DEC`) were not properly getting excluded from training with the decomposer.