### PR TITLE
Split STL `seasonal_period` into separate `seasonal_smoother` and `period`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Fix ARIMA not accounting for gap in prediction from end of training data :pr:`3884`
     * Changes
         * Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values :pr:`3883`
+        * Split decomposer ``seasonal_period`` parameter into ``seasonal_smoother`` and ``period`` parameters :pr:`3896`
     * Documentation Changes
         * Hid non-essential warning messages in time series docs :pr:`3890`
     * Testing Changes

--- a/docs/source/user_guide/timeseries.ipynb
+++ b/docs/source/user_guide/timeseries.ipynb
@@ -321,7 +321,7 @@
     "    PolynomialDecomposer,\n",
     ")\n",
     "\n",
-    "pdc = PolynomialDecomposer(degree=1, seasonal_period=365)\n",
+    "pdc = PolynomialDecomposer(degree=1, period=365)\n",
     "X_t, y_t = pdc.fit_transform(X_train_time, y_train_time)\n",
     "\n",
     "plt.plot(y_train_time, \"bo\", label=\"Signal\")\n",
@@ -367,12 +367,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `PolynomialDecomposer` class, if not explicitly set in the constructor, will set its `seasonal_period` parameter\n",
+    "The `PolynomialDecomposer` class, if not explicitly set in the constructor, will set its `period` parameter\n",
     "based on a `statsmodels` function `freq_to_period` that considers the frequency of the datetime data.  This will give a reasonable guess as to what the frequency could be. For example, if the `PolynomialDecomposer` object is fit with\n",
-    "`seasonal_period` not explicitly set, it will take on a default value of 7, which is good for daily data signals that\n",
+    "`period` not explicitly set, it will take on a default value of 7, which is good for daily data signals that\n",
     "have a known seasonal component period that is weekly.\n",
     "\n",
-    "In this case where the seasonal period is not known beforehand, the `set_seasonal_period()` convenience function will \n",
+    "In this case where the seasonal period is not known beforehand, the `set_period()` convenience function will \n",
     "look at the target data, determine a better guess for the period and set the `Decomposer` object appropriately."
    ]
   },
