### PR TITLE
Upgrade evalml to latest xgboost

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -38,7 +38,7 @@ outputs:
         - shap >=0.40.0
         - texttable >=1.6.2
         - woodwork >=0.19.0
-        - featuretools>=1.7.0
+        - featuretools>=1.7.0,<1.17.0
         - nlp-primitives>=2.2.0,!=2.6.0
         - python >=3.8.*
         - networkx >=2.5,<2.6

--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - requirements-parser >=0.2.0
         - shap >=0.40.0
         - texttable >=1.6.2
-        - woodwork >=0.19.0
+        - woodwork >=0.19.0,<0.20.0
         - featuretools>=1.7.0,<1.17.0
         - nlp-primitives>=2.2.0,!=2.6.0
         - python >=3.8.*

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -14,5 +14,5 @@ texttable>=1.6.2
 woodwork>=0.19.0
 dask>=2021.10.0, !=2022.10.1
 nlp-primitives>=2.2.0,!=2.6.0
-featuretools>=1.7.0
+featuretools>=1.7.0,<1.17.0
 networkx>=2.5,<2.6

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -11,7 +11,7 @@ requirements-parser>=0.2.0
 shap>=0.40.0
 statsmodels>=0.12.2
 texttable>=1.6.2
-woodwork>=0.19.0
+woodwork>=0.19.0,<0.20.0
 dask>=2021.10.0, !=2022.10.1
 nlp-primitives>=2.2.0,!=2.6.0
 featuretools>=1.7.0,<1.17.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
         * Capped dask at < 2022.10.1 :pr:`3797`
         * Uncapped dask and excluded 2022.10.1 from viable versions :pr:`3803`
         * Removed all references to XGBoost's deprecated ``_use_label_encoder`` argument :pr:`3805`
+        * Capped featuretools at < 1.17.0 :pr:`3805`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
     * Changes
         * Capped dask at < 2022.10.1 :pr:`3797`
         * Uncapped dask and excluded 2022.10.1 from viable versions :pr:`3803`
+        * Removed all references to XGBoost's deprecated ``_use_label_encoder`` argument :pr:`3805`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/xgboost_classifier.py
@@ -76,15 +76,11 @@ class XGBoostClassifier(Estimator):
             "eval_metric": eval_metric,
         }
         parameters.update(kwargs)
-        if "use_label_encoder" in parameters:
-            parameters.pop("use_label_encoder")
         xgb_error_msg = (
             "XGBoost is not installed. Please install using `pip install xgboost.`"
         )
         xgb = import_or_raise("xgboost", error_msg=xgb_error_msg)
-        xgb_classifier = xgb.XGBClassifier(
-            use_label_encoder=False, random_state=random_seed, **parameters
-        )
+        xgb_classifier = xgb.XGBClassifier(random_state=random_seed, **parameters)
         self._label_encoder = None
         super().__init__(
             parameters=parameters,

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -1,5 +1,4 @@
 import string
-import warnings
 from unittest.mock import patch
 
 import numpy as np

--- a/evalml/tests/component_tests/test_xgboost_classifier.py
+++ b/evalml/tests/component_tests/test_xgboost_classifier.py
@@ -99,33 +99,6 @@ def test_xgboost_predict_all_boolean_columns():
     assert not preds.isna().any()
 
 
-@pytest.mark.xfail
-@pytest.mark.parametrize(
-    "y,label_encoder",
-    [
-        ([True, False, False], True),
-        ([1.0, 1.1, 1.1], True),
-        (["One", "Two", "Two"], True),
-        ([0, 1, 1], False),
-    ],
-)
-def test_xgboost_catch_warnings_label_encoder(y, label_encoder):
-    X = pd.DataFrame({"a": [True, False, True], "b": [True, False, True]})
-    y = pd.Series(y)
-    xgb = XGBoostClassifier()
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        xgb.fit(X, y)
-    assert len(w) == 0
-    preds = xgb.predict(X)
-    # make sure the predicted outputs are the same labels as the passed-in labels
-    assert preds[0] in y.values
-    if label_encoder:
-        assert xgb._label_encoder is not None
-        return
-    assert xgb._label_encoder is None
-
-
 @patch("xgboost.XGBClassifier.fit")
 @patch("xgboost.XGBClassifier.predict")
 @patch("xgboost.XGBClassifier.predict_proba")

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -3,7 +3,7 @@ click==8.1.3
 cloudpickle==2.2.0
 colorama==0.4.6
 dask==2022.10.2
-featuretools==1.17.0
+featuretools==1.16.2
 graphviz==0.20.1
 imbalanced-learn==0.9.1
 ipywidgets==8.0.2

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -26,7 +26,7 @@ scipy==1.8.1
 seaborn==0.12.1
 shap==0.41.0
 sktime==0.13.0
-statsmodels==0.13.2
+statsmodels==0.13.4
 texttable==1.6.4
 vowpalwabbit==9.5.0
 woodwork==0.19.0

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,9 +1,9 @@
-catboost==1.1
+catboost==1.1.1
 click==8.1.3
 cloudpickle==2.2.0
 colorama==0.4.6
 dask==2022.10.2
-featuretools==1.16.2
+featuretools==1.16.0
 graphviz==0.20.1
 imbalanced-learn==0.9.1
 ipywidgets==8.0.2

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -30,4 +30,4 @@ statsmodels==0.13.2
 texttable==1.6.4
 vowpalwabbit==9.5.0
 woodwork==0.19.0
-xgboost==1.6.2
+xgboost==1.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     shap >= 0.40.0
     statsmodels >= 0.12.2
     texttable >= 1.6.2
-    woodwork >= 0.19.0
+    woodwork >= 0.19.0, < 0.20.0
     dask >= 2021.10.0, !=2022.10.1
     nlp-primitives >= 2.2.0,!=2.6.0
     featuretools >= 1.7.0, < 1.17.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     woodwork >= 0.19.0
     dask >= 2021.10.0, !=2022.10.1
     nlp-primitives >= 2.2.0,!=2.6.0
-    featuretools >= 1.7.0
+    featuretools >= 1.7.0, < 1.17.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0
     kaleido >= 0.1.0


### PR DESCRIPTION
In their most recent release, xgboost deprecated their `_use_label_encoder` argument, which caused a number of our tests to fail. This removes the usage of that argument entirely.