### PR TITLE
Set threshold to account for too many duplicate or nan values in `DateTimeFormatDataCheck`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values :pr:`3883`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/data_checks/datetime_format_data_check.py
+++ b/evalml/data_checks/datetime_format_data_check.py
@@ -47,7 +47,7 @@ class DateTimeFormatDataCheck(DataCheck):
             >>> datetime_format_dc = DateTimeFormatDataCheck(datetime_column="dates")
             >>> assert datetime_format_dc.validate(X, y) == [
             ...     {
-            ...         "message": "No frequency could be detected in column 'dates', possibly due to uneven intervals.",
+            ...         "message": "No frequency could be detected in column 'dates', possibly due to uneven intervals, possibly due to uneven intervals or too many duplicate/missing values.",
             ...         "data_check_name": "DateTimeFormatDataCheck",
             ...         "level": "error",
             ...         "code": "DATETIME_NO_FREQUENCY_INFERRED",
@@ -441,11 +441,14 @@ class DateTimeFormatDataCheck(DataCheck):
                 ).to_dict(),
             )
 
+        datetime_values_no_nans_duplicates = no_nan_datetime_values.drop_duplicates()
         # Give a generic uneven interval error no frequency can be estimated by woodwork
-        if debug_object["estimated_freq"] is None:
+        if debug_object["estimated_freq"] is None or len(
+            datetime_values_no_nans_duplicates,
+        ) < 0.75 * len(datetime_values):
             messages.append(
                 DataCheckError(
-                    message=f"No frequency could be detected in column '{col_name}', possibly due to uneven intervals.",
+                    message=f"No frequency could be detected in column '{col_name}', possibly due to uneven intervals or too many duplicate/missing values.",
                     data_check_name=self.name,
                     message_code=DataCheckMessageCode.DATETIME_NO_FREQUENCY_INFERRED,
                 ).to_dict(),

--- a/evalml/data_checks/datetime_format_data_check.py
+++ b/evalml/data_checks/datetime_format_data_check.py
@@ -47,7 +47,7 @@ class DateTimeFormatDataCheck(DataCheck):
             >>> datetime_format_dc = DateTimeFormatDataCheck(datetime_column="dates")
             >>> assert datetime_format_dc.validate(X, y) == [
             ...     {
-            ...         "message": "No frequency could be detected in column 'dates', possibly due to uneven intervals, possibly due to uneven intervals or too many duplicate/missing values.",
+            ...         "message": "No frequency could be detected in column 'dates', possibly due to uneven intervals or too many duplicate/missing values.",
             ...         "data_check_name": "DateTimeFormatDataCheck",
             ...         "level": "error",
             ...         "code": "DATETIME_NO_FREQUENCY_INFERRED",

--- a/evalml/data_checks/datetime_format_data_check.py
+++ b/evalml/data_checks/datetime_format_data_check.py
@@ -351,8 +351,6 @@ class DateTimeFormatDataCheck(DataCheck):
 
         X = infer_feature_types(X)
         y = infer_feature_types(y)
-        print(X)
-        print(X.ww)
 
         no_dt_found = False
 
@@ -401,9 +399,6 @@ class DateTimeFormatDataCheck(DataCheck):
             window_length=4,
             threshold=0.4,
         )
-        from pprint import pprint
-
-        pprint(ww_payload)
         inferred_freq = ww_payload[0]
         debug_object = ww_payload[1]
         if inferred_freq is not None:

--- a/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
+++ b/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
@@ -535,3 +535,19 @@ def test_datetime_many_duplicates_and_nans():
     result = dc.validate(X, y)
 
     assert result[2]["code"] == "DATETIME_NO_FREQUENCY_INFERRED"
+
+
+def test_aml():
+    X = pd.DataFrame(
+        pd.date_range("2015-01-01", periods=2).append(
+            pd.date_range("2015-01-08", periods=2, freq="H").append(
+                pd.date_range("2016-03-02", periods=2, freq="M"),
+            ),
+        ),
+        columns=["dates"],
+    )
+    y = pd.Series([0, 1, 0, 1, 1, 0])
+    datetime_format_dc = DateTimeFormatDataCheck(datetime_column="dates")
+    from pprint import pprint
+
+    pprint(datetime_format_dc.validate(X, y))

--- a/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
+++ b/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
@@ -535,19 +535,3 @@ def test_datetime_many_duplicates_and_nans():
     result = dc.validate(X, y)
 
     assert result[2]["code"] == "DATETIME_NO_FREQUENCY_INFERRED"
-
-
-def test_aml():
-    X = pd.DataFrame(
-        pd.date_range("2015-01-01", periods=2).append(
-            pd.date_range("2015-01-08", periods=2, freq="H").append(
-                pd.date_range("2016-03-02", periods=2, freq="M"),
-            ),
-        ),
-        columns=["dates"],
-    )
-    y = pd.Series([0, 1, 0, 1, 1, 0])
-    datetime_format_dc = DateTimeFormatDataCheck(datetime_column="dates")
-    from pprint import pprint
-
-    pprint(datetime_format_dc.validate(X, y))

--- a/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
+++ b/evalml/tests/data_checks_tests/test_datetime_format_data_check.py
@@ -523,6 +523,7 @@ def test_datetime_many_duplicates_and_nans():
     dates = dates.append(nans).append(duplicates)
 
     X = pd.DataFrame({"date": dates}, columns=["date"])
+    X = X.reset_index(drop=True)
     y = pd.Series(range(len(dates)))
 
     dc = DateTimeFormatDataCheck(datetime_column="date")
@@ -530,7 +531,12 @@ def test_datetime_many_duplicates_and_nans():
 
     assert result[2]["code"] == "DATETIME_HAS_UNEVEN_INTERVALS"
 
-    X.iloc[0, -1] = None
+    X.iloc[-25, 0] = None
+    dc = DateTimeFormatDataCheck(datetime_column="date", nan_duplicate_threshold=0.70)
+    result = dc.validate(X, y)
+
+    assert result[2]["code"] == "DATETIME_HAS_UNEVEN_INTERVALS"
+
     dc = DateTimeFormatDataCheck(datetime_column="date")
     result = dc.validate(X, y)
 


### PR DESCRIPTION
Currently if a `time_index` is chosen that has duplicate or nan values, these values are dropped prior to the creation of an `alias_dict` in Woodwork which iterates over all identified frequencies in the time series to determine the most likely one. 

The side effect of this is that in a dataset with a length of 20,000, if the `time_index` is just 50 consecutive daily datetime values repeated 400 times, then we currently return `DATETIME_HAS_UNEVEN_INTERVALS` and an action code to fix this data.

This `time_index` should not be considered for regularization as regularizing this data would reduce this dataset from 20,000 observations to 50, since all duplicates and nans would be dropped and the remaining datetime values would have a frequency of `1 day`. This is more of a multi-series concern which is outside the scope of this data check.

I've added a check where if 25% of the `time_index` consists of solely duplicate and nan values, then `DATETIME_NO_FREQUENCY_INFERRED` will be returned instead of `DATETIME_HAS_UNEVEN_INTERVALS`. I'm open to changing this threshold or making it a passable argument, it was more or less arbitrary.