@@ -384,9 +384,9 @@
    "source": [
     "pdc = PolynomialDecomposer()\n",
     "pdc.fit(X_train_time, y_train_time)\n",
-    "assert pdc.seasonal_period == 7\n",
-    "pdc.set_seasonal_period(X_train_time, y_train_time)\n",
-    "assert 363 < pdc.seasonal_period < 368"
+    "assert pdc.period == 7\n",
+    "pdc.set_period(X_train_time, y_train_time)\n",
+    "assert 363 < pdc.period < 368"
    ]
   },
   {
@@ -495,9 +495,9 @@
    "outputs": [],
    "source": [
     "stl = STLDecomposer()\n",
-    "assert stl.seasonal_period == 7\n",
+    "assert stl.period == None\n",
     "stl.fit(X_stl, y_stl)\n",
-    "print(stl.seasonal_period)"
+    "print(stl.period)"
    ]
   },
   {

--- a/evalml/pipelines/components/transformers/preprocessing/decomposer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/decomposer.py
@@ -22,7 +22,8 @@ class Decomposer(Transformer):
         component_obj (class) : Instance of a detrender/deseasonalizer class.
         random_seed (int): Seed for the random number generator. Defaults to 0.
         degree (int) : Currently the degree of the PolynomialDecomposer, not used for STLDecomposer.
-        seasonal_period (int) : The best guess, in units, for the period of the seasonal signal.
+        period (int) : The best guess, in units, for the period of the seasonal signal.
+        seasonal_smoother (int): The seasonal smoothing parameter for STLDecomposer, not used for PolynomialDecomposer.
         time_index (str) : The column name of the feature matrix (X) that the datetime information
             should be pulled from.
     """
@@ -39,19 +40,22 @@ class Decomposer(Transformer):
         component_obj=None,
         random_seed: int = 0,
         degree: int = 1,
-        seasonal_period: int = -1,
+        period: int = -1,
+        seasonal_smoother: int = 7,
         time_index: str = None,
         **kwargs,
     ):
         degree = self._raise_typeerror_if_not_int("degree", degree)
-        self.seasonal_period = self._raise_typeerror_if_not_int(
-            "seasonal_period",
-            seasonal_period,
+        self.seasonal_smoother = self._raise_typeerror_if_not_int(
+            "seasonal_smoother",
+            seasonal_smoother,
         )
+        self.period = period
         self.time_index = time_index
         parameters = {
             "degree": degree,
-            "seasonal_period": self.seasonal_period,
+            "period": period,
+            "seasonal_smoother": self.seasonal_smoother,
             "time_index": time_index,
         }
         parameters.update(kwargs)
@@ -192,7 +196,7 @@ class Decomposer(Transformer):
             relative_maxima = [None]
         return relative_maxima[0]
 
-    def set_seasonal_period(self, X: pd.DataFrame, y: pd.Series):
+    def set_period(self, X: pd.DataFrame, y: pd.Series):
         """Function to set the component's seasonal period based on the target's seasonality.
 
         Args:
@@ -200,8 +204,8 @@ class Decomposer(Transformer):
             y (pandas.Series): The target data of a time series problem.
 
         """
-        self.seasonal_period = self.determine_periodicity(X, y)
-        self.parameters.update({"seasonal_period": self.seasonal_period})
+        self.period = self.determine_periodicity(X, y)
+        self.parameters.update({"period": self.period})
 
     def _check_oos_past(self, y):
         """Function to check whether provided target data is out-of-sample and in the past."""

--- a/evalml/pipelines/components/transformers/preprocessing/polynomial_decomposer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/polynomial_decomposer.py
@@ -30,9 +30,9 @@ class PolynomialDecomposer(Decomposer):
         time_index (str): Specifies the name of the column in X that provides the datetime objects. Defaults to None.
         degree (int): Degree for the polynomial. If 1, linear model is fit to the data.
             If 2, quadratic model is fit, etc. Defaults to 1.
-        seasonal_period (int): The number of entries in the time series data that corresponds to one period of a
+        period (int): The number of entries in the time series data that corresponds to one period of a
             cyclic signal.  For instance, if data is known to possess a weekly seasonal signal, and if the data
-            is daily data, seasonal_period should be 7.  For daily data with a yearly seasonal signal, seasonal_period
+            is daily data, period should be 7.  For daily data with a yearly seasonal signal, period
             should be 365.  Defaults to -1, which uses the statsmodels libarary's freq_to_period function.
             https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/tsatools.py
         random_seed (int): Seed for the random number generator. Defaults to 0.
@@ -50,7 +50,7 @@ class PolynomialDecomposer(Decomposer):
         self,
         time_index: str = None,
         degree: int = 1,
-        seasonal_period: int = -1,
+        period: int = -1,
         random_seed: int = 0,
         **kwargs,
     ):
@@ -69,7 +69,7 @@ class PolynomialDecomposer(Decomposer):
             component_obj=decomposer,
             random_seed=random_seed,
             degree=degree,
-            seasonal_period=seasonal_period,
+            period=period,
             time_index=time_index,
             **kwargs,
         )
@@ -116,14 +116,14 @@ class PolynomialDecomposer(Decomposer):
         # statsmodel's seasonal_decompose() repeats the seasonal signal over the length of
         # the given array.  We'll extract the first iteration and save it for use in .transform()
         # TODO: Resolve with https://github.com/alteryx/evalml/issues/3708
-        if self.seasonal_period == -1:
-            self.seasonal_period = freq_to_period(self.frequency)
+        if self.period == -1:
+            self.period = freq_to_period(self.frequency)
 
         self.seasonal = seasonal_decompose(
             y_detrended_with_time_index,
-            period=self.seasonal_period,
+            period=self.period,
         ).seasonal
-        self.seasonality = self.seasonal[0 : self.seasonal_period]
+        self.seasonality = self.seasonal[0 : self.period]
         self.trend = y - (y_detrended_with_time_index - self.seasonal) - self.seasonal
         return self
 
@@ -167,7 +167,7 @@ class PolynomialDecomposer(Decomposer):
         seasonal = self._project_seasonal(
             y,
             self.seasonality,
-            self.seasonal_period,
+            self.period,
             self.frequency,
         )
 
@@ -248,7 +248,7 @@ class PolynomialDecomposer(Decomposer):
             projected_seasonality = self._project_seasonal(
                 truncated_y_t,
                 self.seasonality,
-                self.seasonal_period,
+                self.period,
                 self.frequency,
             )
 
@@ -320,7 +320,7 @@ class PolynomialDecomposer(Decomposer):
 
             seasonality = seasonal_decompose(
                 y - trend,
-                period=self.seasonal_period,
+                period=self.period,
             ).seasonal
             residual = y - trend - seasonality
             return pd.DataFrame(

--- a/evalml/tests/component_tests/decomposer_tests/test_polynomial_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_polynomial_decomposer.py
@@ -15,7 +15,8 @@ def test_polynomial_decomposer_init():
     delayed_features = PolynomialDecomposer(degree=3, time_index="dates")
     assert delayed_features.parameters == {
         "degree": 3,
-        "seasonal_period": -1,
+        "period": -1,
+        "seasonal_smoother": 7,
         "time_index": "dates",
     }
 

--- a/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
@@ -12,22 +12,23 @@ from evalml.tests.component_tests.decomposer_tests.test_decomposer import (
 
 
 def test_stl_decomposer_init():
-    delayed_features = STLDecomposer(degree=3, time_index="dates")
-    assert delayed_features.parameters == {
+    decomp = STLDecomposer(degree=3, time_index="dates")
+    assert decomp.parameters == {
         "degree": 3,
-        "seasonal_period": 7,
+        "period": None,
+        "seasonal_smoother": 7,
         "time_index": "dates",
     }
 
 
-def test_stl_decomposer_auto_sets_seasonal_period_to_odd(ts_data):
+def test_stl_decomposer_auto_sets_seasonal_smoother_to_odd(ts_data):
     X, _, y = ts_data()
 
-    stl = STLDecomposer(seasonal_period=3)
-    assert stl.seasonal_period == 3
+    stl = STLDecomposer(seasonal_smoother=3)
+    assert stl.seasonal_smoother == 3
 
-    stl = STLDecomposer(seasonal_period=4)
-    assert stl.seasonal_period == 5
+    stl = STLDecomposer(seasonal_smoother=4)
+    assert stl.seasonal_smoother == 5
 
 
 @pytest.mark.parametrize(
@@ -76,7 +77,7 @@ def test_stl_fit_transform_in_sample(
     lin_reg.fit(features, y)
     expected_trend = lin_reg.predict(features)
 
-    stl = STLDecomposer(seasonal_period=period)
+    stl = STLDecomposer(period=period)
 
     X_t, y_t = stl.fit_transform(X, y)
 
@@ -123,18 +124,18 @@ def test_stl_decomposer_inverse_transform(
     transformer_fit_on_data,
 ):
     # Generate 10 periods (the default) of synthetic seasonal data
-    seasonal_period = 7
+    period = 7
     X, y = generate_seasonal_data(real_or_synthetic="synthetic")(
-        period=seasonal_period,
+        period=period,
         freq_str="D",
         set_time_index=True,
     )
     if index_type == "integer_index":
         y = y.reset_index(drop=True)
-    subset_X = X[: 5 * seasonal_period]
-    subset_y = y[: 5 * seasonal_period]
+    subset_X = X[: 5 * period]
+    subset_y = y[: 5 * period]
 
-    decomposer = STLDecomposer(seasonal_period=seasonal_period)
+    decomposer = STLDecomposer(period=period)
     output_X, output_y = decomposer.fit_transform(subset_X, subset_y)
 
     if transformer_fit_on_data == "in-sample":
@@ -144,7 +145,7 @@ def test_stl_decomposer_inverse_transform(
     if transformer_fit_on_data != "in-sample":
         y_t_new = build_test_target(
             subset_y,
-            seasonal_period,
+            period,
             transformer_fit_on_data,
             to_test="inverse_transform",
         )
@@ -194,14 +195,14 @@ def test_stl_decomposer_get_trend_dataframe(
     variateness,
 ):
 
-    seasonal_period = 7
+    period = 7
     X, y = generate_seasonal_data(real_or_synthetic="synthetic")(
-        period=seasonal_period,
+        period=period,
         freq_str="D",
         set_time_index=True,
     )
-    subset_X = X[: 5 * seasonal_period]
-    subset_y = y[: 5 * seasonal_period]
+    subset_X = X[: 5 * period]
+    subset_y = y[: 5 * period]
 
     if transformer_fit_on_data == "in-sample":
         dec = STLDecomposer()
@@ -227,7 +228,7 @@ def test_stl_decomposer_get_trend_dataframe(
 
         y_t_new = build_test_target(
             subset_y,
-            seasonal_period,
+            period,
             transformer_fit_on_data,
             to_test="transform",
         )

--- a/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
@@ -21,14 +21,19 @@ def test_stl_decomposer_init():
     }
 
 
-def test_stl_decomposer_auto_sets_seasonal_smoother_to_odd(ts_data):
-    X, _, y = ts_data()
-
+def test_stl_decomposer_auto_sets_seasonal_smoother_to_odd():
     stl = STLDecomposer(seasonal_smoother=3)
     assert stl.seasonal_smoother == 3
 
     stl = STLDecomposer(seasonal_smoother=4)
     assert stl.seasonal_smoother == 5
+
+
+def test_stl_raises_warning_high_smoother(caplog, ts_data):
+    X, _, y = ts_data()
+    stl = STLDecomposer(seasonal_smoother=101)
+    stl.fit(X, y)
+    assert "STLDecomposer may perform poorly" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently, in [evalml/stl_decomposer.py at main · alteryx/evalml](https://github.com/alteryx/evalml/blob/main/evalml/pipelines/components/transformers/preprocessing/stl_decomposer.py), the STLDecomposer mistakenly takes a value for seasonal and passes it to the seasonal parameters of the underlying STL algorithm.  It seems that seasonal is actually a value for a window that does smoothing (possibly for the trend decomposition).  This fixes that by splitting the `seasonal_period` parameter into separate `seasonal_smoother` (ideally a clearer name for this parameter) and `period`