### PR TITLE
Release v0.65.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.65.0 Jan. 3, 2023**
+    * Enhancements
         * Added the ability to retrieve prediction intervals for estimators that support time series regression :pr:`3876`
         * Added utils to handle the logic for threshold tuning objective and resplitting data :pr:`3888`
         * Integrated ``OrdinalEncoder`` into AutoMLSearch :pr:`3765`
@@ -18,10 +30,6 @@ Release Notes
     * Documentation Changes
         * Hid non-essential warning messages in time series docs :pr:`3890`
     * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.64.0 Dec. 8, 2022**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.64.0"
+__version__ = "0.65.0"


### PR DESCRIPTION
# v0.65.0 Jan. 3, 2023
### Enhancements
- Added the ability to retrieve prediction intervals for estimators that support time series regression #3876
- Added utils to handle the logic for threshold tuning objective and resplitting data #3888
- Integrated ``OrdinalEncoder`` into AutoMLSearch #3765
### Fixes
- Fixed ARIMA not accounting for gap in prediction from end of training data #3884
### Changes
- Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values #3883
- Changed treatment of ``Boolean`` columns for ``SimpleImputer`` and ``ClassImbalanceDataCheck`` to be compatible with new Woodwork inference #3892
- Split decomposer ``seasonal_period`` parameter into ``seasonal_smoother`` and ``period`` parameters #3896
- Excluded catboost from the broken link checking workflow due to 403 errors #3899
- Pinned scikit-learn version below 1.2.0 #3901
### Documentation Changes
- Hid non-essential warning messages in time series docs #3890
### Testing Changes
