### PR TITLE
Hid non-essential warning messages in time series docs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
     * Changes
         * Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values :pr:`3883`
     * Documentation Changes
-        * Hide non-essential warning messages in time series docs :pr:`3890`
+        * Hid non-essential warning messages in time series docs :pr:`3890`
     * Testing Changes
 
 .. warning::

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
     * Changes
         * Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values :pr:`3883`
     * Documentation Changes
+        * Hide non-essential warning messages in time series docs :pr:`3890`
     * Testing Changes
 
 .. warning::

--- a/docs/source/user_guide/timeseries.ipynb
+++ b/docs/source/user_guide/timeseries.ipynb
@@ -1,6 +1,28 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from statsmodels.tools.sm_exceptions import ConvergenceWarning\n",
+    "from sklearn.exceptions import ConvergenceWarning as sklearnConvergenceWarning\n",
+    "from evalml.exceptions import ParameterNotUsedWarning\n",
+    "\n",
+    "warnings_to_ignore = [\n",
+    "    ConvergenceWarning,\n",
+    "    sklearnConvergenceWarning,\n",
+    "    ParameterNotUsedWarning,\n",
+    "]\n",
+    "for warning in warnings_to_ignore:\n",
+    "    warnings.simplefilter(\"ignore\", warning)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -838,6 +860,17 @@
     "However, there are some features corresponding to dates in the future that can be known with certainty, either because they can be derived from the forecast date or because the feature can be controlled by the modeler. This includes features such as if the date is a US Holiday, or the location of a store in a sales dataset. With these sorts of features, we don't need to include them in our time-series specific preprocessing steps (such as Time Series Featurization).\n",
     "\n",
     "To handle these features, EvalML will split them into a separate path through the component graph, bypassing the unnecessary preprocessing steps. Let's take a look at what that looks like, using some synthetic data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "warnings.simplefilter(\"ignore\", UserWarning)"
    ]
   },
   {


### PR DESCRIPTION
Fixes #3620 

A lot of the warning messages that we are seeing has to do with a lot of the internal solvers being unable to find convergence. A significant amount of these errors can be filtered out by filtering them in a hidden cell. 

In addition, for the known in advance section, a number of errors are `UserErrors` related to initial parameter inits in addition to the above convergence error messages. This second cell hiding UserErrors I am a bit more skeptical about as it's a bit broad and leaves room for actual errors to be hidden in the future. 

Current page: https://evalml.alteryx.com/en/stable/user_guide/timeseries.html#Known-in-advance-features
Updated page: https://feature-labs-inc-evalml--3890.com.readthedocs.build/en/3890/user_guide/timeseries.html#Known-in-advance-features