### PR TITLE
Release v0.67.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,18 +3,23 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Re-added ``TimeSeriesPipeline.should_skip_featurization`` to fix bug where data would get featurized unnecessarily :pr:`3964`
-        * Allow float categories to be passed into CatBoost estimators :pr:`3966`
     * Changes
-        * Update pyproject.toml to correctly specify the data filepaths :pr:`3967`
     * Documentation Changes
-        * Added demo for prediction intervals :pr:`3954`
     * Testing Changes
 
 .. warning::
 
     **Breaking Changes**
 
+
+**v0.67.0 Jan. 31, 2023**
+    * Fixes
+        * Re-added ``TimeSeriesPipeline.should_skip_featurization`` to fix bug where data would get featurized unnecessarily :pr:`3964`
+        * Allow float categories to be passed into CatBoost estimators :pr:`3966`
+    * Changes
+        * Update pyproject.toml to correctly specify the data filepaths :pr:`3967`
+    * Documentation Changes
+        * Added demo for prediction intervals :pr:`3954`
 
 **v0.66.1 Jan. 26, 2023**
     * Fixes

--- a/docs/source/user_guide/data_checks.ipynb
+++ b/docs/source/user_guide/data_checks.ipynb
@@ -805,7 +805,6 @@
     "\n",
     "\n",
     "class MyCustomDataChecks(DataChecks):\n",
-    "\n",
     "    data_checks = [\n",
     "        NullDataCheck,\n",
     "        InvalidTargetDataCheck,\n",

--- a/docs/source/user_guide/model_understanding.ipynb
+++ b/docs/source/user_guide/model_understanding.ipynb
@@ -783,7 +783,6 @@
     "\n",
     "\n",
     "def hinge_loss(y_true, y_pred_proba):\n",
-    "\n",
     "    probabilities = np.clip(y_pred_proba.iloc[:, 1], 0.001, 0.999)\n",
     "    y_true[y_true == 0] = -1\n",
     "\n",

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.66.1"
+__version__ = "0.67.0"

--- a/evalml/data_checks/null_data_check.py
+++ b/evalml/data_checks/null_data_check.py
@@ -280,7 +280,6 @@ class NullDataCheck(DataCheck):
             )
 
         if moderately_null_cols:
-
             impute_strategies_dict = {}
             for col in moderately_null_cols:
                 col_in_df = X.ww[col]

--- a/evalml/model_understanding/feature_explanations.py
+++ b/evalml/model_understanding/feature_explanations.py
@@ -43,7 +43,6 @@ def readable_explanation(
         )
 
     if importance_method == "permutation":
-
         if objective == "auto":
             objective = evalml.automl.get_default_primary_search_objective(
                 pipeline.problem_type,

--- a/evalml/pipelines/component_graph.py
+++ b/evalml/pipelines/component_graph.py
@@ -585,7 +585,6 @@ class ComponentGraph:
         for component_instance in transformers:
             component_provenance = component_instance._get_feature_provenance()
             for component_input, component_output in component_provenance.items():
-
                 # Case 1: The transformer created features from one of the original features
                 if component_input in provenance:
                     provenance[component_input] = provenance[component_input].union(

--- a/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
+++ b/evalml/pipelines/components/transformers/encoders/onehot_encoder.py
@@ -277,7 +277,6 @@ class OneHotEncoder(Transformer, metaclass=OneHotEncoderMeta):
             unique_encoded_columns = []
             encoded_features_to_drop = []
             for cat_index, category in enumerate(column_categories):
-
                 # Drop categories specified by the user
                 if (
                     self._encoder.drop_idx_ is not None

--- a/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
+++ b/evalml/pipelines/components/transformers/feature_selection/rf_regressor_feature_selector.py
@@ -47,7 +47,6 @@ class RFRegressorSelectFromModel(FeatureSelector):
         random_seed=0,
         **kwargs,
     ):
-
         parameters = {
             "number_features": number_features,
             "n_estimators": n_estimators,

--- a/evalml/pipelines/components/transformers/preprocessing/time_series_featurizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/time_series_featurizer.py
@@ -241,7 +241,6 @@ class TimeSeriesFeaturizer(Transformer):
                 X_ww[categorical_columns],
             )
             for col_name in cols_to_delay:
-
                 col = X_ww[col_name]
                 if col_name in categorical_columns:
                     col = X_categorical[col_name]

--- a/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
+++ b/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
@@ -9,7 +9,6 @@ from evalml.utils import infer_feature_types
 
 
 class _ExtractFeaturesWithTransformPrimitives(Transformer):
-
     hyperparameter_ranges = {}
     """{}"""
 

--- a/evalml/pipelines/time_series_pipeline_base.py
+++ b/evalml/pipelines/time_series_pipeline_base.py
@@ -108,7 +108,6 @@ class TimeSeriesPipelineBase(PipelineBase, metaclass=PipelineBaseMeta):
             )
             and self.gap
         ):
-
             # The training data does not have the gap dates so don't need to include them
             last_row_of_training -= self.gap
 

