### PR TITLE
Release v0.66.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.66.0 Jan. 24, 2023**
+    * Enhancements
         * Improved decomposer ``determine_periodicity`` functionality for better period guesses :pr:`3912`
         * Added ``dates_needed_for_prediction`` for time series pipelines :pr:`3906`
         * Added ``RFClassifierRFESelector``  and ``RFRegressorRFESelector`` components for feature selection using recursive feature elimination :pr:`3934`
@@ -15,12 +27,6 @@ Release Notes
         * Add ruff and use pyproject.toml (move away from setup.cfg) :pr:`3928`
         * Pinned `category-encoders`` to 2.5.1.post0 :pr:`3933`
         * Remove requirements-parser and tomli from core requirements :pr:`3948`
-    * Documentation Changes
-    * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.65.0 Jan. 3, 2023**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.65.0"
+__version__ = "0.66.0"


### PR DESCRIPTION
# v0.66.0 Jan. 25, 2023
### Enhancements
- Improved decomposer ``determine_periodicity`` functionality for better period guesses #3912
- Added ``dates_needed_for_prediction`` for time series pipelines #3906
- Added ``RFClassifierRFESelector``  and ``RFRegressorRFESelector`` components for feature selection using recursive feature elimination #3934
### Fixes
- Fixed ``set_period()`` not updating decomposer parameters #3932
- Removed second identical batch for time series problems in ``DefaultAlgorithm`` #3936
- Fix install command for alteryx-open-src-update-checker #3940
- Fixed non-prophet case of ``test_components_can_be_used_for_partial_dependence_fast_mode`` #3949
### Changes
- Updated ``PolynomialDecomposer`` to work with sktime v0.15.1 #3930
- Add ruff and use pyproject.toml (move away from setup.cfg) #3928
- Pinned `category-encoders`` to 2.5.1.post0 #3933
- Remove requirements-parser and tomli from core requirements #3948