### PR TITLE
Update networkx version

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -40,7 +40,7 @@ outputs:
         - featuretools>=1.16.0
         - nlp-primitives>=2.9.0
         - python >=3.8.*
-        - networkx >=2.5,<2.6
+        - networkx >=2.6
         - category_encoders >=2.2.2, <=2.5.1.post0
         - python-graphviz >=0.13
         - tomli >=2.0.1

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -14,4 +14,4 @@ woodwork>= 0.21.1
 dask>=2022.2.0, !=2022.10.1
 nlp-primitives>=2.9.0
 featuretools>=1.16.0
-networkx>=2.5,<2.6
+networkx>=2.6

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -7,8 +7,9 @@ Release Notes
         * Add new downcast utils for component-specific nullable type handling and begin implementation on objective and component base classes :pr:`4024`
     * Fixes
     * Changes
-        * Uncapped `pmdarima` and updated minimum version :pr:`4027`
+        * Uncapped ``pmdarima`` and updated minimum version :pr:`4027`
         * Increase min catboost to 1.1.1 and xgboost to 1.7.0 to add nullable type support for those estimators :pr:`3996`
+        * Unpinned ``networkx`` and updated minimum version :pr:`4035`
     * Documentation Changes
     * Testing Changes
         * Use ``release.yaml`` for performance tests on merge to main :pr:`4007`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -14,7 +14,7 @@ lightgbm==3.3.5
 lime==0.2.0.1
 matplotlib==3.7.0
 matplotlib-inline==0.1.6
-networkx==2.5.1
+networkx==3.0.0
 nlp-primitives==2.10.0
 numpy==1.23.5
 packaging==23.0

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -14,7 +14,7 @@ lightgbm==3.3.5
 lime==0.2.0.1
 matplotlib==3.7.0
 matplotlib-inline==0.1.6
-networkx==3.0.0
+networkx==3.0
 nlp-primitives==2.10.0
 numpy==1.23.5
 packaging==23.0

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -13,7 +13,7 @@ kaleido==0.1.0
 lightgbm==2.3.1
 lime==0.2.0.1
 matplotlib==3.3.3
-networkx==2.5
+networkx==2.6
 nlp-primitives==2.9.0
 numpy==1.21.0
 packaging==23.0

--- a/evalml/tests/dependency_update_check/minimum_test_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_test_requirements.txt
@@ -17,7 +17,7 @@ lightgbm==2.3.1
 lime==0.2.0.1
 matplotlib==3.3.3
 nbval==0.9.3
-networkx==2.5
+networkx==2.6
 nlp-primitives==2.9.0
 numpy==1.21.0
 packaging==23.0

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -111,15 +111,11 @@ def test_init(example_graph):
     comp_graph = ComponentGraph(graph)
     assert len(comp_graph.component_dict) == 6
 
-    expected_order = [
-        "Imputer",
-        "OneHot_ElasticNet",
-        "Elastic Net",
-        "OneHot_RandomForest",
-        "Random Forest",
-        "Logistic Regression Classifier",
-    ]
-    assert comp_graph.compute_order == expected_order
+    order = comp_graph.compute_order
+    assert order[0] == "Imputer"
+    assert order.index("OneHot_ElasticNet") < order.index("Elastic Net")
+    assert order.index("OneHot_RandomForest") < order.index("Random Forest")
+    assert order[-1] == "Logistic Regression Classifier"
 
 
 def test_init_str_components():
@@ -139,15 +135,11 @@ def test_init_str_components():
     comp_graph = ComponentGraph(graph)
     assert len(comp_graph.component_dict) == 6
 
-    expected_order = [
-        "Imputer",
-        "OneHot_ElasticNet",
-        "Elastic Net",
-        "OneHot_RandomForest",
-        "Random Forest",
-        "Logistic Regression Classifier",
-    ]
-    assert comp_graph.compute_order == expected_order
+    order = comp_graph.compute_order
+    assert order[0] == "Imputer"
+    assert order.index("OneHot_ElasticNet") < order.index("Elastic Net")
+    assert order.index("OneHot_RandomForest") < order.index("Random Forest")
+    assert order[-1] == "Logistic Regression Classifier"
 
 
 def test_init_instantiated():
@@ -271,15 +263,11 @@ def test_instantiate_with_parameters(example_graph):
     }
     component_graph.instantiate(parameters)
 
-    expected_order = [
-        "Imputer",
-        "OneHot_ElasticNet",
-        "Elastic Net",
-        "OneHot_RandomForest",
-        "Random Forest",
-        "Logistic Regression Classifier",
-    ]
-    assert component_graph.compute_order == expected_order
+    order = component_graph.compute_order
+    assert order[0] == "Imputer"
+    assert order.index("OneHot_ElasticNet") < order.index("Elastic Net")
+    assert order.index("OneHot_RandomForest") < order.index("Random Forest")
+    assert order[-1] == "Logistic Regression Classifier"
 
     assert isinstance(component_graph.get_component("Imputer"), Imputer)
     assert isinstance(
@@ -311,15 +299,11 @@ def test_instantiate_without_parameters(parameters, example_graph):
         "OneHot_RandomForest",
     ) is not component_graph.get_component("OneHot_ElasticNet")
 
