### PR TITLE
Allow engineered features in pipeline with dfs transfomer to have pd calculations done

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,9 @@ Release Notes
         * Updated demo dataset links to point to new endpoint :pr:`3826`
         * Updated ``STLDecomposer`` to infer the time index frequency if it's not present :pr:`3829`
         * Updated ``_drop_time_index`` to move the time index from X to both ``X.index`` and ``y.index`` :pr:`3829`
+        * Fixed bug where engineered features lost their origin attribute in partial dependence, causing it to fail :pr:`3830`
+        * Fixed bug partial dependence's DFS Transformer fast mode handling wouldn't work with multi output features :pr:`3830`
+        * Allowed target to be present and ignored in partial dependence's DFS Transformer fast mode handling  :pr:`3830`
     * Changes
         * Consolidated decomposition frequency validation logic to ``Decomposer`` class :pr:`3811`
         * Removed Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed :pr:`3813`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,7 +11,7 @@ Release Notes
         * Updated ``STLDecomposer`` to infer the time index frequency if it's not present :pr:`3829`
         * Updated ``_drop_time_index`` to move the time index from X to both ``X.index`` and ``y.index`` :pr:`3829`
         * Fixed bug where engineered features lost their origin attribute in partial dependence, causing it to fail :pr:`3830`
