### PR TITLE
Add catch for invalid time index frequencies

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Fixes
         * Fixed bug with datetime conversion in ``get_time_index`` :pr:`3792`
         * Fixed bug where invalid anchored or offset frequencies were including the ``STLDecomposer`` in pipelines :pr:`3794`
+        * Fixed bug where irregular datetime frequencies were causing errors in ``make_pipeline`` :pr:`3800`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -231,6 +231,9 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
     components = []
     if is_time_series(problem_type) and is_regression(problem_type):
         time_index = get_time_index(X, y, None)
+        # If the time index frequency is uninferrable, STL will fail
+        if time_index.freq is None:
+            return components
         freq = time_index.freq.name.split("-")[0]
         if (
             freq[-1] not in _UNSUPPORTED_FREQUENCIES_STL_DECOMPOSER

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -206,6 +206,7 @@ def test_make_pipeline(
         ("10T", False),
         ("AS-JAN", False),
         ("YS", False),
+        (None, False),
     ],
 )
 def test_make_pipeline_controls_decomposer_time_series(
@@ -219,7 +220,16 @@ def test_make_pipeline_controls_decomposer_time_series(
         problem_type,
         column_names=["dates", "numerical"],
     )
-    X.ww["dates"] = pd.Series(pd.date_range("2000-02-03", periods=20, freq=frequency))
+    if frequency is None:
+        X.ww["dates"] = pd.Series(
+            pd.date_range("2000-02-03", periods=10, freq=frequency).append(
+                pd.date_range("2000-02-15", periods=10, freq=frequency),
+            ),
+        )
+    else:
+        X.ww["dates"] = pd.Series(
+            pd.date_range("2000-02-03", periods=20, freq=frequency),
+        )
     parameters = {
         "pipeline": {
             "time_index": "date",


### PR DESCRIPTION
Fixes a bug where uninferrable time indices were causing `make_pipeline` to fail