### PR TITLE
Bump min version for Featuretools (1.16.0), nlp-primitives (2.9.0) and Dask(2022.2.0)

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -38,8 +38,8 @@ outputs:
         - shap >=0.40.0
         - texttable >=1.6.2
         - woodwork >=0.19.0,!=0.20.0
-        - featuretools>=1.7.0
-        - nlp-primitives>=2.2.0,!=2.6.0
+        - featuretools>=1.16.0
+        - nlp-primitives>=2.9.0
         - python >=3.8.*
         - networkx >=2.5,<2.6
         - category_encoders >=2.2.2

--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -26,7 +26,7 @@ outputs:
       run:
         - numpy >=1.21.0
         - pandas >=1.4.0
-        - dask >=2021.10.0,!=2022.10.1
+        - dask >=2022.2.0,!=2022.10.1
         - scipy >=1.5.0
         - scikit-learn >=1.1.2
         - scikit-optimize >=0.9.0

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -12,7 +12,7 @@ shap>=0.40.0
 statsmodels>=0.12.2
 texttable>=1.6.2
 woodwork>=0.19.0,!=0.20.0
-dask>=2021.10.0, !=2022.10.1
+dask>=2022.2.0, !=2022.10.1
 nlp-primitives>=2.9.0
 featuretools>=1.16.0
 networkx>=2.5,<2.6

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -13,6 +13,6 @@ statsmodels>=0.12.2
 texttable>=1.6.2
 woodwork>=0.19.0,!=0.20.0
 dask>=2021.10.0, !=2022.10.1
-nlp-primitives>=2.2.0,!=2.6.0
-featuretools>=1.7.0
+nlp-primitives>=2.9.0
+featuretools>=1.16.0
 networkx>=2.5,<2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
     * Fixes
     * Changes
         * Remove Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`
+        * Update min Featuretools version to 0.16.0 and min nlp-primitives version to 2.9.0 :pr:`3823`
     * Documentation Changes
     * Testing Changes
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Release Notes
     * Fixes
     * Changes
         * Remove Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`
-        * Update min Featuretools version to 0.16.0 and min nlp-primitives version to 2.9.0 :pr:`3823`
+        * Update min Featuretools version to 0.16.0, min nlp-primitives version to 2.9.0 and min Dask version to 2022.2.0 :pr:`3823`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -3,7 +3,7 @@ category_encoders==2.2.2
 click==7.1.2
 cloudpickle==1.5.0
 colorama==0.4.4
-dask==2021.10.0
+dask==2022.2.0
 featuretools==1.16.0
 graphviz==0.13
 imbalanced-learn==0.9.1

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -4,7 +4,7 @@ click==7.1.2
 cloudpickle==1.5.0
 colorama==0.4.4
 dask==2021.10.0
-featuretools==1.7.0
+featuretools==1.16.0
 graphviz==0.13
 imbalanced-learn==0.9.1
 ipywidgets==7.5
@@ -13,7 +13,7 @@ lightgbm==2.3.1
 lime==0.2.0.1
 matplotlib==3.3.3
 networkx==2.5
-nlp-primitives==2.2.0
+nlp-primitives==2.9.0
 numpy==1.21.0
 pandas==1.4.0
 plotly==5.0.0

--- a/evalml/tests/dependency_update_check/minimum_test_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_test_requirements.txt
@@ -8,7 +8,7 @@ codecov==2.1.11
 colorama==0.4.4
 coverage[toml]==6.4
 dask==2021.10.0
-featuretools==1.7.0
+featuretools==1.16.0
 graphviz==0.13
 imbalanced-learn==0.9.1
 ipywidgets==7.5
@@ -18,7 +18,7 @@ lime==0.2.0.1
 matplotlib==3.3.3
 nbval==0.9.3
 networkx==2.5
-nlp-primitives==2.2.0
+nlp-primitives==2.9.0
 numpy==1.21.0
 pandas==1.4.0
 plotly==5.0.0

--- a/evalml/tests/dependency_update_check/minimum_test_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_test_requirements.txt
@@ -7,7 +7,7 @@ cloudpickle==1.5.0
 codecov==2.1.11
 colorama==0.4.4
 coverage[toml]==6.4
-dask==2021.10.0
+dask==2022.2.0
 featuretools==1.16.0
 graphviz==0.13
 imbalanced-learn==0.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ install_requires =
     texttable >= 1.6.2
     woodwork >= 0.19.0, !=0.20.0
     dask >= 2021.10.0, !=2022.10.1
-    nlp-primitives >= 2.2.0,!=2.6.0
-    featuretools >= 1.7.0
+    featuretools >= 1.16.0
+    nlp-primitives >= 2.9.0
     networkx >= 2.5, < 2.6
     plotly >= 5.0.0
     kaleido >= 0.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     statsmodels >= 0.12.2
     texttable >= 1.6.2
     woodwork >= 0.19.0, !=0.20.0
-    dask >= 2021.10.0, !=2022.10.1
+    dask >= 2022.2.0, !=2022.10.1
     featuretools >= 1.16.0
     nlp-primitives >= 2.9.0
     networkx >= 2.5, < 2.6


### PR DESCRIPTION
### Bump min version for Featuretools (1.16.0), nlp-primitives (2.9.0) and Dask(2022.2.0)

Increase minimum versions for Featuretools and nlp-primitives to prevent a situation where incompatible versions of these two libraries could be installed. Also required bumping Dask version since Featuretools 0.16.0 sets a more recent min for Dask than was specified.

Fixes #3822 
