### PR TITLE
Reduce use_covariates threshold

### DIFF
--- a/evalml/automl/automl_search.py
+++ b/evalml/automl/automl_search.py
@@ -711,7 +711,7 @@ class AutoMLSearch:
         self.search_parameters = search_parameters or {}
         # Fitting takes a long time if the data is too wide or long.
         if is_time_series(problem_type) and (
-            self.X_train.shape[1] >= 10 or self.X_train.shape[0] >= 10000
+            self.X_train.shape[1] >= 7 or self.X_train.shape[0] >= 1000
         ):
             user_arima_hyperparams = ARIMARegressor.name in self.search_parameters
             if user_arima_hyperparams and not self.search_parameters[


### PR DESCRIPTION
Moves to defaulting to `use_covariates=False` in more cases, since it produces significant slowdown without much benefit for larger datasets