### PR TITLE
Handle Categorical Boolean values

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+        * Updated ``LabelEncoder`` to store the original typing information :pr:``
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.66.0 Jan. 24, 2023**
+    * Enhancements
         * Improved decomposer ``determine_periodicity`` functionality for better period guesses :pr:`3912`
         * Added ``dates_needed_for_prediction`` for time series pipelines :pr:`3906`
         * Added ``RFClassifierRFESelector``  and ``RFRegressorRFESelector`` components for feature selection using recursive feature elimination :pr:`3934`
@@ -15,12 +27,6 @@ Release Notes
         * Add ruff and use pyproject.toml (move away from setup.cfg) :pr:`3928`
         * Pinned `category-encoders`` to 2.5.1.post0 :pr:`3933`
         * Remove requirements-parser and tomli from core requirements :pr:`3948`
-    * Documentation Changes
-    * Testing Changes
-
-.. warning::
-
-    **Breaking Changes**
 
 
 **v0.65.0 Jan. 3, 2023**

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Updated ``LabelEncoder`` to store the original typing information :pr:``
+        * Updated ``LabelEncoder`` to store the original typing information :pr:`3960`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.65.0"
+__version__ = "0.66.0"

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -23,6 +23,7 @@ class LabelEncoder(Transformer):
     def __init__(self, positive_label=None, random_seed=0, **kwargs):
         parameters = {"positive_label": positive_label}
         parameters.update(kwargs)
+        self.original_typing = ""
 
         super().__init__(
             parameters=parameters,
@@ -46,6 +47,7 @@ class LabelEncoder(Transformer):
         if y is None:
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
+        self.original_typing = str(y_ww.ww.logical_type)
         self.mapping = {val: i for i, val in enumerate(sorted(y_ww.unique()))}
         if self.parameters["positive_label"] is not None:
             if len(self.mapping) != 2:
@@ -114,5 +116,5 @@ class LabelEncoder(Transformer):
         if y is None:
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
-        y_it = infer_feature_types(y_ww.map(self.inverse_mapping))
+        y_it = infer_feature_types(y_ww.map(self.inverse_mapping), self.original_typing)
         return y_it

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -47,6 +47,7 @@ class LabelEncoder(Transformer):
         if y is None:
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
+        # remove this when typelib gets deprecated
         self.original_typing = str(y_ww.ww.logical_type)
         self.mapping = {val: i for i, val in enumerate(sorted(y_ww.unique()))}
         if self.parameters["positive_label"] is not None:

--- a/evalml/pipelines/components/transformers/encoders/label_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/label_encoder.py
@@ -47,7 +47,6 @@ class LabelEncoder(Transformer):
         if y is None:
             raise ValueError("y cannot be None!")
         y_ww = infer_feature_types(y)
-        # remove this when typelib gets deprecated
         self.original_typing = str(y_ww.ww.logical_type)
         self.mapping = {val: i for i, val in enumerate(sorted(y_ww.unique()))}
         if self.parameters["positive_label"] is not None:

--- a/evalml/tests/component_tests/test_label_encoder.py
+++ b/evalml/tests/component_tests/test_label_encoder.py
@@ -223,11 +223,15 @@ def test_label_encoder_with_positive_label_with_custom_indices():
     assert_index_equal(y_with_custom_indices.index, y_transformed.index)
 
 
-def test_label_encoder_categorical_boolean_values():
+@pytest.mark.parametrize("logical_type", ["Categorical", "Boolean"])
+def test_label_encoder_categorical_handled_properly_boolean_values(logical_type):
+    # adding this test after WW version 0.21.2, which introduces auto-boolean inference
+    # This broke this test case where the logical type converts to boolean after inverse_transform
+    # because of woodwork inference
     X = pd.DataFrame({})
     # binary
     y = pd.Series(["yes", "yes", "no", "yes"])
-    y = ww.init_series(y, logical_type="Categorical")
+    y = ww.init_series(y, logical_type=logical_type)
     y_expected = pd.Series([1, 1, 0, 1])
     encoder = LabelEncoder()
     encoder.fit(X, y)

--- a/evalml/tests/component_tests/test_label_encoder.py
+++ b/evalml/tests/component_tests/test_label_encoder.py
@@ -221,3 +221,17 @@ def test_label_encoder_with_positive_label_with_custom_indices():
     y_with_custom_indices = pd.Series(["b", "a", "a"], index=[5, 6, 7])
     _, y_transformed = encoder.transform(None, y_with_custom_indices)
     assert_index_equal(y_with_custom_indices.index, y_transformed.index)
+
+
+def test_label_encoder_categorical_boolean_values():
+    X = pd.DataFrame({})
+    # binary
+    y = pd.Series(["yes", "yes", "no", "yes"])
+    y = ww.init_series(y, logical_type="Categorical")
+    y_expected = pd.Series([1, 1, 0, 1])
+    encoder = LabelEncoder()
+    encoder.fit(X, y)
+    X_t, y_t = encoder.transform(X, y)
+    pd.testing.assert_series_equal(y_t, y_expected)
+    y_inverse = encoder.inverse_transform(y_t)
+    pd.testing.assert_series_equal(y_inverse, y)


### PR DESCRIPTION
Previously, if we passed in a categorical column (ie 'yes', 'no') that gets inferred as boolean through WW's new boolean typing, the `infer_feature_types` line in `LabelEncoder.inverseTransform` will transform the mapped column back into boolean. 

This PR puts up a fix for that.