### PR TITLE
Allow float categories to be passed into CatBoost estimators

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
         * Re-added ``TimeSeriesPipeline.should_skip_featurization`` to fix bug where data would get featurized unnecessarily :pr:`3964`
+        * Allow float categories to be passed into CatBoost estimators :pr:`3966`
     * Changes
         * Update pyproject.toml to correctly specify the data filepaths :pr:`3967`
     * Documentation Changes

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -135,6 +135,7 @@ class CatBoostClassifier(Estimator):
             pd.DataFrame: Predicted values.
         """
         X = infer_feature_types(X)
+        X = handle_float_categories_for_catboost(X)
         predictions = self._component_obj.predict(X)
         if predictions.ndim == 2 and predictions.shape[1] == 1:
             predictions = predictions.flatten()

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -9,6 +9,7 @@ from skopt.space import Integer, Real
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
 from evalml.pipelines.components.transformers import LabelEncoder
+from evalml.pipelines.components.utils import handle_float_categories_for_catboost
 from evalml.problem_types import ProblemTypes
 from evalml.utils import import_or_raise, infer_feature_types
 
@@ -119,6 +120,8 @@ class CatBoostClassifier(Estimator):
         if y.nunique() <= 2:
             self._label_encoder = LabelEncoder()
             y = self._label_encoder.fit_transform(None, y)[1]
+
+        X = handle_float_categories_for_catboost(X)
         self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
         return self
 

--- a/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/catboost_classifier.py
@@ -132,7 +132,7 @@ class CatBoostClassifier(Estimator):
             X (pd.DataFrame): Data of shape [n_samples, n_features].
 
         Returns:
-            pd.DataFrame: Predicted values.
+            pd.Series: Predicted values.
         """
         X = infer_feature_types(X)
         X = handle_float_categories_for_catboost(X)
@@ -145,6 +145,20 @@ class CatBoostClassifier(Estimator):
             )
         predictions = infer_feature_types(predictions)
         predictions.index = X.index
+        return predictions
+
+    def predict_proba(self, X):
+        """Make prediction probabilities using the fitted CatBoost classifier.
+
+        Args:
+            X (pd.DataFrame): Data of shape [n_samples, n_features].
+
+        Returns:
+            pd.DataFrame: Predicted probability values.
+        """
+        X = infer_feature_types(X)
+        X = handle_float_categories_for_catboost(X)
+        predictions = super().predict_proba(X)
         return predictions
 
     @property

--- a/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
@@ -119,6 +119,19 @@ class CatBoostRegressor(Estimator):
         self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
         return self
 
+    def predict(self, X):
+        """Make predictions using the fitted CatBoost regressor.
+
+        Args:
+            X (pd.DataFrame): Data of shape [n_samples, n_features].
+
+        Returns:
+            pd.DataFrame: Predicted values.
+        """
+        X = handle_float_categories_for_catboost(X)
+        predictions = super().predict(X)
+        return predictions
+
     @property
     def feature_importance(self):
         """Feature importance of fitted CatBoost regressor."""

--- a/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
@@ -128,6 +128,7 @@ class CatBoostRegressor(Estimator):
         Returns:
             pd.DataFrame: Predicted values.
         """
+        X = infer_feature_types(X)
         X = handle_float_categories_for_catboost(X)
         predictions = super().predict(X)
         return predictions

--- a/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/catboost_regressor.py
@@ -7,6 +7,7 @@ from skopt.space import Integer, Real
 
 from evalml.model_family import ModelFamily
 from evalml.pipelines.components.estimators import Estimator
+from evalml.pipelines.components.utils import handle_float_categories_for_catboost
 from evalml.problem_types import ProblemTypes
 from evalml.utils import (
     downcast_int_nullable_to_double,
@@ -113,6 +114,8 @@ class CatBoostRegressor(Estimator):
         self.input_feature_names = list(X.columns)
         X, y = super()._manage_woodwork(X, y)
         X = downcast_int_nullable_to_double(X)
+
+        X = handle_float_categories_for_catboost(X)
         self._component_obj.fit(X, y, silent=True, cat_features=cat_cols)
         return self
 

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -474,10 +474,23 @@ def make_balancing_dictionary(y, sampling_ratio):
 
 
 def handle_float_categories_for_catboost(X):
-    """Catboost cannot handle data in X that is Categoriecal with floating point categories.
+    """Updates input data to be compatible with CatBoost estimators.
 
-    When those values can be converted to integers, they should be. If they cannot, we should
-    convert them to string categories or error DECIDE WHICH --> fill this out completly
+    CatBoost cannot handle data in X that is the Categorical Woodwork logical type with floating point categories.
+    This utility determines if the floating point categories can be converted to integers
+    without truncating any data, and if they can be, converts them to int64 categories.
+    Will not attempt to use values that are truly floating points.
+
+    Args:
+        X (pd.DataFrame): Input data to CatBoost that has Woodwork initialized
+
+    Returns:
+        DataFrame: Input data with exact same Woodwork typing info as the original but with any float categories
+            converted to be int64 when possible.
+
+    Raises:
+        ValueError: if the numeric categories are actual floats that cannot be converted to integers
+            without truncating data
     """
     original_schema = X.ww.schema
     original_dtypes = X.dtypes
