### PR TITLE
Cast `OneHotEncoder` created columns to `bool`

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Split decomposer ``seasonal_period`` parameter into ``seasonal_smoother`` and ``period`` parameters :pr:`3896`
         * Excluded catboost from the broken link checking workflow due to 403 errors :pr:`3899`
         * Pinned scikit-learn version below 1.2.0 :pr:`3901`
+        * Cast newly created one hot encoded columns as ``bool`` dtype :pr:`3913`
     * Documentation Changes
         * Hid non-essential warning messages in time series docs :pr:`3890`
     * Testing Changes

--- a/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
@@ -197,6 +197,8 @@ class OneHotEncoder(Transformer, metaclass=OneHotEncoderMeta):
             )
             X_cat.columns = self._get_feature_names()
             X_cat.drop(columns=self._features_to_drop, inplace=True)
+            for col in X_cat:
+                X_cat[col] = X_cat[col].astype("bool")
             X_cat.ww.init(logical_types={c: "Boolean" for c in X_cat.columns})
             self._feature_names = X_cat.columns
 


### PR DESCRIPTION
Casting `OHE` created columns to `bool` dtype before initializing through woodwork will help save time during transformation