### PR TITLE
Release v0.64.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,18 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.64.0 Dec. 8, 2022**
+    * Enhancements
+    * Fixes
         * Allowed the DFS Transformer to calculate feature values for Features with a ``dataframe_name`` that is not ``"X"`` :pr:`3873`
         * Stopped passing full list of DFS Transformer features into cloned pipeline in partial dependence fast mode :pr:`3875`
     * Changes
@@ -13,12 +25,8 @@ Release Notes
     * Documentation Changes
     * Testing Changes
 
-.. warning::
 
-    **Breaking Changes**
-
-
-**v0.63.0 Nov.23, 2022**
+**v0.63.0 Nov. 23, 2022**
     * Enhancements
         * Added fast mode to partial dependence :pr:`3753`
         * Added the ability to serialize featuretools features into time series pipelines :pr:`3836`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.63.0"
+__version__ = "0.64.0"


### PR DESCRIPTION
# v0.64.0 Dec. 8, 2022
### Fixes
- Allowed the DFS Transformer to calculate feature values for Features with a ``dataframe_name`` that is not ``"X"`` #3873
- Stopped passing full list of DFS Transformer features into cloned pipeline in partial dependence fast mode #3875

### Changes
- Remove Int64Index after Pandas 1.5 Upgrade #3825
- Reduced the threshold for setting ``use_covariates`` to False for ARIMA models in AutoMLSearch #3868
- Pinned woodwork version at <=0.19.0 #3871
- Updated minimum Pandas version to 1.5.0 #3808
