### PR TITLE
Remove non-selected-categorical columns from dataframe used to create numeric pipelines in DefaultAlgo

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
         * Integrated ``OrdinalEncoder`` into AutoMLSearch :pr:`3765`
     * Fixes
         * Fixed ARIMA not accounting for gap in prediction from end of training data :pr:`3884`
+        * Fixed ``DefaultAlgorithm`` adding an extra ``OneHotEncoder`` when a categorical column is not selected :pr:`3914`
     * Changes
         * Added a threshold to ``DateTimeFormatDataCheck`` to account for too many duplicate or nan values :pr:`3883`
         * Changed treatment of ``Boolean`` columns for ``SimpleImputer`` and ``ClassImbalanceDataCheck`` to be compatible with new Woodwork inference :pr:`3892`

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -583,9 +583,13 @@ class DefaultAlgorithm(AutoMLAlgorithm):
 
     def _make_split_pipeline(self, estimator, pipeline_name=None):
         if self._X_with_cat_cols is None or self._X_without_cat_cols is None:
+            # Should be category, not categorical so that we make sure to exclude
+            # all logical types with the "category" tag
+            numeric_exclude_types = ["category", "EmailAddress", "URL"]
             self._X_without_cat_cols = self.X.ww.select(
-                exclude=["category", "EmailAddress", "URL"],
+                exclude=numeric_exclude_types,
             )
+
             self._X_with_cat_cols = self.X.ww[self._selected_cat_cols]
 
         if self._selected_cat_cols and self._selected_cols:
@@ -597,9 +601,7 @@ class DefaultAlgorithm(AutoMLAlgorithm):
             numeric_pipeline_parameters = {
                 "Select Columns Transformer": {"columns": self._selected_cols},
                 "Select Columns By Type Transformer": {
-                    # Should be category, not categorical so that we make sure to exclude
-                    # all logical types with the "category" tag
-                    "column_types": ["category", "EmailAddress", "URL"],
+                    "column_types": numeric_exclude_types,
                     "exclude": True,
                 },
             }

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -583,9 +583,8 @@ class DefaultAlgorithm(AutoMLAlgorithm):
 
     def _make_split_pipeline(self, estimator, pipeline_name=None):
         if self._X_with_cat_cols is None or self._X_without_cat_cols is None:
-            self._X_without_cat_cols = self.X.ww.drop(self._selected_cat_cols)
-            self._X_without_cat_cols = self._X_without_cat_cols.ww.select(
-                self._selected_cols,
+            self._X_without_cat_cols = self.X.ww.select(
+                exclude=["category", "EmailAddress", "URL"],
             )
             self._X_with_cat_cols = self.X.ww[self._selected_cat_cols]
 

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -582,10 +582,10 @@ class DefaultAlgorithm(AutoMLAlgorithm):
             )
 
     def _make_split_pipeline(self, estimator, pipeline_name=None):
+        # Should be category, not categorical so that we make sure to exclude
+        # all logical types with the "category" tag
+        numeric_exclude_types = ["category", "EmailAddress", "URL"]
         if self._X_with_cat_cols is None or self._X_without_cat_cols is None:
-            # Should be category, not categorical so that we make sure to exclude
-            # all logical types with the "category" tag
-            numeric_exclude_types = ["category", "EmailAddress", "URL"]
             self._X_without_cat_cols = self.X.ww.select(
                 exclude=numeric_exclude_types,
             )

--- a/evalml/automl/automl_algorithm/default_algorithm.py
+++ b/evalml/automl/automl_algorithm/default_algorithm.py
@@ -584,6 +584,9 @@ class DefaultAlgorithm(AutoMLAlgorithm):
     def _make_split_pipeline(self, estimator, pipeline_name=None):
         if self._X_with_cat_cols is None or self._X_without_cat_cols is None:
             self._X_without_cat_cols = self.X.ww.drop(self._selected_cat_cols)
+            self._X_without_cat_cols = self._X_without_cat_cols.ww.select(
+                self._selected_cols,
+            )
             self._X_with_cat_cols = self.X.ww[self._selected_cat_cols]
 
         if self._selected_cat_cols and self._selected_cols:

--- a/evalml/tests/automl_tests/test_default_algorithm.py
+++ b/evalml/tests/automl_tests/test_default_algorithm.py
@@ -377,6 +377,7 @@ def test_make_split_pipeline(sampler, features, X_y_binary):
     X["A"] = "a"
     X["B"] = "b"
     X["C"] = "c"
+    X["D"] = "d"
 
     algo = DefaultAlgorithm(
         X,


### PR DESCRIPTION
If a dataframe contained a categorical column that was not selected by the feature selector, ``DefaultAlgorithm`` would send a dataframe with such categorical column to the make pipeline util for the numeric pipeline. This would cause a OHE to be inserted into the numeric pipeline. This change makes it so that a dataframe matching the parameters in the `SelectByType` is sent to the pipeline util instead.