### PR TITLE
Update Featuretools and Woodwork requirements

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -37,8 +37,8 @@ outputs:
         - requirements-parser >=0.2.0
         - shap >=0.40.0
         - texttable >=1.6.2
-        - woodwork >=0.19.0,<0.20.0
-        - featuretools>=1.7.0,<1.17.0
+        - woodwork >=0.19.0,!=0.20.0
+        - featuretools>=1.7.0
         - nlp-primitives>=2.2.0,!=2.6.0
         - python >=3.8.*
         - networkx >=2.5,<2.6

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -11,8 +11,8 @@ requirements-parser>=0.2.0
 shap>=0.40.0
 statsmodels>=0.12.2
 texttable>=1.6.2
-woodwork>=0.19.0,<0.20.0
+woodwork>=0.19.0,!=0.20.0
 dask>=2021.10.0, !=2022.10.1
 nlp-primitives>=2.2.0,!=2.6.0
-featuretools>=1.7.0,<1.17.0
+featuretools>=1.7.0
 networkx>=2.5,<2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Remove Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -3,7 +3,7 @@ click==8.1.3
 cloudpickle==2.2.0
 colorama==0.4.6
 dask==2022.10.2
-featuretools==1.16.0
+featuretools==1.17.0
 graphviz==0.20.1
 imbalanced-learn==0.9.1
 ipywidgets==8.0.2
@@ -26,7 +26,7 @@ scipy==1.8.1
 seaborn==0.12.1
 shap==0.41.0
 sktime==0.13.0
-statsmodels==0.13.4
+statsmodels==0.13.5
 texttable==1.6.4
 vowpalwabbit==9.5.0
 woodwork==0.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,10 +53,10 @@ install_requires =
     shap >= 0.40.0
     statsmodels >= 0.12.2
     texttable >= 1.6.2
-    woodwork >= 0.19.0, < 0.20.0
+    woodwork >= 0.19.0, !=0.20.0
     dask >= 2021.10.0, !=2022.10.1
     nlp-primitives >= 2.2.0,!=2.6.0
-    featuretools >= 1.7.0, < 1.17.0
+    featuretools >= 1.7.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0
     kaleido >= 0.1.0


### PR DESCRIPTION
Removes FT upper bound restriction and exclude WW 0.20.0.