-    expected_order = [
-        "Imputer",
-        "OneHot_ElasticNet",
-        "Elastic Net",
-        "OneHot_RandomForest",
-        "Random Forest",
-        "Logistic Regression Classifier",
-    ]
-    assert component_graph.compute_order == expected_order
+    order = component_graph.compute_order
+    assert order[0] == "Imputer"
+    assert order.index("OneHot_ElasticNet") < order.index("Elastic Net")
+    assert order.index("OneHot_RandomForest") < order.index("Random Forest")
+    assert order[-1] == "Logistic Regression Classifier"
 
 
 def test_reinstantiate(example_graph):
@@ -806,15 +790,11 @@ def test_multiple_y_parents():
 
 def test_component_graph_order(example_graph):
     component_graph = ComponentGraph(example_graph)
-    expected_order = [
-        "Imputer",
-        "OneHot_ElasticNet",
-        "Elastic Net",
-        "OneHot_RandomForest",
-        "Random Forest",
-        "Logistic Regression Classifier",
-    ]
-    assert expected_order == component_graph.compute_order
+    order = component_graph.compute_order
+    assert order[0] == "Imputer"
+    assert order.index("OneHot_ElasticNet") < order.index("Elastic Net")
+    assert order.index("OneHot_RandomForest") < order.index("Random Forest")
+    assert order[-1] == "Logistic Regression Classifier"
 
     component_graph = ComponentGraph({"Imputer": [Imputer, "X", "y"]})
     expected_order = ["Imputer"]
@@ -1023,9 +1003,9 @@ def test_iteration(example_graph):
     expected = [
         Imputer,
         OneHotEncoder,
-        ElasticNetClassifier,
         OneHotEncoder,
         RandomForestClassifier,
+        ElasticNetClassifier,
         LogisticRegressionClassifier,
     ]
     iteration = [component for component in component_graph]
@@ -1034,10 +1014,10 @@ def test_iteration(example_graph):
     component_graph.instantiate({"OneHot_RandomForest": {"top_n": 32}})
     expected = [
         Imputer(),
-        OneHotEncoder(),
-        ElasticNetClassifier(),
         OneHotEncoder(top_n=32),
+        OneHotEncoder(),
         RandomForestClassifier(),
+        ElasticNetClassifier(),
         LogisticRegressionClassifier(),
     ]
     iteration = [component for component in component_graph]

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2100,9 +2100,9 @@ def test_nonlinear_pipeline_iteration(nonlinear_binary_pipeline):
     expected_order = [
         Imputer(),
         OneHotEncoder(),
-        ElasticNetClassifier(),
         OneHotEncoder(),
         RandomForestClassifier(),
+        ElasticNetClassifier(),
         LogisticRegressionClassifier(n_jobs=1),
     ]
 
@@ -2114,10 +2114,10 @@ def test_nonlinear_pipeline_iteration(nonlinear_binary_pipeline):
 
     expected_order_params = [
         Imputer(),
-        OneHotEncoder(top_n=2),
-        ElasticNetClassifier(),
         OneHotEncoder(top_n=5),
+        OneHotEncoder(top_n=2),
         RandomForestClassifier(),
+        ElasticNetClassifier(),
         LogisticRegressionClassifier(),
     ]
 
@@ -2153,10 +2153,10 @@ def test_nonlinear_getitem(nonlinear_binary_pipeline):
     pipeline = nonlinear_binary_pipeline.new({"OneHot_RandomForest": {"top_n": 4}})
 
     assert pipeline[0] == Imputer()
-    assert pipeline[1] == OneHotEncoder()
-    assert pipeline[2] == ElasticNetClassifier()
-    assert pipeline[3] == OneHotEncoder(top_n=4)
-    assert pipeline[4] == RandomForestClassifier()
+    assert pipeline[1] == OneHotEncoder(top_n=4)
+    assert pipeline[2] == OneHotEncoder()
+    assert pipeline[3] == RandomForestClassifier()
+    assert pipeline[4] == ElasticNetClassifier()
     assert pipeline[5] == LogisticRegressionClassifier()
 
     assert pipeline["Imputer"] == Imputer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ namespaces = true
     "demos/data/churn.csv",
     "demos/data/daily-min-temperatures.csv",
     "demos/data/fraud_transactions.csv.gz",
+    "tests/data/churn.csv",
     "tests/data/daily-min-temperatures.csv",
     "tests/data/fraud_transactions.csv.gz",
     "tests/data/tips.csv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "dask >= 2022.2.0, != 2022.10.1",
     "featuretools >= 1.16.0",
     "nlp-primitives >= 2.9.0",
-    "networkx >= 2.5, < 2.6",
+    "networkx >= 2.6",
     "plotly >= 5.0.0",
     "kaleido >= 0.1.0",
     "ipywidgets >= 7.5",


### PR DESCRIPTION
Closes #3972 

Networkx changed the topological order of their DAGs with version 2.6, which broke some of our tests that validate the computation order. We [pinned it](https://github.com/alteryx/evalml/pull/2476) and left it there. Changes here unpin the version and update the tests to be more flexible about the order of computations, so long as the data flow is still maintained.