### PR TITLE
Release v0.68.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,22 +2,26 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
-        * Integrated ``determine_periodicity`` into ``AutoMLSearch`` :pr:`3952`
-        * Removed frequency limitations for decomposition using the ``STLDecomposer`` :pr:`3952`
     * Fixes
     * Changes
-        * Remove requirements-parser requirement :pr:`3978`
-        * Updated the ``SKOptTuner`` to use a gradient boosting regressor for tuning instead of extra trees :pr:`3983`
-        * Unpinned sktime from below 1.2, increased minimum to 1.2.1 :pr:`3983`
     * Documentation Changes
     * Testing Changes
-        * Add pull request check for linked issues to CI workflow :pr:`3970`, :pr:`3980`
-        * Upgraded minimum `IPython` version to 8.10.0 :pr:`3987`
 
 .. warning::
 
     **Breaking Changes**
 
+**v0.68.0 Feb. 15, 2023**
+    * Enhancements
+        * Integrated ``determine_periodicity`` into ``AutoMLSearch`` :pr:`3952`
+        * Removed frequency limitations for decomposition using the ``STLDecomposer`` :pr:`3952`
+    * Changes
+        * Remove requirements-parser requirement :pr:`3978`
+        * Updated the ``SKOptTuner`` to use a gradient boosting regressor for tuning instead of extra trees :pr:`3983`
+        * Unpinned sktime from below 1.2, increased minimum to 1.2.1 :pr:`3983`
+    * Testing Changes
+        * Add pull request check for linked issues to CI workflow :pr:`3970`, :pr:`3980`
+        * Upgraded minimum `IPython` version to 8.10.0 :pr:`3987`
 
 **v0.67.0 Jan. 31, 2023**
     * Fixes

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.67.0"
+__version__ = "0.68.0"


### PR DESCRIPTION
# v0.68.0 Feb. 15, 2023
### Enhancements
- Integrated ``determine_periodicity`` into ``AutoMLSearch`` #3952
- Removed frequency limitations for decomposition using the ``STLDecomposer`` #3952
### Changes
- Remove requirements-parser requirement #3978
- Updated the ``SKOptTuner`` to use a gradient boosting regressor for tuning instead of extra trees #3983
- Unpinned sktime from below 1.2, increased minimum to 1.2.1 #3983
### Testing Changes
- Add pull request check for linked issues to CI workflow #3970, #3980
- Upgraded minimum `IPython` version to 8.10.0 #3987