### PR TITLE
Release v0.63.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,7 +1,18 @@
 Release Notes
 -------------
-
 **Future Releases**
+    * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.63.0 Nov.23, 2022**
     * Enhancements
         * Added fast mode to partial dependence :pr:`3753`
         * Added the ability to serialize featuretools features into time series pipelines :pr:`3836`
@@ -22,11 +33,6 @@ Release Notes
         * Reverted change adding a ``should_skip_featurization`` flag to time series pipelines :pr:`3862`
     * Documentation Changes
         * Added information about STL Decomposition to the time series docs :pr:`3835`
-    * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.62.0 Nov. 01, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.62.0"
+__version__ = "0.63.0"


### PR DESCRIPTION
# v0.63.0 Nov. 23, 2022
### Enhancements
- Added fast mode to partial dependence #3753
- Added the ability to serialize featuretools features into time series pipelines #3836
### Fixes
- Fixed ``TimeSeriesFeaturizer`` potentially selecting lags outside of feature engineering window #3773
- Fixed bug where ``TimeSeriesFeaturizer`` could not encode Ordinal columns with non numeric categories #3812
- Updated demo dataset links to point to new endpoint #3826
- Updated ``STLDecomposer`` to infer the time index frequency if it's not present #3829
- Updated ``_drop_time_index`` to move the time index from X to both ``X.index`` and ``y.index`` #3829
- Added ``TimeSeriesPipeline.should_skip_featurization`` to fix bug where data would get featurized unnecessarily #3849
- Fixed bug where engineered features lost their origin attribute in partial dependence, causing it to fail #3830
- Fixed bug where partial dependence's fast mode handling for the DFS Transformer wouldn't work with multi output features #3830
- Allowed target to be present and ignored in partial dependence's DFS Transformer fast mode handling  #3830
### Changes
- Consolidated decomposition frequency validation logic to ``Decomposer`` class #3811
- Removed Featuretools version upper bound and prevent Woodwork 0.20.0 from being installed #3813
- Updated min Featuretools version to 0.16.0, min nlp-primitives version to 2.9.0 and min Dask version to 2022.2.0 #3823
- Rename issue templates config.yaml to config.yml #3844
### Documentation Changes
- Added information about STL Decomposition to the time series docs #3835