### PR TITLE
Clean up decomposer index logic

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,10 +5,12 @@ Release Notes
     * Enhancements
     * Fixes
         * Fixed bug where ``TimeSeriesFeaturizer`` could not encode Ordinal columns with non numeric categories :pr:`3812`
-        * Update demo dataset links to point to new endpoint :pr:`3826`
+        * Updated demo dataset links to point to new endpoint :pr:`3826`
+        * Updated ``STLDecomposer`` to infer the time index frequency if it's not present :pr:`3829`
+        * Updated ``_drop_time_index`` to move the time index from X to both ``X.index`` and ``y.index`` :pr:`3829`
     * Changes
-        * Remove Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`
-        * Update min Featuretools version to 0.16.0, min nlp-primitives version to 2.9.0 and min Dask version to 2022.2.0 :pr:`3823`
+        * Removed Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`
+        * Updated min Featuretools version to 0.16.0, min nlp-primitives version to 2.9.0 and min Dask version to 2022.2.0 :pr:`3823`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/components/transformers/preprocessing/stl_decomposer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/stl_decomposer.py
@@ -161,7 +161,7 @@ class STLDecomposer(Decomposer):
             )
 
         # Save the frequency of the fitted series for checking against transform data.
-        self.frequency = y.index.freqstr
+        self.frequency = y.index.freqstr or pd.infer_freq(y.index)
 
         stl = STL(y, seasonal=self.seasonal_period)
         res = stl.fit()

