### PR TITLE
Fix BooleanNullable SimpleImputer bug

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Fixed bug where all-null ``BooleanNullable`` columns would break the imputer during transform :pr:`3959`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.66.0 Jan. 24, 2023**
+    * Enhancements
         * Improved decomposer ``determine_periodicity`` functionality for better period guesses :pr:`3912`
         * Added ``dates_needed_for_prediction`` for time series pipelines :pr:`3906`
         * Added ``RFClassifierRFESelector``  and ``RFRegressorRFESelector`` components for feature selection using recursive feature elimination :pr:`3934`
@@ -15,12 +27,6 @@ Release Notes
         * Add ruff and use pyproject.toml (move away from setup.cfg) :pr:`3928`
         * Pinned `category-encoders`` to 2.5.1.post0 :pr:`3933`
         * Remove requirements-parser and tomli from core requirements :pr:`3948`
-    * Documentation Changes
-    * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.65.0 Jan. 3, 2023**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.65.0"
+__version__ = "0.66.0"

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -85,9 +85,13 @@ class SimpleImputer(Transformer):
         X, _ = drop_natural_language_columns(X)
 
         # Convert any boolean columns to IntegerNullable, but keep track of the columns so they can be converted back
-        self._boolean_cols = X.ww.schema._filter_cols(
-            include=["Boolean", "BooleanNullable"],
+        self._boolean_cols = list(
+            X.ww.select(
+                include=["Boolean", "BooleanNullable"],
+                return_schema=True,
+            ).columns,
         )
+        # import pdb; pdb.set_trace()
         # Make sure we're tracking Categorical columns that should be boolean as well
         self._boolean_cols.extend(
             [

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -91,7 +91,6 @@ class SimpleImputer(Transformer):
                 return_schema=True,
             ).columns,
         )
-        # import pdb; pdb.set_trace()
         # Make sure we're tracking Categorical columns that should be boolean as well
         self._boolean_cols.extend(
             [

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -88,6 +88,14 @@ class SimpleImputer(Transformer):
         self._boolean_cols = X.ww.schema._filter_cols(
             include=["Boolean", "BooleanNullable"],
         )
+        # Make sure we're tracking Categorical columns that should be boolean as well
+        self._boolean_cols.extend(
+            [
+                col
+                for col in X.ww.select("Categorical")
+                if is_categorical_actually_boolean(X, col)
+            ],
+        )
         X = set_boolean_columns_to_integer(X)
 
         # If the Dataframe only had natural language columns, do nothing.

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -186,14 +186,14 @@ def drop_natural_language_columns(X):
     return X, natural_language_columns
 
 
-def set_boolean_columns_to_categorical(X):
-    """Sets boolean columns to categorical for the imputer.
+def set_boolean_columns_to_integer(X):
+    """Sets boolean columns to integer nullable for the imputer.
 
     Args:
         X (pd.Dataframe): The dataframe that we want to impute on.
 
     Returns:
-        pd.Dataframe: the dataframe with any of its ww columns that are boolean set to categorical.
+        pd.Dataframe: the dataframe with any of its ww columns that are boolean set to integer nullable.
     """
     X = X.ww.copy()
     X_schema = X.ww.schema
@@ -201,7 +201,7 @@ def set_boolean_columns_to_categorical(X):
         subset_cols=X_schema._filter_cols(exclude=["Boolean", "BooleanNullable"]),
     )
     X_boolean_cols = X_schema._filter_cols(include=["Boolean", "BooleanNullable"])
-    new_ltypes_for_boolean_cols = {col: "Categorical" for col in X_boolean_cols}
+    new_ltypes_for_boolean_cols = {col: "IntegerNullable" for col in X_boolean_cols}
     X.ww.init(schema=original_X_schema, logical_types=new_ltypes_for_boolean_cols)
     return X
 

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -196,11 +196,20 @@ def set_boolean_columns_to_integer(X):
         pd.Dataframe: the dataframe with any of its ww columns that are boolean set to integer nullable.
     """
     X = X.ww.copy()
-    X_schema = X.ww.schema
-    original_X_schema = X_schema.get_subset_schema(
-        subset_cols=X_schema._filter_cols(exclude=["Boolean", "BooleanNullable"]),
+    original_X_schema = X.ww.schema.get_subset_schema(
+        subset_cols=list(
+            X.ww.select(
+                exclude=["Boolean", "BooleanNullable"],
+                return_schema=True,
+            ).columns,
+        ),
     )
-    X_boolean_cols = X_schema._filter_cols(include=["Boolean", "BooleanNullable"])
+    X_boolean_cols = list(
+        X.ww.select(
+            include=["Boolean", "BooleanNullable"],
+            return_schema=True,
+        ).columns,
+    )
     new_ltypes_for_boolean_cols = {col: "IntegerNullable" for col in X_boolean_cols}
     X.ww.init(schema=original_X_schema, logical_types=new_ltypes_for_boolean_cols)
     return X

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -608,3 +608,19 @@ def test_simple_imputer_errors_with_bool_and_categorical_columns(
     else:
         si = SimpleImputer()
         si.fit(X_df)
+
+
+def test_simple_imputer_boolean_nullable_all_null():
+    X_train = pd.DataFrame({"a": [pd.NA] * 20 + [1.0] + [pd.NA] * 20})
+    y = pd.Series(range(len(X_train)))
+    X_test = pd.DataFrame({"a": [pd.NA] * 10})
+
+    X_train.ww.init(logical_types={"a": "boolean_nullable"})
+    X_test.ww.init(logical_types={"a": "boolean_nullable"})
+
+    imp = SimpleImputer()
+    imp.fit(X_train, y)
+
+    X_t = imp.transform(X_test)
+    assert not X_t["a"].isna().any()
+    assert X_t.ww.logical_types["a"].type_string == "boolean_nullable"

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -487,11 +487,10 @@ def test_simple_imputer_woodwork_custom_overrides_returned_by_components(
     except ww.exceptions.TypeConversionError:
         return
 
-    impute_strategy_to_use = impute_strategy
-    if logical_type in [NaturalLanguage, Categorical]:
-        impute_strategy_to_use = "most_frequent"
+    if logical_type in [NaturalLanguage, Categorical, Boolean, BooleanNullable]:
+        impute_strategy = "most_frequent"
 
-    imputer = SimpleImputer(impute_strategy=impute_strategy_to_use)
+    imputer = SimpleImputer(impute_strategy=impute_strategy)
     transformed = imputer.fit_transform(X, y)
     assert isinstance(transformed, pd.DataFrame)
     if str(logical_type) == "IntegerNullable":

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -609,7 +609,10 @@ def test_simple_imputer_errors_with_bool_and_categorical_columns(
         si.fit(X_df)
 
 
-def test_simple_imputer_boolean_nullable_all_null():
+def test_simple_imputer_boolean_nullable_valid_train_empty_test():
+    """Test to ensure we can handle sparse boolean nullable columns, where
+    the training data has some non-null values but the test set has none.
+    """
     X_train = pd.DataFrame({"a": [pd.NA] * 20 + [1.0] + [pd.NA] * 20})
     y = pd.Series(range(len(X_train)))
     X_test = pd.DataFrame({"a": [pd.NA] * 10})
@@ -622,4 +625,4 @@ def test_simple_imputer_boolean_nullable_all_null():
 
     X_t = imp.transform(X_test)
     assert not X_t["a"].isna().any()
-    assert X_t.ww.logical_types["a"].type_string == "boolean_nullable"
+    assert isinstance(X_t.ww.logical_types["a"], BooleanNullable)

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -21,7 +21,7 @@ from evalml.pipelines.components.utils import (
     handle_component_class,
     make_balancing_dictionary,
     scikit_learn_wrapped_estimator,
-    set_boolean_columns_to_categorical,
+    set_boolean_columns_to_integer,
 )
 from evalml.problem_types import ProblemTypes
 from evalml.utils.woodwork_utils import infer_feature_types
@@ -273,7 +273,7 @@ def test_drop_natural_languages():
     assert_frame_equal(X_expected, X_t)
 
 
-def test_set_boolean_columns_to_categorical():
+def test_set_boolean_columns_to_integer():
     X = pd.DataFrame(
         {
             "bool with nan": pd.Series(
@@ -296,20 +296,20 @@ def test_set_boolean_columns_to_categorical():
     X_e = infer_feature_types(X_e)
     X_e.ww.set_types(
         logical_types={
-            "bool with nan": "Categorical",
-            "bool no nan": "Categorical",
+            "bool with nan": "IntegerNullable",
+            "bool no nan": "IntegerNullable",
         },
     )
     X = infer_feature_types(X)
-    assert len(X.ww.select(["Categorical"]) == 0)
+    assert len(X.ww.select(["IntegerNullable"]) == 0)
 
-    X = set_boolean_columns_to_categorical(X)
+    X = set_boolean_columns_to_integer(X)
 
-    assert len(X.ww.select(["Categorical"]).columns) == 2
-    assert len(X.ww.select(["Categorical"]) == 5)
+    assert len(X.ww.select(["IntegerNullable"]).columns) == 2
+    assert len(X.ww.select(["IntegerNullable"]) == 5)
 
     assert_frame_equal(
-        X.ww.select(["Categorical"]),
-        X_e.ww.select(["Categorical"]),
+        X.ww.select(["IntegerNullable"]),
+        X_e.ww.select(["IntegerNullable"]),
         check_dtype=False,
     )


### PR DESCRIPTION
Fixes the bug where all-null BooleanNullable columns will break the simple imputer during transform, when fit on nullable data that has a non-null value.