@@ -508,7 +521,7 @@ def handle_float_categories_for_catboost(X):
         else:
             # CatBoost explanation as to why they don't support float categories: https://catboost.ai/en/docs/concepts/faq#floating-point-values
             # CatBoost bug keeping us from converting to string: https://github.com/catboost/catboost/issues/1965
-            # Pandas bug keeping us from converting `.astype("string").astype("object")` to create the categories:
+            # Pandas bug keeping us from converting `.astype("string").astype("object")`: https://github.com/pandas-dev/pandas/issues/51074
             raise ValueError(
                 f"Invalid category found in {col}. CatBoost does not support floats as categories.",
             )

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -1,5 +1,8 @@
 import warnings
 
+import pandas as pd
+import woodwork as ww
+
 from evalml.pipelines.components import CatBoostClassifier
 from evalml.utils import SEED_BOUNDS
 
@@ -35,3 +38,27 @@ def test_catboost_classifier_init_thread_count():
         CatBoostClassifier(thread_count=2)
     assert len(w) == 1
     assert "Parameter 'thread_count' will be ignored. " in str(w[-1].message)
+
+
+def test_catboost_classifier_double_categories_in_X():
+    X = pd.DataFrame({"double_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20)})
+    y = pd.Series(range(100))
+    y.ww.init()
+    X.ww.init(logical_types={"double_cats": "Categorical"})
+
+    clf = CatBoostClassifier()
+    clf.fit(X, y)
+
+
+def test_catboost_classifier_double_categories_in_y():
+    X = pd.DataFrame({"cats": pd.Series([1, 2, 3, 4, 5] * 20)})
+    X.ww.init(logical_types={"cats": "Categorical"})
+    # --> this was never causing errors it seems - test more though to confirm!!
+    y = pd.Series(
+        [1.0, 2.0, 3.0, 4.0, 5.0] * 20,
+    )
+    ww.init_series(y, logical_type="Categorical")
+
+    clf = CatBoostClassifier()
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, CatBoostClassifier)

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -40,10 +40,8 @@ def test_catboost_classifier_init_thread_count():
     assert "Parameter 'thread_count' will be ignored. " in str(w[-1].message)
 
 
-def test_catboost_classifier_double_categories_in_y():
-    X = pd.DataFrame({"cats": pd.Series([1, 2, 3, 4, 5] * 20)})
-    X.ww.init(logical_types={"cats": "Categorical"})
-    # --> this was never causing errors it seems - test more though to confirm!!
+def test_catboost_classifier_double_categories_in_y(categorical_floats_df):
+    X = categorical_floats_df
     y = pd.Series(
         [1.0, 2.0, 3.0, 4.0, 5.0] * 20,
     )
@@ -62,5 +60,4 @@ def test_catboost_classifier_double_categories_in_X(categorical_floats_df):
     fitted = clf.fit(X, y)
     assert isinstance(fitted, CatBoostClassifier)
     predictions = clf.predict(X)
-    # --> double check a series is expected - maybe diff for classification
     assert isinstance(predictions, pd.Series)

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -61,3 +61,5 @@ def test_catboost_classifier_double_categories_in_X(categorical_floats_df):
     assert isinstance(fitted, CatBoostClassifier)
     predictions = clf.predict(X)
     assert isinstance(predictions, pd.Series)
+    predictions = clf.predict_proba(X)
+    assert isinstance(predictions, pd.DataFrame)

--- a/evalml/tests/component_tests/test_catboost_classifier.py
+++ b/evalml/tests/component_tests/test_catboost_classifier.py
@@ -40,16 +40,6 @@ def test_catboost_classifier_init_thread_count():
     assert "Parameter 'thread_count' will be ignored. " in str(w[-1].message)
 
 
-def test_catboost_classifier_double_categories_in_X():
-    X = pd.DataFrame({"double_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20)})
-    y = pd.Series(range(100))
-    y.ww.init()
-    X.ww.init(logical_types={"double_cats": "Categorical"})
-
-    clf = CatBoostClassifier()
-    clf.fit(X, y)
-
-
 def test_catboost_classifier_double_categories_in_y():
     X = pd.DataFrame({"cats": pd.Series([1, 2, 3, 4, 5] * 20)})
     X.ww.init(logical_types={"cats": "Categorical"})
@@ -62,3 +52,15 @@ def test_catboost_classifier_double_categories_in_y():
     clf = CatBoostClassifier()
     fitted = clf.fit(X, y)
     assert isinstance(fitted, CatBoostClassifier)
+
+
+def test_catboost_classifier_double_categories_in_X(categorical_floats_df):
+    X = categorical_floats_df
+    y = pd.Series([1, 2, 3, 4, 5] * 20)
+
+    clf = CatBoostClassifier()
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, CatBoostClassifier)
+    predictions = clf.predict(X)
+    # --> double check a series is expected - maybe diff for classification
+    assert isinstance(predictions, pd.Series)

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -48,6 +48,3 @@ def test_catboost_regressor_double_categories_in_X(categorical_floats_df):
     assert isinstance(fitted, CatBoostRegressor)
     predictions = clf.predict(X)
     assert isinstance(predictions, pd.Series)
-
-
-# --> consider adding a test that confirms the original catboost error is still present - if it goes away we can remove this logic but keep the tests in the component test

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -50,13 +50,4 @@ def test_catboost_regressor_double_categories_in_X(categorical_floats_df):
     assert isinstance(predictions, pd.Series)
 
 
-# --> do we need to actually predict? Or do something after just fitting?
-
-
-# test with float in X
-# test that converting to Int64 isn't problematic for estimator
-# test that when nans are present it's not problematic for estimator
-# test that when we turn floats to strings it's not problematic for estimator
-
-# --> these need to test with predict as well once fit is fixed!
-# --> consider adding at est that confirms the original catboost error is still present - if it goes away we can remove this logic but keep the tests in the component test
+# --> consider adding a test that confirms the original catboost error is still present - if it goes away we can remove this logic but keep the tests in the component test

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -1,5 +1,7 @@
 import warnings
 
+import pandas as pd
+
 from evalml.pipelines.components import CatBoostRegressor
 from evalml.utils import SEED_BOUNDS
 
@@ -35,3 +37,24 @@ def test_catboost_regressor_init_thread_count():
         CatBoostRegressor(thread_count=2)
     assert len(w) == 1
     assert "Parameter 'thread_count' will be ignored. " in str(w[-1].message)
+
+
+def test_catboost_regressor_double_categories_in_X():
+    X = pd.DataFrame({"double_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20)})
+    y = pd.Series(range(100))
+    X.ww.init(logical_types={"double_cats": "Categorical"})
+
+    clf = CatBoostRegressor()
+    fitted = clf.fit(X, y)
+    assert isinstance(fitted, CatBoostRegressor)
+
+
+# --> do we need to actually predict? Or do something after just fitting?
+
+
+# test with float in X
+# test that converting to Int64 isn't problematic for estimator
+# test that when nans are present it's not problematic for estimator
+# test that when we turn floats to strings it's not problematic for estimator
+
+# --> these need to test with predict as well once fit is fixed!

--- a/evalml/tests/component_tests/test_catboost_regressor.py
+++ b/evalml/tests/component_tests/test_catboost_regressor.py
@@ -39,14 +39,15 @@ def test_catboost_regressor_init_thread_count():
     assert "Parameter 'thread_count' will be ignored. " in str(w[-1].message)
 
 
-def test_catboost_regressor_double_categories_in_X():
-    X = pd.DataFrame({"double_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20)})
-    y = pd.Series(range(100))
-    X.ww.init(logical_types={"double_cats": "Categorical"})
+def test_catboost_regressor_double_categories_in_X(categorical_floats_df):
+    X = categorical_floats_df
+    y = pd.Series([1, 2, 3, 4, 5] * 20)
 
     clf = CatBoostRegressor()
     fitted = clf.fit(X, y)
     assert isinstance(fitted, CatBoostRegressor)
+    predictions = clf.predict(X)
+    assert isinstance(predictions, pd.Series)
 
 
 # --> do we need to actually predict? Or do something after just fitting?
@@ -58,3 +59,4 @@ def test_catboost_regressor_double_categories_in_X():
 # test that when we turn floats to strings it's not problematic for estimator
 
 # --> these need to test with predict as well once fit is fixed!
+# --> consider adding at est that confirms the original catboost error is still present - if it goes away we can remove this logic but keep the tests in the component test

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -320,36 +320,45 @@ def test_set_boolean_columns_to_integer():
     )
 
 
-def test_handle_float_categories_for_catboost():
-    X = pd.DataFrame({"double_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20)})
-    X.ww.init(logical_types={"double_cats": "Categorical"})
+def test_handle_float_categories_for_catboost(categorical_floats_df):
+    X = categorical_floats_df.ww[["double_int_cats"]]
 
-    assert X["double_cats"].dtype.categories.dtype == "float64"
     X_t = handle_float_categories_for_catboost(X)
-    assert X_t["double_cats"].dtype.categories.dtype == "Int64"
+    assert X["double_int_cats"].dtype.categories.dtype == "float64"
+    assert X_t["double_int_cats"].dtype.categories.dtype == "int64"
 
 
 def test_handle_float_categories_for_catboost_with_nans():
+    # --> maybe this should error - there hsouldn't be any nans present at this stage!
     X = pd.DataFrame({"double_cats_nan": pd.Series([1.0, 2.0, None, 4.0, 5.0] * 20)})
     X.ww.init(logical_types={"double_cats_nan": "Categorical"})
 
-    assert X["double_cats_nan"].dtype.categories.dtype == "float64"
     X_t = handle_float_categories_for_catboost(X)
+    assert X["double_cats_nan"].dtype.categories.dtype == "float64"
     assert X_t["double_cats_nan"].dtype.categories.dtype == "Int64"
 
 
-def test_handle_float_categories_for_catboost_with_actual_floats():
-    X = pd.DataFrame({"double_cats_nan": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20)})
-    X.ww.init(logical_types={"double_cats_nan": "Categorical"})
+def test_handle_float_categories_for_catboost_with_actual_floats(categorical_floats_df):
+    X = categorical_floats_df.ww[["really_double_cats"]]
 
-    assert X["double_cats_nan"].dtype.categories.dtype == "float64"
     X_t = handle_float_categories_for_catboost(X)
-    assert X_t["double_cats_nan"].dtype.categories.dtype == "string"
+    assert X["really_double_cats"].dtype.categories.dtype == "float64"
+    assert X_t["really_double_cats"].dtype.categories.dtype == "O"
 
 
-def test_handle_float_categories_for_catboost_no_categorical_cols():
-    X = pd.DataFrame({"double_cats_nan": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20)})
-    X.ww.init()
+def test_handle_float_categories_for_catboost_no_categorical_cols(
+    categorical_floats_df,
+):
+    X = categorical_floats_df.ww[["int_col"]]
+
+    X_t = handle_float_categories_for_catboost(X)
+    pd.testing.assert_frame_equal(X, X_t)
+
+
+def test_handle_float_categories_for_catboost_string_categorical_cols(
+    categorical_floats_df,
+):
+    X = categorical_floats_df.ww[["string_cats"]]
 
     X_t = handle_float_categories_for_catboost(X)
     pd.testing.assert_frame_equal(X, X_t)
@@ -362,5 +371,3 @@ def test_handle_float_categories_for_catboost_no_categorical_cols():
 # test in larger dataset with other categoricals that cant be converted to numeric
 # test with actual floating points like 1.1
 # --> these need to test with transform as well once fit is fixed!
-# --> test no categorical cols
-# test no float c ats

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -331,10 +331,11 @@ def test_handle_float_categories_for_catboost(categorical_floats_df):
 
     expected_dtype_before_and_after = {
         "double_int_cats": ("float64", "int64"),
-        "really_double_cats": ("float64", "O"),
         # These shouldn't change
         "string_cats": None,
+        "int_cats": None,
         "int_col": None,
+        "double_col": None,
     }
 
     for col in X.columns:
@@ -349,20 +350,19 @@ def test_handle_float_categories_for_catboost(categorical_floats_df):
             pd.testing.assert_series_equal(X[col], X_t[col])
 
 
-# def test_handle_float_categories_for_catboost_with_nans():
-#     # --> maybe this should error - there hsouldn't be any nans present at this stage!
-#     X = pd.DataFrame({"double_cats_nan": pd.Series([1.0, 2.0, None, 4.0, 5.0] * 20)})
-#     X.ww.init(logical_types={"double_cats_nan": "Categorical"})
+def test_handle_float_categories_for_catboost_actual_floats():
+    X = pd.DataFrame({"really_double_cats": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20)})
+    X.ww.init(logical_types={"really_double_cats": "Categorical"})
 
-#     X_t = handle_float_categories_for_catboost(X)
-#     assert X["double_cats_nan"].dtype.categories.dtype == "float64"
-#     assert X_t["double_cats_nan"].dtype.categories.dtype == "Int64"
+    error = "CatBoost does not support floats as categories."
+    with pytest.raises(ValueError, match=error):
+        handle_float_categories_for_catboost(X)
 
 
 def test_handle_float_categories_for_catboost_noop(
     categorical_floats_df,
 ):
-    X = categorical_floats_df.ww[["string_cats", "int_col"]]
+    X = categorical_floats_df.ww[["string_cats", "int_col", "int_cats"]]
 
     X_t = handle_float_categories_for_catboost(X)
     pd.testing.assert_frame_equal(X, X_t)

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -2319,17 +2319,19 @@ def categorical_floats_df():
     X = pd.DataFrame(
         {
             "double_int_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20),
-            "really_double_cats": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20),
             "string_cats": pd.Series(["a", "b", "c", "d", "e"] * 20),
+            "int_cats": pd.Series([1, 2, 3, 4, 5] * 20),
             "int_col": pd.Series([1, 2, 3, 4, 5] * 20),
+            "double_col": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20),
         },
     )
     X.ww.init(
         logical_types={
             "double_int_cats": "Categorical",
-            "really_double_cats": "Categorical",
             "string_cats": "Categorical",
+            "int_cats": "Categorical",
             "int_col": "Integer",
+            "double_col": "Double",
         },
     )
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -2312,3 +2312,25 @@ def generate_seasonal_data():
             return generate_real_data
 
     return _return_proper_func
+
+
+@pytest.fixture
+def categorical_floats_df():
+    X = pd.DataFrame(
+        {
+            "double_int_cats": pd.Series([1.0, 2.0, 3.0, 4.0, 5.0] * 20),
+            "really_double_cats": pd.Series([1.2, 2.3, 3.9, 4.1, 5.5] * 20),
+            "string_cats": pd.Series(["a", "b", "c", "d", "e"] * 20),
+            "int_col": pd.Series([1, 2, 3, 4, 5] * 20),
+        },
+    )
+    X.ww.init(
+        logical_types={
+            "double_int_cats": "Categorical",
+            "really_double_cats": "Categorical",
+            "string_cats": "Categorical",
+            "int_col": "Integer",
+        },
+    )
+
+    return X


### PR DESCRIPTION
fixes https://github.com/alteryx/evalml/issues/3965

Since catboost cannot handle float categories, converts categories that are really integers to be `int64`