--- a/evalml/pipelines/time_series_classification_pipelines.py
+++ b/evalml/pipelines/time_series_classification_pipelines.py
@@ -50,7 +50,7 @@ class TimeSeriesClassificationPipeline(TimeSeriesPipelineBase, ClassificationPip
             ValueError: If the number of unique classes in y are not appropriate for the type of pipeline.
         """
         self.frequency = infer_frequency(X[self.time_index])
-        X = self._drop_time_index(X, y)
+        X, y = self._drop_time_index(X, y)
         return super().fit(X, y)
 
     def predict_proba_in_sample(self, X_holdout, y_holdout, X_train, y_train):
@@ -169,8 +169,8 @@ class TimeSeriesClassificationPipeline(TimeSeriesPipelineBase, ClassificationPip
         """
         X, y = self._convert_to_woodwork(X, y)
         X_train, y_train = self._convert_to_woodwork(X_train, y_train)
-        X = self._drop_time_index(X, y)
-        X_train = self._drop_time_index(X_train, y_train)
+        X, y = self._drop_time_index(X, y)
+        X_train, y_train = self._drop_time_index(X_train, y_train)
         objectives = self.create_objectives(objectives)
         y_predicted, y_predicted_proba = self._compute_predictions(
             X,

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -154,7 +154,7 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
             y.ww.init(schema=y_schema)
             X.ww.set_index(self.time_index)
             X = X.ww.drop(self.time_index)
-        return X
+        return X, y
 
     def transform_all_but_final(self, X, y=None, X_train=None, y_train=None):
         """Transforms the data by applying all pre-processing components.
@@ -207,8 +207,8 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
             raise ValueError(
                 "Cannot call predict_in_sample() on a component graph because the final component is not an Estimator.",
             )
-        X = self._drop_time_index(X, y)
-        X_train = self._drop_time_index(X_train, y_train)
+        X, y = self._drop_time_index(X, y)
+        X_train, y_train = self._drop_time_index(X_train, y_train)
         target = infer_feature_types(y)
         features = self.transform_all_but_final(X, target, X_train, y_train)
         predictions = self._estimator_predict(features)
@@ -255,8 +255,8 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
             X_train.index[-X.shape[0] :],
             self.gap + X.shape[0],
         )
-        X = self._drop_time_index(X, pd.Series([0] * len(X)))
-        X_train = self._drop_time_index(X_train, y_train)
+        X, y = self._drop_time_index(X, pd.Series([0] * len(X)))
+        X_train, y_train = self._drop_time_index(X_train, y_train)
         X_train, y_train = self._convert_to_woodwork(X_train, y_train)
         y_holdout = self._create_empty_series(y_train, X.shape[0])
         y_holdout = infer_feature_types(y_holdout)

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -149,18 +149,10 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
     def _drop_time_index(self, X, y):
         """Helper method to drop the time index column from the data if DateTime Featurizer is not present."""
         if self.should_drop_time_index and self.time_index in X.columns:
-            X_schema = X.ww.schema
             y_schema = y.ww.schema
-            index_name = X.index.name
-            X = X.set_index(X[self.time_index])
-            X.index.name = index_name
             y = y.set_axis(X[self.time_index])
-            X.ww.init(schema=X_schema)
             y.ww.init(schema=y_schema)
-            if X.ww.schema is not None:
-                X = X.ww.drop([self.time_index])
-            else:
-                X = X.drop(columns=[self.time_index])
+            X.ww.set_index(self.time_index)
         return X
 
     def transform_all_but_final(self, X, y=None, X_train=None, y_train=None):

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -153,6 +153,7 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
             y = y.set_axis(X[self.time_index])
             y.ww.init(schema=y_schema)
             X.ww.set_index(self.time_index)
+            X = X.ww.drop(self.time_index)
         return X
 
     def transform_all_but_final(self, X, y=None, X_train=None, y_train=None):

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -150,16 +150,14 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
         """Helper method to drop the time index column from the data if DateTime Featurizer is not present."""
         if self.should_drop_time_index and self.time_index in X.columns:
             index_name = X.index.name
-            time_index = pd.DatetimeIndex(
-                X[self.time_index],
-                freq=pd.infer_freq(X[self.time_index]),
-            )
+            time_index = X[self.time_index]
 
             y_schema = y.ww.schema
             y = y.set_axis(time_index)
             y.ww.init(schema=y_schema)
 
             if X.ww.schema is not None:
+                X.ww.set_time_index(None)
                 X.ww.set_index(self.time_index)
                 X = X.ww.drop(self.time_index)
             else:

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -150,7 +150,7 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
         """Helper method to drop the time index column from the data if DateTime Featurizer is not present."""
         if self.should_drop_time_index and self.time_index in X.columns:
             index_name = X.index.name
-            time_index = X[self.time_index]
+            time_index = pd.DatetimeIndex(X[self.time_index], freq=self.frequency)
 
             y_schema = y.ww.schema
             y = y.set_axis(time_index)

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -65,7 +65,7 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
                 "Time Series Regression pipeline can only handle numeric target data!",
             )
 
-        X = self._drop_time_index(X, y)
+        X, y = self._drop_time_index(X, y)
         self._fit(X, y)
         return self
 

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -327,6 +327,7 @@ def test_decomposer_build_seasonal_signal(
     )
 
 
+@pytest.mark.parametrize("has_freq", [True, False])
 @pytest.mark.parametrize(
     "test_first_index",
     ["on period", "before period", "just after period", "mid period"],
@@ -334,6 +335,7 @@ def test_decomposer_build_seasonal_signal(
 def test_decomposer_projected_seasonality_integer_and_datetime(
     ts_data,
     test_first_index,
+    has_freq,
 ):
     period = 10
     test_first_index = {
@@ -345,7 +347,8 @@ def test_decomposer_projected_seasonality_integer_and_datetime(
 
     X, _, y = ts_data()
     datetime_index = pd.date_range(start="01-01-2002", periods=len(X), freq="M")
-    datetime_index.freq = None
+    if not has_freq:
+        datetime_index.freq = None
 
     y_integer = y.set_axis(pd.RangeIndex(len(X)))
     y_datetime = y.set_axis(datetime_index)

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -328,6 +328,66 @@ def test_decomposer_build_seasonal_signal(
 
 
 @pytest.mark.parametrize(
+    "test_first_index",
+    ["on period", "before period", "just after period", "mid period"],
+)
+def test_decomposer_projected_seasonality_integer_and_datetime(
+    ts_data,
+    test_first_index,
+):
+    period = 10
+    test_first_index = {
+        "on period": 3 * period,
+        "before period": 3 * period - 1,
+        "just after period": 3 * period + 1,
+        "mid period": 3 * period + 4,
+    }[test_first_index]
+
+    X, _, y = ts_data()
+    datetime_index = pd.date_range(start="01-01-2002", periods=len(X), freq="M")
+    datetime_index.freq = None
+
+    y_integer = y.set_axis(pd.RangeIndex(len(X)))
+    y_datetime = y.set_axis(datetime_index)
+
+    int_decomposer = STLDecomposer()
+    int_decomposer.fit(X, y_integer)
+
+    date_decomposer = STLDecomposer()
+    date_decomposer.fit(X, y_datetime)
+
+    # Synthesize a one-week long cyclic signal
+    single_period_seasonal_signal = np.sin(y[0:period] * 2 * np.pi / len(y[0:period]))
+
+    # Split the target data.  Since the period of this data is 7 days, we'll test
+    # when the cycle begins, an index before it begins, an index after it begins
+    # and in the middle of a cycle
+    y_int_test = y_integer[test_first_index:]
+    y_date_test = y_datetime[test_first_index:]
+
+    integer_projected_seasonality = int_decomposer._project_seasonal(
+        y_int_test,
+        single_period_seasonal_signal,
+        period,
+        int_decomposer.frequency,
+    )
+    datetime_projected_seasonality = date_decomposer._project_seasonal(
+        y_date_test,
+        single_period_seasonal_signal,
+        period,
+        date_decomposer.frequency,
+    )
+
+    # Make sure that the function extracted the correct portion of the repeating, full seasonal signal
+
+    pd.testing.assert_series_equal(
+        integer_projected_seasonality,
+        datetime_projected_seasonality,
+        check_index=False,
+    )
+
+
+@pytest.mark.parametrize(
     "decomposer_child_class",
     decomposer_list,
 )

--- a/evalml/tests/pipeline_tests/test_time_series_baseline_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_baseline_pipeline.py
@@ -69,7 +69,7 @@ def test_time_series_baseline(
 
     # TODO: Replace this with a better test that reproduces the issue with bike_sharing
     # causing the name of the internal X to shift.
-    X_train_t = clf._drop_time_index(X_train, y_train)
+    X_train_t, _ = clf._drop_time_index(X_train, y_train)
     assert X_train_t.index.name == X_train.index.name
 
     np.testing.assert_allclose(

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1072,7 +1072,7 @@ def test_binary_predict_pipeline_objective_mismatch(
         ValueError,
         match="Objective Precision Micro is not defined for time series binary classification.",
     ):
-        binary_pipeline.predict(X[30:32], "precision micro", X[:30], y[:30])
+        binary_pipeline.predict(X[30:35], "precision micro", X[:30], y[:30])
 
 
 @pytest.fixture

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1693,3 +1693,34 @@ def test_time_series_random_forest_transform_all_but_final(
         "z_features_rolling_mean",
         "target_rolling_mean",
     ]
+
+
+def test_drop_time_index_woodwork(ts_data, time_series_regression_pipeline_class):
+    X, _, y = ts_data()
+    X.ww.set_time_index("date")
+
+    pipeline = time_series_regression_pipeline_class(
+        parameters={
+            "pipeline": {
+                "gap": 0,
+                "max_delay": 1,
+                "time_index": "date",
+                "forecast_horizon": 1,
+            },
+            "Time Series Featurizer": {
+                "gap": 0,
+                "max_delay": 1,
+                "time_index": "date",
+                "forecast_horizon": 1,
+            },
+        },
+    )
+    pipeline.should_drop_time_index = True
+
+    X_t, y_t = pipeline._drop_time_index(X, y)
+    assert "date" not in X_t.columns
+    assert X_t.ww.schema is not None
+    assert y_t.ww.schema is not None
+
+    assert isinstance(X_t.index, pd.DatetimeIndex)
+    assert isinstance(y_t.index, pd.DatetimeIndex)

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1072,7 +1072,7 @@ def test_binary_predict_pipeline_objective_mismatch(
         ValueError,
         match="Objective Precision Micro is not defined for time series binary classification.",
     ):
-        binary_pipeline.predict(X[30:35], "precision micro", X[:30], y[:30])
+        binary_pipeline.predict(X[30:32], "precision micro", X[:30], y[:30])
 
 
 @pytest.fixture

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -1001,9 +1001,11 @@ def test_get_time_index_maintains_freq():
     time_idx = get_time_index(X, y, None)
     assert X.index.equals(time_idx)
     assert y.index.equals(time_idx)
+    assert time_idx.freq is not None
 
     X = pd.DataFrame({"date": idx})
     y = pd.Series(range(len(idx)))
     X.ww.init()
     y.ww.init()
     time_idx = get_time_index(X, y, None)
+    assert time_idx.freq is not None

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -693,7 +693,7 @@ def get_time_index(X: pd.DataFrame, y: pd.Series, time_index_name: str):
                     f"Too many Datetime features provided in data and provided time_index column {time_index_name} not present in data.",
                 )
 
-    if not isinstance(dt_col, pd.DatetimeIndex):
+    if not isinstance(dt_col, pd.DatetimeIndex) or dt_col.freq is None:
         dt_col = pd.DatetimeIndex(dt_col, freq="infer")
     time_index = dt_col.rename(y.index.name)
     return time_index


### PR DESCRIPTION
Ensures we set y's time index as well as X during `drop_time_index`, and saves the frequency in `STLDecomposer` so we don't mis-assume the frequency when determining the seasonality offset in `inverse_transform`