--- a/evalml/tests/automl_tests/parallel_tests/test_cf_engine.py
+++ b/evalml/tests/automl_tests/parallel_tests/test_cf_engine.py
@@ -166,7 +166,6 @@ def test_submit_evaluate_job_single(
     pool = get_pool(pool_type, thread_pool, process_pool)
 
     with CFClient(pool) as client:
-
         pipeline = BinaryClassificationPipeline(
             component_graph=["Logistic Regression Classifier"],
             parameters={"Logistic Regression Classifier": {"n_jobs": 1}},
@@ -232,7 +231,6 @@ def test_submit_evaluate_jobs_multiple(
     pool = get_pool(pool_type, thread_pool, process_pool)
 
     with CFClient(pool) as client:
-
         pipelines = [
             BinaryClassificationPipeline(
                 component_graph=["Logistic Regression Classifier"],
@@ -296,7 +294,6 @@ def test_submit_scoring_job_single(
     pool = get_pool(pool_type, thread_pool, process_pool)
 
     with CFClient(pool) as client:
-
         pipeline = BinaryClassificationPipeline(
             component_graph=["Logistic Regression Classifier"],
             parameters={"Logistic Regression Classifier": {"n_jobs": 1}},
@@ -343,7 +340,6 @@ def test_submit_scoring_jobs_multiple(
     pool = get_pool(pool_type, thread_pool, process_pool)
 
     with CFClient(pool) as client:
-
         pipelines = [
             BinaryClassificationPipeline(
                 component_graph=["Logistic Regression Classifier"],

--- a/evalml/tests/automl_tests/parallel_tests/test_dask_engine.py
+++ b/evalml/tests/automl_tests/parallel_tests/test_dask_engine.py
@@ -116,7 +116,6 @@ def test_submit_evaluate_job_single(X_y_binary_cls):
     )
 
     with DaskEngine() as engine:
-
         # Verify that engine evaluates a pipeline
         pipeline_future = engine.submit_evaluation_job(
             X=X,

--- a/evalml/tests/automl_tests/test_automl.py
+++ b/evalml/tests/automl_tests/test_automl.py
@@ -3077,7 +3077,6 @@ def test_automl_rerun(AutoMLTestEnv, X_y_binary, caplog):
 
 
 def test_timeseries_baseline_init_with_correct_gap_max_delay(AutoMLTestEnv, ts_data):
-
     X, _, y = ts_data()
     automl = AutoMLSearch(
         X_train=X,
@@ -3130,7 +3129,6 @@ def test_automl_does_not_include_positive_only_objectives_by_default(
     problem_type,
     X_y_regression,
 ):
-
     X, y = X_y_regression
 
     only_positive = []
@@ -3156,7 +3154,6 @@ def test_automl_does_not_include_positive_only_objectives_by_default(
 
 @pytest.mark.parametrize("non_core_objective", get_non_core_objectives())
 def test_automl_validate_objective(non_core_objective, X_y_regression):
-
     X, y = X_y_regression
 
     with pytest.raises(ValueError, match="is not allowed in AutoML!"):
@@ -3528,7 +3525,6 @@ def test_train_batch_works(
     stackable_classifiers,
     caplog,
 ):
-
     exceptions_to_check = [
         str(e) for e in pipeline_fit_side_effect if isinstance(e, Exception)
     ]
@@ -3653,7 +3649,6 @@ def test_score_batch_works(
     stackable_classifiers,
     caplog,
 ):
-
     exceptions_to_check = []
     expected_scores = {}
     for i, e in enumerate(pipeline_score_side_effect):
@@ -3700,7 +3695,6 @@ def test_score_batch_works(
     def score_batch_and_check():
         caplog.clear()
         with env.test_context(mock_score_side_effect=pipeline_score_side_effect):
-
             scores = automl.score_pipelines(
                 pipelines,
                 X,
@@ -3854,7 +3848,6 @@ def test_automl_supports_float_targets_for_classification(
     ],
 )
 def test_automl_issues_beta_warning_for_time_series(problem_type, X_y_binary):
-
     X, y = X_y_binary
 
     with warnings.catch_warnings(record=True) as warn:
@@ -4872,7 +4865,6 @@ def test_automl_with_iterative_algorithm_puts_ts_estimators_first(
     AutoMLTestEnv,
     is_using_windows,
 ):
-
     X, _, y = ts_data()
 
     env = AutoMLTestEnv("time series regression")
@@ -5004,7 +4996,6 @@ def test_automl_does_not_restrict_use_covariates_if_user_specified(
     is_using_windows,
     X_y_binary,
 ):
-
     X, y = X_y_binary
     X = pd.DataFrame(X)
     X["Date"] = pd.date_range("2010-01-01", periods=X.shape[0])

--- a/evalml/tests/automl_tests/test_automl_search_classification.py
+++ b/evalml/tests/automl_tests/test_automl_search_classification.py
@@ -611,7 +611,6 @@ def test_max_time_units(X_y_binary):
 
 
 def test_plot_iterations_max_iterations(X_y_binary, go):
-
     X, y = X_y_binary
 
     automl = AutoMLSearch(

--- a/evalml/tests/automl_tests/test_automl_search_regression.py
+++ b/evalml/tests/automl_tests/test_automl_search_regression.py
@@ -143,7 +143,6 @@ def test_categorical_regression(X_y_categorical_regression):
 
 
 def test_plot_iterations_max_iterations(X_y_regression, go):
-
     X, y = X_y_regression
 
     automl = AutoMLSearch(
@@ -167,7 +166,6 @@ def test_plot_iterations_max_iterations(X_y_regression, go):
 
 
 def test_plot_iterations_max_time(AutoMLTestEnv, X_y_regression, go):
-
     X, y = X_y_regression
 
     automl = AutoMLSearch(

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -43,7 +43,6 @@ def test_set_time_index(decomposer_child_class):
     decomposer_list,
 )
 def test_decomposer_init_raises_error_if_degree_not_int(decomposer_child_class):
-
     with pytest.raises(TypeError, match="Received str"):
         decomposer_child_class(degree="1")
 
@@ -459,7 +458,6 @@ def test_decomposer_determine_periodicity(
     synthetic_data,
     generate_seasonal_data,
 ):
-
     X, y = generate_seasonal_data(real_or_synthetic=synthetic_data)(
         period,
         trend_degree=trend_degree,

--- a/evalml/tests/component_tests/decomposer_tests/test_polynomial_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_polynomial_decomposer.py
@@ -42,7 +42,6 @@ def test_polynomial_decomposer_get_trend_dataframe(
     ts_data_quadratic_trend,
     ts_data_cubic_trend,
 ):
-
     if degree == 1:
         X_input, _, y_input = ts_data()
     elif degree == 2:

--- a/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_stl_decomposer.py
@@ -69,7 +69,6 @@ def test_stl_fit_transform_in_sample(
     synthetic_data,
     generate_seasonal_data,
 ):
-
     X, y = generate_seasonal_data(real_or_synthetic=synthetic_data)(
         period,
         freq_str=freq,
@@ -201,7 +200,6 @@ def test_stl_decomposer_get_trend_dataframe(
     fit_before_decompose,
     variateness,
 ):
-
     period = 7
     X, y = generate_seasonal_data(real_or_synthetic="synthetic")(
         period=period,
@@ -232,7 +230,6 @@ def test_stl_decomposer_get_trend_dataframe(
             [get_trend_dataframe_format_correct(x) for idx, x in enumerate(result_dfs)]
 
     elif transformer_fit_on_data != "in-sample":
-
         y_t_new = build_test_target(
             subset_y,
             period,
@@ -276,7 +273,6 @@ def test_stl_decomposer_get_trend_dataframe(
 def test_stl_decomposer_get_trend_dataframe_sets_time_index_internally(
     generate_seasonal_data,
 ):
-
     X, y = generate_seasonal_data(real_or_synthetic="synthetic")(
         period=7,
         set_time_index=False,

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -1301,7 +1301,6 @@ def test_all_transformers_check_fit_input_type(
     make_data_type,
     ts_data,
 ):
-
     X, y = X_y_binary
     X = make_data_type(data_type, X)
     y = make_data_type(data_type, y)
@@ -1721,7 +1720,6 @@ def test_estimator_fit_respects_custom_indices(
     ts_data,
     helper_functions,
 ):
-
     supported_problem_types = estimator_class.supported_problem_types
 
     ts_problem = False

--- a/evalml/tests/component_tests/test_ft_transform_primitive_components.py
+++ b/evalml/tests/component_tests/test_ft_transform_primitive_components.py
@@ -232,7 +232,6 @@ def test_component_fit_transform(
     make_expected_ltypes,
     df_with_url_and_email,
 ):
-
     data = make_data(df_with_url_and_email)
     expected = make_expected(data)
     expected_logical_types = make_expected_ltypes()

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -51,7 +51,6 @@ def test_imputer_init(
     numeric_impute_strategy,
     boolean_impute_strategy,
 ):
-
     imputer = Imputer(
         categorical_impute_strategy=categorical_impute_strategy,
         numeric_impute_strategy=numeric_impute_strategy,

--- a/evalml/tests/component_tests/test_lgbm_classifier.py
+++ b/evalml/tests/component_tests/test_lgbm_classifier.py
@@ -47,7 +47,6 @@ def test_lightgbm_classifier_random_seed_bounds_seed(X_y_binary):
 
 
 def test_fit_predict_binary(X_y_binary, lgbm):
-
     X, y = X_y_binary
 
     sk_clf = lgbm.sklearn.LGBMClassifier(random_state=0)
@@ -65,7 +64,6 @@ def test_fit_predict_binary(X_y_binary, lgbm):
 
 
 def test_fit_predict_multi(X_y_multi, lgbm):
-
     X, y = X_y_multi
 
     clf = lgbm.sklearn.LGBMClassifier(random_state=0)
@@ -83,7 +81,6 @@ def test_fit_predict_multi(X_y_multi, lgbm):
 
 
 def test_feature_importance(X_y_binary, lgbm):
-
     X, y = X_y_binary
 
     clf = LightGBMClassifier(n_jobs=1)
@@ -98,7 +95,6 @@ def test_feature_importance(X_y_binary, lgbm):
 
 
 def test_fit_string_features(X_y_binary, lgbm):
-
     X, y = X_y_binary
     X = pd.DataFrame(X)
     X["string_col"] = "abc"
@@ -269,7 +265,6 @@ def test_binary_label_encoding(mock_predict, X_y_binary):
 
 
 def test_binary_rf(X_y_binary, lgbm):
-
     X, y = X_y_binary
 
     with pytest.raises(lgbm.basic.LightGBMError, match="bagging_fraction"):

--- a/evalml/tests/component_tests/test_lgbm_regressor.py
+++ b/evalml/tests/component_tests/test_lgbm_regressor.py
@@ -43,7 +43,6 @@ def test_lightgbm_regressor_random_seed_bounds_seed(X_y_regression):
 
 
 def test_fit_predict_regression(X_y_regression, lgbm):
-
     X, y = X_y_regression
 
     sk_clf = lgbm.sklearn.LGBMRegressor(n_estimators=20, random_state=0)
@@ -58,7 +57,6 @@ def test_fit_predict_regression(X_y_regression, lgbm):
 
 
 def test_feature_importance(X_y_regression, lgbm):
-
     X, y = X_y_regression
 
     clf = LightGBMRegressor()
@@ -73,7 +71,6 @@ def test_feature_importance(X_y_regression, lgbm):
 
 
 def test_fit_string_features(X_y_regression, lgbm):
-
     X, y = X_y_regression
     X = pd.DataFrame(X)
     X["string_col"] = "abc"
@@ -178,7 +175,6 @@ def test_multiple_fit(mock_predict):
 
 
 def test_regression_rf(X_y_regression, lgbm):
-
     X, y = X_y_regression
 
     with pytest.raises(lgbm.basic.LightGBMError, match="bagging_fraction"):

--- a/evalml/tests/component_tests/test_one_hot_encoder.py
+++ b/evalml/tests/component_tests/test_one_hot_encoder.py
@@ -82,7 +82,6 @@ def test_invalid_inputs():
 
 
 def test_ohe_is_no_op_for_not_categorical_features():
-
     ohe = OneHotEncoder(handle_missing="error")
     X = pd.DataFrame(
         {
@@ -594,7 +593,6 @@ def test_data_types(data_type):
     ],
 )
 def test_ohe_preserves_custom_index(index):
-
     df = pd.DataFrame(
         {"categories": [f"cat_{i}" for i in range(5)], "numbers": np.arange(5)},
         index=index,

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -261,7 +261,6 @@ def test_samplers_perform_equally(
 
 
 def test_smoten_categorical_boolean(X_y_binary, im):
-
     X, y = X_y_binary
     X.ww.set_types({0: "Categorical", 1: "Boolean"})
     X = X.drop(range(2, len(X.columns)), axis=1)
@@ -271,7 +270,6 @@ def test_smoten_categorical_boolean(X_y_binary, im):
 
 
 def test_smotenc_boolean_numeric(X_y_binary, im):
-
     X, y = X_y_binary
     X.ww.set_types({5: "Boolean", 12: "Boolean"})
     snc = Oversampler()

--- a/evalml/tests/component_tests/test_prophet_regressor.py
+++ b/evalml/tests/component_tests/test_prophet_regressor.py
@@ -23,7 +23,6 @@ def prophet():
 
 
 def test_cmdstanpy_backend(prophet):
-
     m = prophet.Prophet(stan_backend="CMDSTANPY")
     assert m.stan_backend.get_type() == "CMDSTANPY"
 

--- a/evalml/tests/component_tests/test_time_series_imputer.py
+++ b/evalml/tests/component_tests/test_time_series_imputer.py
@@ -43,7 +43,6 @@ def test_imputer_init(
     numeric_impute_strategy,
     categorical_impute_strategy,
 ):
-
     imputer = TimeSeriesImputer(
         categorical_impute_strategy=categorical_impute_strategy,
         numeric_impute_strategy=numeric_impute_strategy,

--- a/evalml/tests/component_tests/test_time_series_regularizer.py
+++ b/evalml/tests/component_tests/test_time_series_regularizer.py
@@ -68,7 +68,6 @@ def assert_features_and_length_equal(
 
 
 def test_ts_regularizer_init():
-
     ts_regularizer = TimeSeriesRegularizer(time_index="dates")
 
     assert ts_regularizer.name == "Time Series Regularizer"
@@ -230,7 +229,6 @@ def test_ts_regularizer_duplicate(
     duplicate_scattered,
     duplicate_continuous,
 ):
-
     if duplicate_location == "beginning":
         dates = duplicate_beginning
     elif duplicate_location == "middle":
@@ -263,7 +261,6 @@ def test_ts_regularizer_missing(
     missing_scattered,
     missing_continuous,
 ):
-
     if missing_location == "beginning":
         dates = missing_beginning
     elif missing_location == "middle":
@@ -297,7 +294,6 @@ def test_ts_regularizer_uneven(
     uneven_continuous,
     uneven_work_week,
 ):
-
     if uneven_type == "beginning":
         dates = uneven_beginning
     elif uneven_type == "middle":

--- a/evalml/tests/component_tests/test_vowpal_wabbit_binary_classifier.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_binary_classifier.py
@@ -48,7 +48,6 @@ def test_vw_parameters():
 
 
 def test_fit_predict(X_y_binary, vw):
-
     X, y = X_y_binary
     vw_classifier = VowpalWabbitBinaryClassifier()
 

--- a/evalml/tests/component_tests/test_vowpal_wabbit_multiclass_classifier.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_multiclass_classifier.py
@@ -48,7 +48,6 @@ def test_vw_parameters():
 
 
 def test_vw_fit_predict(X_y_multi, vw):
-
     X, y = X_y_multi
     vw_classifier = VowpalWabbitMulticlassClassifier()
 

--- a/evalml/tests/component_tests/test_vowpal_wabbit_regressor.py
+++ b/evalml/tests/component_tests/test_vowpal_wabbit_regressor.py
@@ -43,7 +43,6 @@ def test_vw_parameters():
 
 
 def test_vw_fit_predict(X_y_regression, vw):
-
     X, y = X_y_regression
     vw_regressor = VowpalWabbitRegressor()
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -446,7 +446,6 @@ def all_pipeline_classes():
     all_possible_pipeline_classes = []
     for estimator in _all_estimators():
         for problem_type in estimator.supported_problem_types:
-
             all_possible_pipeline_classes.append(
                 create_mock_pipeline(
                     estimator,
@@ -1987,7 +1986,9 @@ class _AutoMLTestEnv:
             new_callable=sleep_time,
         )
         if mock_predict_proba_in_sample is None:
-            with mock_sleep, mock_fit as fit, mock_score as score, mock_get_names as get_names, mock_encode_targets as encode, mock_predict_proba as proba, mock_tell as tell, mock_optimize as optimize:
+            with (
+                mock_sleep
+            ), mock_fit as fit, mock_score as score, mock_get_names as get_names, mock_encode_targets as encode, mock_predict_proba as proba, mock_tell as tell, mock_optimize as optimize:
                 # Can think of `yield` as blocking this method until the computation finishes running
                 yield
                 self._mock_fit = fit
@@ -1998,7 +1999,9 @@ class _AutoMLTestEnv:
                 self._mock_predict_proba = proba
                 self._mock_optimize_threshold = optimize
         else:
-            with mock_sleep, mock_fit as fit, mock_score as score, mock_get_names as get_names, mock_encode_targets as encode, mock_predict_proba as proba, mock_predict_proba_in_sample as proba_in_sample, mock_tell as tell, mock_optimize as optimize:
+            with (
+                mock_sleep
+            ), mock_fit as fit, mock_score as score, mock_get_names as get_names, mock_encode_targets as encode, mock_predict_proba as proba, mock_predict_proba_in_sample as proba_in_sample, mock_tell as tell, mock_optimize as optimize:
                 # Can think of `yield` as blocking this method until the computation finishes running
                 yield
                 self._mock_fit = fit
@@ -2129,7 +2132,6 @@ def dummy_data_check_name():
 
 @pytest.fixture
 def dummy_data_check_validate_output_warnings():
-
     return [
         {
             "message": "Data check dummy message",
@@ -2150,7 +2152,6 @@ def dummy_data_check_validate_output_warnings():
 
 @pytest.fixture
 def dummy_data_check_validate_output_errors():
-
     return [
         {
             "message": "Data check dummy message",

--- a/evalml/tests/data_checks_tests/test_sparsity_data_check.py
+++ b/evalml/tests/data_checks_tests/test_sparsity_data_check.py
@@ -13,7 +13,6 @@ sparsity_data_check_name = SparsityDataCheck.name
 
 
 def test_sparsity_data_check_init():
-
     sparsity_check = SparsityDataCheck("multiclass", threshold=4 / 15)
     assert sparsity_check.threshold == 4 / 15
 

--- a/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
+++ b/evalml/tests/data_checks_tests/test_ts_parameters_data_check.py
@@ -55,7 +55,6 @@ def test_time_series_param_data_check(
     n_splits,
     is_valid,
 ):
-
     config = {
         "gap": gap,
         "max_delay": max_delay,

--- a/evalml/tests/integration_tests/test_time_series_integration.py
+++ b/evalml/tests/integration_tests/test_time_series_integration.py
@@ -22,7 +22,6 @@ PERIODS = 500
 def test_can_run_automl_for_time_series_with_categorical_and_boolean_features(
     problem_type,
 ):
-
     X = pd.DataFrame(
         {
             "features": range(101, 101 + PERIODS),
@@ -92,7 +91,6 @@ def test_can_run_automl_for_time_series_known_in_advance(
     problem_type,
     sampler,
 ):
-
     X = pd.DataFrame(
         {
             "features": range(101, 101 + PERIODS),
@@ -172,7 +170,6 @@ def test_can_run_automl_for_time_series_with_exclude_featurizers(
     mock_add_X_y,
     problem_type,
 ):
-
     X = pd.DataFrame(
         {
             "features": range(101, 101 + PERIODS),

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_algorithms.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_algorithms.py
@@ -306,7 +306,6 @@ def test_explainers(
 
 @pytest.mark.parametrize("data_type", ["ww", "np"])
 def test_lime_xgboost(data_type, X_y_multi):
-
     from evalml.pipelines.components import XGBoostClassifier
 
     X, y = X_y_multi
@@ -362,7 +361,6 @@ def test_compute_shap_values_absolute_probs(mock_predict_proba, X_y_binary):
 
 
 def test_normalize_values_exceptions():
-
     with pytest.raises(
         ValueError,
         match="^Unsupported data type for _normalize_explainer_values",
@@ -402,7 +400,6 @@ def check_equal_dicts(normalized, answer):
     ],
 )
 def test_normalize_values(values, answer):
-
     normalized = _normalize_explainer_values(values)
     if isinstance(normalized, dict):
         check_equal_dicts(normalized, answer)

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_explainers.py
@@ -33,7 +33,6 @@ def compare_two_tables(table_1, table_2):
 
 
 def test_error_metrics():
-
     np.testing.assert_array_equal(
         abs_error(pd.Series([1, 2, 3]), pd.Series([4, 1, 0])),
         np.array([3, 1, 3]),
@@ -483,7 +482,6 @@ multiclass_no_best_worst_answer = """Test Pipeline Name
 
 
 def _add_custom_index(answer, index_best, index_worst, output_format):
-
     if output_format == "text":
         answer = answer.format(index_0=index_best, index_1=index_worst)
     elif output_format == "dataframe":
@@ -947,7 +945,6 @@ def test_explain_predictions_best_worst_custom_metric(
     output_format,
     answer,
 ):
-
     mock_make_table.return_value = (
         "table goes here"
         if output_format == "text"
@@ -1129,7 +1126,6 @@ def test_json_serialization(
     X_y_multi,
     logistic_regression_multiclass_pipeline,
 ):
-
     if problem_type == problem_type.REGRESSION:
         X, y = X_y_regression
         y = pd.Series(y)
@@ -1165,7 +1161,6 @@ def test_json_serialization(
 
 
 def transform_y_for_problem_type(problem_type, y):
-
     if problem_type == ProblemTypes.REGRESSION:
         y = y.astype("int")
     elif problem_type == ProblemTypes.MULTICLASS:

--- a/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_user_interface.py
+++ b/evalml/tests/model_understanding_tests/prediction_explanations_tests/test_user_interface.py
@@ -613,7 +613,6 @@ def test_make_single_prediction_table(
     output_format,
     answer,
 ):
-
     class_names = ["0", "1", "2"]
 
     if isinstance(values, list):

--- a/evalml/tests/model_understanding_tests/test_metrics.py
+++ b/evalml/tests/model_understanding_tests/test_metrics.py
@@ -274,7 +274,6 @@ def test_precision_recall_curve_pos_label_idx_error(make_data_type):
 
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_precision_recall_curve(X_y_binary, data_type, make_data_type, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred_proba = y_true * rs.random(y_true.shape)
@@ -302,7 +301,6 @@ def test_graph_precision_recall_curve(X_y_binary, data_type, make_data_type, go)
 
 
 def test_graph_precision_recall_curve_title_addition(X_y_binary, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred_proba = y_true * rs.random(y_true.shape)
@@ -414,7 +412,6 @@ def test_roc_curve_multiclass(data_type, make_data_type):
 
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_roc_curve_binary(X_y_binary, data_type, make_data_type, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred_proba = y_true * rs.random(y_true.shape)
@@ -442,7 +439,6 @@ def test_graph_roc_curve_binary(X_y_binary, data_type, make_data_type, go):
 
 
 def test_graph_roc_curve_nans(go):
-
     one_val_y_zero = np.array([0])
     with pytest.warns(UndefinedMetricWarning):
         fig = graph_roc_curve(one_val_y_zero, one_val_y_zero)
@@ -466,7 +462,6 @@ def test_graph_roc_curve_nans(go):
 
 
 def test_graph_roc_curve_multiclass(binarized_ys, go):
-
     y_true, y_tr, y_pred_proba = binarized_ys
     fig = graph_roc_curve(y_true, y_pred_proba)
     assert isinstance(fig, type(go.Figure()))
@@ -497,7 +492,6 @@ def test_graph_roc_curve_multiclass(binarized_ys, go):
 
 
 def test_graph_roc_curve_multiclass_custom_class_names(binarized_ys, go):
-
     y_true, y_tr, y_pred_proba = binarized_ys
     custom_class_names = ["one", "two", "three"]
     fig = graph_roc_curve(y_true, y_pred_proba, custom_class_names=custom_class_names)
@@ -518,7 +512,6 @@ def test_graph_roc_curve_multiclass_custom_class_names(binarized_ys, go):
 
 
 def test_graph_roc_curve_title_addition(X_y_binary, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred_proba = y_true * rs.random(y_true.shape)
@@ -533,7 +526,6 @@ def test_graph_roc_curve_title_addition(X_y_binary, go):
 
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_graph_confusion_matrix_default(X_y_binary, data_type, make_data_type, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred = np.round(y_true * rs.random(y_true.shape)).astype(int)
@@ -570,7 +562,6 @@ def test_graph_confusion_matrix_default(X_y_binary, data_type, make_data_type, g
 
 
 def test_graph_confusion_matrix_norm_disabled(X_y_binary, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred = np.round(y_true * rs.random(y_true.shape)).astype(int)
@@ -597,7 +588,6 @@ def test_graph_confusion_matrix_norm_disabled(X_y_binary, go):
 
 
 def test_graph_confusion_matrix_title_addition(X_y_binary, go):
-
     X, y_true = X_y_binary
     rs = get_random_state(42)
     y_pred = np.round(y_true * rs.random(y_true.shape)).astype(int)

--- a/evalml/tests/model_understanding_tests/test_partial_dependence.py
+++ b/evalml/tests/model_understanding_tests/test_partial_dependence.py
@@ -994,7 +994,6 @@ def test_graph_partial_dependence_ww_categories(
     logistic_regression_binary_pipeline,
     go,
 ):
-
     X, y = fraud_100
     X.ww.set_types(
         logical_types={
@@ -1183,7 +1182,6 @@ def test_graph_partial_dependence_multiclass(
     logistic_regression_multiclass_pipeline,
     go,
 ):
-
     X, y = wine_local
     logistic_regression_multiclass_pipeline.fit(X, y)
 
@@ -1417,7 +1415,6 @@ def test_graph_partial_dependence_regression_and_binary_categorical(
     X_y_binary,
     logistic_regression_binary_pipeline,
 ):
-
     if problem_type == "binary":
         X, y = X_y_binary
         pipeline = logistic_regression_binary_pipeline
@@ -1484,7 +1481,6 @@ def test_partial_dependence_multiclass_categorical(
     class_label,
     logistic_regression_multiclass_pipeline,
 ):
-
     X, y = wine_local
     X.ww["categorical_column"] = ww.init_series(
         pd.Series([i % 3 for i in range(X.shape[0])]).astype(str),
@@ -1557,7 +1553,6 @@ def test_partial_dependence_multiclass_categorical(
 def test_partial_dependence_all_nan_value_error(
     logistic_regression_binary_pipeline,
 ):
-
     X = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
     y = pd.Series([0, 1, 0])
     logistic_regression_binary_pipeline.fit(X, y)
@@ -1740,7 +1735,6 @@ def test_graph_partial_dependence_regression_and_binary_datetime(
     X_y_regression,
     X_y_binary,
 ):
-
     if problem_type == "binary":
         X, y = X_y_binary
         pipeline = BinaryClassificationPipeline(
@@ -1782,7 +1776,6 @@ def test_graph_partial_dependence_regression_and_binary_datetime(
 
 
 def test_graph_partial_dependence_regression_date_order(X_y_binary):
-
     X, y = X_y_binary
     pipeline = BinaryClassificationPipeline(
         component_graph=[
@@ -2340,7 +2333,6 @@ def test_partial_dependence_categorical_nan(fraud_100):
     side_effect=lambda X: np.array([[0.2, 0.8]] * X.shape[0]),
 )
 def test_partial_dependence_preserves_woodwork_schema(mock_predict_proba, fraud_100):
-
     X, y = fraud_100
     X_test = X.ww.copy()
 

--- a/evalml/tests/model_understanding_tests/test_permutation_importance.py
+++ b/evalml/tests/model_understanding_tests/test_permutation_importance.py
@@ -760,7 +760,6 @@ def test_graph_permutation_importance(
     logistic_regression_binary_pipeline,
     go,
 ):
-
     X, y = X_y_binary
     logistic_regression_binary_pipeline.fit(X, y)
     fig = graph_permutation_importance(
@@ -803,7 +802,6 @@ def test_graph_permutation_importance_show_all_features(
     logistic_regression_binary_pipeline,
     go,
 ):
-
     mock_perm_importance.return_value = pd.DataFrame(
         {"feature": ["f1", "f2"], "importance": [0.0, 0.6]},
     )
@@ -828,7 +826,6 @@ def test_graph_permutation_importance_threshold(
     go,
     logistic_regression_binary_pipeline,
 ):
-
     mock_perm_importance.return_value = pd.DataFrame(
         {"feature": ["f1", "f2"], "importance": [0.0, 0.6]},
     )

--- a/evalml/tests/model_understanding_tests/test_visualizations.py
+++ b/evalml/tests/model_understanding_tests/test_visualizations.py
@@ -151,7 +151,6 @@ def test_graph_binary_objective_vs_threshold(
     make_data_type,
     go,
 ):
-
     X, y = X_y_binary
     X = make_data_type(data_type, X)
     y = make_data_type(data_type, y)
@@ -255,7 +254,6 @@ def test_get_prediction_vs_actual_data(data_type, make_data_type):
 
 
 def test_graph_prediction_vs_actual_default(go):
-
     y_true = [1, 2, 3000, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     y_pred = [5, 4, 2, 8, 6, 6, 5, 1, 7, 2, 1, 3000]
 
@@ -277,7 +275,6 @@ def test_graph_prediction_vs_actual_default(go):
 
 @pytest.mark.parametrize("data_type", ["pd", "ww"])
 def test_graph_prediction_vs_actual(data_type, go):
-
     y_true = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     y_pred = [5, 4, 3, 8, 6, 3, 5, 9, 7, 12, 1, 2]
 
@@ -739,7 +736,6 @@ def test_t_sne_errors_marker_size(marker_size):
 @pytest.mark.parametrize("perplexity", [0, 2.6, 3])
 @pytest.mark.parametrize("learning_rate", [100.0, 0.1])
 def test_graph_t_sne(data_type, perplexity, learning_rate, go):
-
     if data_type == "np":
         X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     elif data_type == "pd":

--- a/evalml/tests/objective_tests/test_lead_scoring.py
+++ b/evalml/tests/objective_tests/test_lead_scoring.py
@@ -7,7 +7,6 @@ from evalml.objectives import LeadScoring
 
 
 def test_lead_scoring_works_during_automl_search(X_y_binary):
-
     X, y = X_y_binary
 
     objective = LeadScoring(true_positives=1, false_positives=-1)
@@ -29,7 +28,6 @@ def test_lead_scoring_works_during_automl_search(X_y_binary):
 
 
 def test_lead_scoring_objective():
-
     objective = LeadScoring(true_positives=1, false_positives=-1)
 
     predicted = pd.Series([1, 10, 0.5, 5])

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -63,7 +63,6 @@ def test_get_objective_does_raises_error_for_incorrect_name_or_random_class():
 
 
 def test_get_objective_return_instance_does_not_work_for_some_objectives():
-
     with pytest.raises(
         ObjectiveCreationError,
         match="In get_objective, cannot pass in return_instance=True for Cost Benefit Matrix",
@@ -80,7 +79,6 @@ def test_get_objective_does_not_work_for_none_type():
 
 
 def test_get_objective_kwargs():
-
     obj = get_objective(
         "cost benefit matrix",
         return_instance=True,

--- a/evalml/tests/objective_tests/test_standard_metrics.py
+++ b/evalml/tests/objective_tests/test_standard_metrics.py
@@ -733,7 +733,6 @@ def test_calculate_percent_difference(objective_class):
     product(_all_objectives_dict().values(), [None, np.nan]),
 )
 def test_calculate_percent_difference_with_nan(objective_class, nan_value):
-
     assert pd.isna(objective_class.calculate_percent_difference(nan_value, 2))
     assert pd.isna(objective_class.calculate_percent_difference(-1, nan_value))
     assert pd.isna(objective_class.calculate_percent_difference(nan_value, nan_value))
@@ -758,7 +757,6 @@ def test_calculate_percent_difference_when_baseline_0_or_close_to_0(
 
 
 def test_calculate_percent_difference_negative_and_equal_numbers():
-
     assert (
         CostBenefitMatrix.calculate_percent_difference(score=5, baseline_score=5) == 0
     )

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -1321,7 +1321,6 @@ def test_component_graph_types_merge_mock(mock_rf_fit):
 
 
 def test_component_graph_preserves_ltypes_created_during_pipeline_evaluation():
-
     # This test checks that the component graph preserves logical types created during pipeline evaluation
     # The other tests ensure that logical types set before pipeline evaluation are preserved
 
@@ -2671,7 +2670,6 @@ def test_component_graph_handles_engineered_features(
 
 
 def test_get_component_input_logical_types():
-
     X = pd.DataFrame(
         {
             "cat": pd.Series(["a"] * 50 + ["b"] * 50 + ["c"] * 50),

--- a/evalml/tests/pipeline_tests/test_graphs.py
+++ b/evalml/tests/pipeline_tests/test_graphs.py
@@ -42,7 +42,6 @@ def test_component_graph(example_graph):
 
 
 def test_backend(test_pipeline, graphviz):
-
     with patch("graphviz.Digraph.pipe") as mock_func:
         mock_func.side_effect = graphviz.backend.ExecutableNotFound("Not Found")
         clf = test_pipeline
@@ -51,14 +50,12 @@ def test_backend(test_pipeline, graphviz):
 
 
 def test_returns_digraph_object(test_pipeline, graphviz):
-
     clf = test_pipeline
     graph = clf.graph()
     assert isinstance(graph, graphviz.Digraph)
 
 
 def test_backend_comp_graph(test_component_graph, graphviz):
-
     with patch("graphviz.Digraph.pipe") as mock_func:
         mock_func.side_effect = graphviz.backend.ExecutableNotFound("Not Found")
         comp = test_component_graph
@@ -74,14 +71,12 @@ def test_saving_png_file(tmpdir, test_pipeline):
 
 
 def test_returns_digraph_object_comp_graph(test_component_graph, graphviz):
-
     comp = test_component_graph
     graph = comp.graph("test", "png")
     assert isinstance(graph, graphviz.Digraph)
 
 
 def test_returns_digraph_object_comp_graph_with_params(test_component_graph, graphviz):
-
     comp = test_component_graph
     parameters = {
         "OneHot_RandomForest": {"top_n": 3},

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -89,7 +89,6 @@ def test_make_pipeline(
     column_names,
     get_test_data_from_configuration,
 ):
-
     X, y = get_test_data_from_configuration(
         input_type,
         problem_type,
@@ -703,7 +702,6 @@ def test_generate_code_pipeline_json_with_objects():
 
 
 def test_generate_code_pipeline():
-
     binary_pipeline = BinaryClassificationPipeline(
         ["Imputer", "Random Forest Classifier"],
     )

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2318,7 +2318,6 @@ def test_undersampler_component_in_pipeline_predict():
 
 @patch("evalml.pipelines.components.LogisticRegressionClassifier.fit")
 def test_oversampler_component_in_pipeline_fit(mock_fit):
-
     X = pd.DataFrame(
         {
             "a": [i for i in range(1000)],

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -219,7 +219,6 @@ def test_fit_drop_nans_before_estimator(
     include_delayed_features,
     ts_data,
 ):
-
     X, _, y = ts_data(problem_type=pipeline_class.problem_type)
 
     if include_delayed_features:
@@ -427,7 +426,6 @@ def test_predict_and_predict_in_sample(
     include_feature_not_known_in_advance,
     ts_data,
 ):
-
     X, _, target = ts_data(problem_type=pipeline_class.problem_type)
     if include_feature_not_known_in_advance:
         X.ww["not_known_in_advance_1"] = (
@@ -586,7 +584,6 @@ def test_predict_and_predict_in_sample_with_time_index(
     estimator_name,
     ts_data,
 ):
-
     X, _, target = ts_data(problem_type=pipeline_class.problem_type)
     mock_to_check = mock_regressor_predict
     if is_classification(pipeline_class.problem_type):
@@ -1636,7 +1633,6 @@ def test_ts_pipeline_transform_with_final_estimator(
 
 
 def test_time_index_cannot_be_none(time_series_regression_pipeline_class):
-
     with pytest.raises(ValueError, match="time_index cannot be None!"):
         time_series_regression_pipeline_class(
             {

--- a/evalml/tests/utils_tests/test_cli_utils.py
+++ b/evalml/tests/utils_tests/test_cli_utils.py
@@ -23,7 +23,6 @@ def current_dir():
 
 
 def get_requirements(current_dir):
-
     evalml_path = os.path.abspath(os.path.join(current_dir, "..", "..", ".."))
     full_requirements = get_evalml_pip_requirements(evalml_path)
 

--- a/evalml/tests/utils_tests/test_woodwork_utils.py
+++ b/evalml/tests/utils_tests/test_woodwork_utils.py
@@ -182,7 +182,6 @@ def test_infer_feature_types_preserves_semantic_tags():
 
 
 def test_infer_feature_types_raises_invalid_schema_error():
-
     df = pd.DataFrame(pd.Series([1, 2, None]))
 
     # Raise error when user requests incompatible type


### PR DESCRIPTION
# v0.67.0 Jan. 31, 2023
### Fixes
- Re-added ``TimeSeriesPipeline.should_skip_featurization`` to fix bug where data would get featurized unnecessarily #3964
- Allow float categories to be passed into CatBoost estimators #3966
### Changes
- Update pyproject.toml to correctly specify the data filepaths #3967
### Documentation Changes
- Added demo for prediction intervals #3954