### PR TITLE
Pin dask below 2022.10.1

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -26,7 +26,7 @@ outputs:
       run:
         - numpy >=1.21.0
         - pandas >=1.4.0
-        - dask >=2021.10.0
+        - dask >=2021.10.0,<2022.10.1
         - scipy >=1.5.0
         - scikit-learn >=1.1.2
         - scikit-optimize >=0.9.0

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -12,7 +12,7 @@ shap>=0.40.0
 statsmodels>=0.12.2
 texttable>=1.6.2
 woodwork>=0.19.0
-dask>=2021.10.0
+dask>=2021.10.0,<2022.10.1
 nlp-primitives>=2.2.0,!=2.6.0
 featuretools>=1.7.0
 networkx>=2.5,<2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Fixed bug with datetime conversion in ``get_time_index`` :pr:`3792`
         * Fixed bug where invalid anchored or offset frequencies were including the ``STLDecomposer`` in pipelines :pr:`3794`
     * Changes
+        * Capped dask at < 2022.10.1 :pr:`3797`
     * Documentation Changes
     * Testing Changes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     statsmodels >= 0.12.2
     texttable >= 1.6.2
     woodwork >= 0.19.0
-    dask >= 2021.10.0
+    dask >= 2021.10.0, < 2022.10.1
     nlp-primitives >= 2.2.0,!=2.6.0
     featuretools >= 1.7.0
     networkx >= 2.5, < 2.6


### PR DESCRIPTION
The most recent dask version seems to break a bunch of our unit tests. Pinning the version until we figure out what's up.