-        * Fixed bug partial dependence's DFS Transformer fast mode handling wouldn't work with multi output features :pr:`3830`
+        * Fixed bug where partial dependence's fast mode handling for the DFS Transformer wouldn't work with multi output features :pr:`3830`
         * Allowed target to be present and ignored in partial dependence's DFS Transformer fast mode handling  :pr:`3830`
     * Changes
         * Consolidated decomposition frequency validation logic to ``Decomposer`` class :pr:`3811`

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -35,8 +35,8 @@ def _get_cloned_feature_pipelines(
     new_parameters = pipeline.parameters
     for component in pipeline.component_graph.component_instances.values():
         new_parameters = component._handle_partial_dependence_fast_mode(
-            X_train,
             new_parameters,
+            X=X_train,
             target=pipeline.input_target_name,
         )
 

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -37,6 +37,7 @@ def _get_cloned_feature_pipelines(
         new_parameters = component._handle_partial_dependence_fast_mode(
             X_train,
             new_parameters,
+            target=pipeline.input_target_name,
         )
 
     # Create a fit pipeline for each feature

--- a/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
+++ b/evalml/model_understanding/_partial_dependence_fast_mode_utils.py
@@ -77,9 +77,7 @@ def _transform_single_feature(
             fit for it.
     """
     changed_col_df = pd.DataFrame({variable: part_dep_column})
-    changed_col_df.ww.init(
-        logical_types={variable: X.ww.logical_types[variable]},
-    )
+    changed_col_df.ww.init(schema=X.ww.schema.get_subset_schema([variable]))
 
     # Take the changed column and send it through transform by itself
     X_t_single_col = cloned_pipeline.transform_all_but_final(changed_col_df)

--- a/evalml/model_understanding/_partial_dependence_utils.py
+++ b/evalml/model_understanding/_partial_dependence_utils.py
@@ -318,8 +318,8 @@ def _partial_dependence_calculation(
                     X_eval.ww[variable] = ww.init_series(
                         part_dep_column,
                         logical_type=X_eval.ww.logical_types[variable],
+                        origin=X_eval.ww.columns[variable].origin,
                     )
-
             pred = prediction_method(X_eval)
             predictions.append(pred)
             # average over samples

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -103,14 +103,19 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     def _supported_by_list_API(cls):
         return not cls.modifies_target
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
+    def _handle_partial_dependence_fast_mode(
+        self,
+        pipeline_parameters,
+        X=None,
+        target=None,
+    ):
         """Determines whether or not a component can be used with partial dependence's fast mode.
 
         Args:
-            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
-            target (str): The target whose values we are trying to predict.
+            X (pd.DataFrame, optional): Holdout data being used for partial dependence calculations.
+            target (str, optional): The target whose values we are trying to predict.
         """
         if self._can_be_used_for_fast_partial_dependence:
             return pipeline_parameters

--- a/evalml/pipelines/components/component_base.py
+++ b/evalml/pipelines/components/component_base.py
@@ -103,13 +103,14 @@ class ComponentBase(ABC, metaclass=ComponentBaseMeta):
     def _supported_by_list_API(cls):
         return not cls.modifies_target
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
         """Determines whether or not a component can be used with partial dependence's fast mode.
 
         Args:
             X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
+            target (str): The target whose values we are trying to predict.
         """
         if self._can_be_used_for_fast_partial_dependence:
             return pipeline_parameters

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -71,7 +71,7 @@ class FeatureSelector(Transformer):
         """
         return self.fit(X, y).transform(X, y)
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
         """Updates pipeline parameters to not drop any features based off of feature importance.
 
             This is needed, because fast mode refits cloned pipelines on single columns,
@@ -84,6 +84,7 @@ class FeatureSelector(Transformer):
             X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
+            target (str): The target whose values we are trying to predict.
 
         Return:
             pipeline_parameters (dict): Pipeline parameters updated to allow the FeatureSelector component

--- a/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/feature_selector.py
@@ -71,7 +71,12 @@ class FeatureSelector(Transformer):
         """
         return self.fit(X, y).transform(X, y)
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
+    def _handle_partial_dependence_fast_mode(
+        self,
+        pipeline_parameters,
+        X=None,
+        target=None,
+    ):
         """Updates pipeline parameters to not drop any features based off of feature importance.
 
             This is needed, because fast mode refits cloned pipelines on single columns,
@@ -81,10 +86,10 @@ class FeatureSelector(Transformer):
             pipeline to determine if that feature gets dropped or not.
 
         Args:
-            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
-            target (str): The target whose values we are trying to predict.
+            X (pd.DataFrame, optional): Holdout data being used for partial dependence calculations.
+            target (str, optional): The target whose values we are trying to predict.
 
         Return:
             pipeline_parameters (dict): Pipeline parameters updated to allow the FeatureSelector component

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -59,9 +59,6 @@ class DFSTransformer(Transformer):
             ):
                 continue
 
-            # an identity feature whose cols are in X
-            # an engineered feature whose inputs are in X
-
             # If feature's required columns doesn't exist, skip feature
             input_cols = [f.get_name() for f in feature.base_features]
             if not isinstance(feature, IdentityFeature) and not set(

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -59,6 +59,9 @@ class DFSTransformer(Transformer):
             ):
                 continue
 
+            # an identity feature whose cols are in X
+            # an engineered feature whose inputs are in X
+
             # If feature's required columns doesn't exist, skip feature
             input_cols = [f.get_name() for f in feature.base_features]
             if not isinstance(feature, IdentityFeature) and not set(
@@ -129,7 +132,7 @@ class DFSTransformer(Transformer):
         feature_matrix.ww.init(schema=partial_schema)
         return feature_matrix
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters):
+    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
         """Determines whether or not a DFSTransformer component can be used with partial dependence's fast mode.
 
         Note:
@@ -146,9 +149,17 @@ class DFSTransformer(Transformer):
         dfs_transformer = pipeline_parameters.get("DFS Transformer")
         if dfs_transformer is not None:
             dfs_features = dfs_transformer["features"]
+            # remove the target if it's there
+            dfs_feature_names = [
+                name
+                for feature in dfs_features
+                for name in feature.get_feature_names()
+                if name != target
+            ]
             X_cols = set(X.columns)
+
             if dfs_features is None or any(
-                f.get_name() not in X_cols for f in dfs_features
+                name not in X_cols for name in dfs_feature_names
             ):
                 raise ValueError(
                     "Cannot use fast mode with DFS Transformer when features are unspecified or not all present in X.",

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -129,8 +129,8 @@ class DFSTransformer(Transformer):
         feature_matrix.ww.init(schema=partial_schema)
         return feature_matrix
 
-    def _handle_partial_dependence_fast_mode(self, X, pipeline_parameters, target):
-        """Determines whether or not a DFSTransformer component can be used with partial dependence's fast mode.
+    def _handle_partial_dependence_fast_mode(self, pipeline_parameters, X, target):
+        """Determines whether or not a DFS Transformer component can be used with partial dependence's fast mode.
 
         Note:
             This component can be used with partial dependence fast mode only when
@@ -138,12 +138,12 @@ class DFSTransformer(Transformer):
             in the DataFrame.
 
         Args:
-            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
-            target (str): The target whose values we are trying to predict. May be present in the
-                list of features in the DFS Transformer's parameters, in which case we should ignore it.
-
+            X (pd.DataFrame): Holdout data being used for partial dependence calculations.
+            target (str): The target whose values we are trying to predict. This is used
+                to know which column to ignore if the target column is present in the list of features
+                in the DFS Transformer's parameters
         """
         dfs_transformer = pipeline_parameters.get("DFS Transformer")
         if dfs_transformer is not None:

--- a/evalml/pipelines/components/transformers/preprocessing/featuretools.py
+++ b/evalml/pipelines/components/transformers/preprocessing/featuretools.py
@@ -144,6 +144,8 @@ class DFSTransformer(Transformer):
             X (pd.DataFrame): Holdout data being used for partial dependence calculations.
             pipeline_parameters (dict): Pipeline parameters that will be used to create the pipelines
                 used in partial dependence fast mode.
+            target (str): The target whose values we are trying to predict. May be present in the
+                list of features in the DFS Transformer's parameters, in which case we should ignore it.
 
         """
         dfs_transformer = pipeline_parameters.get("DFS Transformer")

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2850,11 +2850,9 @@ def test_partial_dependence_dfs_transformer_handling_with_multi_output_primitive
 ):
     X = df_with_url_and_email
     y = pd.Series(range(len(X)))
-    X.columns = X.columns.astype(str)
     X.ww.name = "X"
     X.ww.set_index("numeric")
-    # --> failing for somereason with this col, so dropping it
-    X.ww.pop("categorical")
+    X.ww.set_types(logical_types={"categorical": "NaturalLanguage"})
 
     es = ft.EntitySet()
     es = es.add_dataframe(

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2828,13 +2828,12 @@ def test_partial_dependence_on_engineered_feature_with_dfs_transformer_and_engin
     engineered_feature = "ABSOLUTE(1)"
     assert X_fm.ww.columns[engineered_feature].origin == "engineered"
 
-    pipeline = pipeline.clone()
     pipeline.fit(X_fm, y)
     part_dep = partial_dependence(
         pipeline,
         X_fm,
         features=engineered_feature,
-        grid_resolution=5,
+        grid_resolution=2,
         fast_mode=fast_mode,
         X_train=X_fm,
         y_train=y,

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -1,5 +1,4 @@
 import re
-from pdb import set_trace
 from unittest.mock import patch
 
 import featuretools as ft

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2797,7 +2797,7 @@ def test_partial_dependence_fast_mode_errors_if_train(
 
 
 @pytest.mark.parametrize("fast_mode", [True, False])
-def test_partial_dependence_on_engineered_feature_with_dfs_transformer_and_engineered_feature(
+def test_partial_dependence_on_engineered_feature_with_dfs_transformer(
     fast_mode,
     X_y_binary,
 ):
@@ -2839,8 +2839,8 @@ def test_partial_dependence_on_engineered_feature_with_dfs_transformer_and_engin
         y_train=y,
     )
 
-    assert not part_dep.feature_values.isna().any()
-    assert not part_dep.partial_dependence.isna().any()
+    assert part_dep.feature_values.notnull().all()
+    assert part_dep.partial_dependence.notnull().all()
 
 
 @pytest.mark.parametrize("fast_mode", [True, False])
@@ -2872,20 +2872,21 @@ def test_partial_dependence_dfs_transformer_handling_with_multi_output_primitive
         [dfs_transformer, "Standard Scaler", "Random Forest Regressor"],
     )
     # Confirm that a multi-output feature is present
-    assert any(len(f.get_feature_names()) > 1 for f in features)
+    assert any(f.number_output_features > 1 for f in features)
 
     pipeline.fit(X_fm, y)
-    part_dep = partial_dependence(pipeline, X_fm, features=1, grid_resolution=5)
-    fast_part_dep = partial_dependence(
+    part_dep = partial_dependence(
         pipeline,
         X_fm,
-        features=1,
-        grid_resolution=5,
+        features=0,
+        grid_resolution=2,
         fast_mode=fast_mode,
         X_train=X_fm,
         y_train=y,
     )
-    pd.testing.assert_frame_equal(part_dep, fast_part_dep)
+
+    assert part_dep.feature_values.notnull().all()
+    assert part_dep.partial_dependence.notnull().all()
 
 
 @pytest.mark.parametrize("fast_mode", [True, False])
@@ -2921,14 +2922,15 @@ def test_partial_dependence_dfs_transformer_target_in_features(fast_mode, X_y_bi
     )
 
     pipeline.fit(X_fm, y)
-    part_dep = partial_dependence(pipeline, X_fm, features=1, grid_resolution=5)
-    fast_part_dep = partial_dependence(
+    part_dep = partial_dependence(
         pipeline,
         X_fm,
-        features=1,
-        grid_resolution=5,
+        features=0,
+        grid_resolution=2,
         fast_mode=fast_mode,
         X_train=X_fm,
         y_train=y,
     )
-    pd.testing.assert_frame_equal(part_dep, fast_part_dep)
+
+    assert part_dep.feature_values.notnull().all()
+    assert part_dep.partial_dependence.notnull().all()

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2871,7 +2871,7 @@ def test_partial_dependence_dfs_transformer_handling_with_multi_output_primitive
     pipeline = RegressionPipeline(
         [dfs_transformer, "Standard Scaler", "Random Forest Regressor"],
     )
-    # Confirm that the LSA primitive was actually used
+    # Confirm that a multi-output feature is present
     assert any(len(f.get_feature_names()) > 1 for f in features)
 
     pipeline.fit(X_fm, y)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -2841,3 +2841,11 @@ def test_partial_dependence_on_engineered_feature_with_dfs_transformer_and_engin
 
     assert not part_dep.feature_values.isna().any()
     assert not part_dep.partial_dependence.isna().any()
+
+
+def test_partial_dependence_dfs_transformer_handling_with_multi_output_primitive():
+    pass
+
+
+def test_partial_dependence_dfs_transformer_target_in_features():
+    pass


### PR DESCRIPTION
There are several partial dependence fixes relating to the DFS Transformer that happen in this PR:

1. This PR updates partial dependence to keep the origin values the same. Closes https://github.com/alteryx/evalml/issues/3834
2.  This PR excludes the target from consideration if it's present in the list of `features`. Closes https://github.com/alteryx/evalml/issues/3833
3.  This PR uses `f.get_feature_names` instead of `f.get_name` to handle multi output features correctly. Closes https://github.com/alteryx/evalml/issues/3832
