### PR TITLE
Refactor imputer components to remove unnecessary logic 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,7 +13,7 @@ Release Notes
         * Uncapped ``pmdarima`` and updated minimum version :pr:`4027`
         * Increase min catboost to 1.1.1 and xgboost to 1.7.0 to add nullable type support for those estimators :pr:`3996`
         * Unpinned ``networkx`` and updated minimum version :pr:`4035`
-        * Remove unnecessary logic from imputer components :pr:`4038`
+        * Remove unnecessary logic from imputer components prior to nullable type handling :pr:`4038`
     * Documentation Changes
     * Testing Changes
         * Use ``release.yaml`` for performance tests on merge to main :pr:`4007`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
         * Uncapped ``pmdarima`` and updated minimum version :pr:`4027`
         * Increase min catboost to 1.1.1 and xgboost to 1.7.0 to add nullable type support for those estimators :pr:`3996`
         * Unpinned ``networkx`` and updated minimum version :pr:`4035`
+        * Remove unnecessary logic from imputer components :pr:`4038`
     * Documentation Changes
     * Testing Changes
         * Use ``release.yaml`` for performance tests on merge to main :pr:`4007`

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -127,17 +127,21 @@ class Imputer(Transformer):
         nan_ratio = X.isna().sum() / X.shape[0]
         self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()
 
-        X_numerics = X[[col for col in numeric_cols if col not in self._all_null_cols]]
+        X_numerics = X.ww[
+            [col for col in numeric_cols if col not in self._all_null_cols]
+        ]
         if len(X_numerics.columns) > 0:
             self._numeric_imputer.fit(X_numerics, y)
             self._numeric_cols = X_numerics.columns
 
-        X_categorical = X[[col for col in cat_cols if col not in self._all_null_cols]]
+        X_categorical = X.ww[
+            [col for col in cat_cols if col not in self._all_null_cols]
+        ]
         if len(X_categorical.columns) > 0:
             self._categorical_imputer.fit(X_categorical, y)
             self._categorical_cols = X_categorical.columns
 
-        X_boolean = X[[col for col in bool_cols if col not in self._all_null_cols]]
+        X_boolean = X.ww[[col for col in bool_cols if col not in self._all_null_cols]]
         if len(X_boolean.columns) > 0:
             self._boolean_imputer.fit(X_boolean, y)
             self._boolean_cols = X_boolean.columns

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -5,7 +5,6 @@ from woodwork import init_series
 from evalml.pipelines.components.transformers import Transformer
 from evalml.pipelines.components.transformers.imputers import KNNImputer, SimpleImputer
 from evalml.utils import downcast_nullable_types, infer_feature_types
-from evalml.utils.gen_utils import is_categorical_actually_boolean
 
 
 class Imputer(Transformer):
@@ -124,15 +123,6 @@ class Imputer(Transformer):
             X.ww.select(["BooleanNullable", "Boolean"], return_schema=True).columns,
         )
         numeric_cols = list(X.ww.select(["numeric"], return_schema=True).columns)
-
-        # TODO: Remove this when columns with True/False/NaN are inferred properly as BooleanNullable.
-        # If columns with boolean values and NaN are included with normal categorical columns, columns
-        # with object dtypes are attempted to be cast to float64 with scikit-learn 1.1.  So we separate
-        # boolean and categorical into separate imputers.
-        for col in cat_cols:
-            if is_categorical_actually_boolean(X, col):
-                cat_cols.remove(col)
-                bool_cols.append(col)
 
         nan_ratio = X.isna().sum() / X.shape[0]
         self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()

--- a/evalml/pipelines/components/transformers/imputers/knn_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/knn_imputer.py
@@ -89,7 +89,6 @@ class KNNImputer(Transformer):
         original_index = X.index
         original_schema = X.ww.schema
 
-        # Drop natural language columns and transform the other columns
         if not self._cols_to_impute:
             return X.ww[not_all_null_cols]
 

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -94,7 +94,8 @@ class SimpleImputer(Transformer):
         X = X[self._cols_to_impute]
         if (X.dtypes == bool).all():
             # Ensure that _component_obj still gets fit so that if any of the dtypes are different
-            # at transform, we've fit the component
+            # at transform, we've fit the component. This is needed because sklearn doesn't allow
+            # data with only bool dtype to be passed in.
             X = X.astype("boolean")
 
         self._component_obj.fit(X, y)
@@ -117,8 +118,8 @@ class SimpleImputer(Transformer):
         X_t = X[self._cols_to_impute]
         not_all_null_cols = [col for col in X.columns if col not in self._all_null_cols]
         if not self._cols_to_impute or (X_t.dtypes == bool).all():
-            # If there are no columns to impute or all columns to impute are bool dtype, which sklearn errors on,
-            # return the original data without any fully null columns
+            # If there are no columns to impute or all columns to impute are bool dtype,
+            # which will never have null values, return the original data without any fully null columns
             return X.ww[not_all_null_cols]
 
         X_t = self._component_obj.transform(X_t)

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -73,10 +73,12 @@ class SimpleImputer(Transformer):
 
         # Keep track of the different types of data in X
         self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()
-        self._natural_language_cols = X.ww.select(
-            "NaturalLanguage",
-            return_schema=True,
-        ).columns.keys()
+        self._natural_language_cols = list(
+            X.ww.select(
+                "NaturalLanguage",
+                return_schema=True,
+            ).columns.keys(),
+        )
 
         # Only impute data that is not natural language columns or fully null
         self._cols_to_impute = [

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -70,11 +70,13 @@ class SimpleImputer(Transformer):
             )
 
         nan_ratio = X.isna().sum() / X.shape[0]
-        self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()
 
         # Keep track of the different types of data in X
         self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()
-        self._natural_language_cols = X.ww.select("NaturalLanguage").columns.to_list()
+        self._natural_language_cols = X.ww.select(
+            "NaturalLanguage",
+            return_schema=True,
+        ).columns.keys()
 
         # Only impute data that is not natural language columns or fully null
         self._cols_to_impute = [
@@ -119,7 +121,7 @@ class SimpleImputer(Transformer):
         elif self._fit_with_all_bool_dtypes:
             self._component_obj.fit(X[self._cols_to_impute])
 
-        X_t = self._component_obj.transform(X.ww[self._cols_to_impute])
+        X_t = self._component_obj.transform(X[self._cols_to_impute])
         X_t = pd.DataFrame(X_t, columns=self._cols_to_impute)
 
         # Get Woodwork types for the imputed data

--- a/evalml/pipelines/components/transformers/imputers/simple_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/simple_imputer.py
@@ -113,6 +113,7 @@ class SimpleImputer(Transformer):
             # If there are no columns to impute, return the original data without any fully null columns
             return X.ww[not_all_null_cols]
         elif (X.dtypes == bool).all():
+            # --> problematic potentially if the training data has nans and therefore has a different logical type
             return X
 
         X_t = self._component_obj.transform(X.ww[self._cols_to_impute])

--- a/evalml/pipelines/components/transformers/imputers/target_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/target_imputer.py
@@ -99,7 +99,7 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
             raise TypeError("Provided target full of nulls.")
         y = y.to_frame()
 
-        # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
+        # Return early if all the columns are bool dtype, which will never have null values
         if (y.dtypes == bool).all():
             return y
 
@@ -123,7 +123,7 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
         y_ww = infer_feature_types(y)
         y_df = y_ww.ww.to_frame()
 
-        # Return early since bool dtype doesn't support nans and sklearn errors if all cols are bool
+        # Return early if all the columns are bool dtype, which will never have null values
         if (y_df.dtypes == bool).all():
             return X, y_ww
 

--- a/evalml/pipelines/components/transformers/imputers/target_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/target_imputer.py
@@ -7,7 +7,7 @@ from sklearn.impute import SimpleImputer as SkImputer
 from woodwork.logical_types import (
     Boolean,
     BooleanNullable,
-    Integer,
+    Double,
     IntegerNullable,
 )
 
@@ -131,8 +131,7 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
 
         new_logical_type = y_ww.ww.logical_type
         if isinstance(y_ww.ww.logical_type, IntegerNullable):
-            # --> need to check if this truncates floats
-            new_logical_type = Integer
+            new_logical_type = Double
         elif isinstance(y_ww.ww.logical_type, BooleanNullable):
             new_logical_type = Boolean
 

--- a/evalml/pipelines/components/transformers/imputers/target_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/target_imputer.py
@@ -8,6 +8,7 @@ from woodwork.logical_types import (
     Boolean,
     BooleanNullable,
     Double,
+    Integer,
     IntegerNullable,
 )
 
@@ -131,7 +132,10 @@ class TargetImputer(Transformer, metaclass=TargetImputerMeta):
 
         new_logical_type = y_ww.ww.logical_type
         if isinstance(y_ww.ww.logical_type, IntegerNullable):
-            new_logical_type = Double
+            if self.parameters["impute_strategy"] in ["mean", "median"]:
+                new_logical_type = Double
+            else:
+                new_logical_type = Integer
         elif isinstance(y_ww.ww.logical_type, BooleanNullable):
             new_logical_type = Boolean
 

--- a/evalml/pipelines/components/transformers/imputers/time_series_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/time_series_imputer.py
@@ -108,7 +108,7 @@ class TimeSeriesImputer(Transformer):
         """
         X = infer_feature_types(X)
 
-        nan_ratio = X.ww.describe().loc["nan_count"] / X.shape[0]
+        nan_ratio = X.isna().sum() / X.shape[0]
         self._all_null_cols = nan_ratio[nan_ratio == 1].index.tolist()
 
         def _filter_cols(impute_strat, X):

--- a/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
+++ b/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
@@ -73,17 +73,6 @@ class _ExtractFeaturesWithTransformPrimitives(Transformer):
         es = self._make_entity_set(X_ww)
         features = ft.calculate_feature_matrix(features=self._features, entityset=es)
 
-        # Convert to object dtype so that pd.NA is converted to np.nan
-        # until sklearn imputer can handle pd.NA in release 1.1
-        # FT returns these as string types, currently there isn't much difference
-        # in terms of performance between object and string
-        # see https://pandas.pydata.org/docs/user_guide/text.html#text-data-types
-        # "Currently, the performance of object dtype arrays of strings
-        # "and arrays.StringArray are about the same."
-        features = features.astype(object, copy=False)
-        features.index = X_ww.index
-        features.ww.init(logical_types={col_: "categorical" for col_ in features})
-
         X_ww = X_ww.ww.drop(self._columns)
         X_ww = ww.concat_columns([X_ww, features])
 

--- a/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
+++ b/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
@@ -73,6 +73,14 @@ class _ExtractFeaturesWithTransformPrimitives(Transformer):
         es = self._make_entity_set(X_ww)
         features = ft.calculate_feature_matrix(features=self._features, entityset=es)
 
+        ltypes = features.ww.logical_types
+        # CatBoost has an issue with categoricals with string categories:
+        # https://github.com/catboost/catboost/issues/1965
+        # Which will pop up if these categorical features are left with string categories,
+        # so convert them to object until the bug is fixed.
+        features = features.astype(object, copy=False)
+        features.ww.init(logical_types=ltypes)
+
         X_ww = X_ww.ww.drop(self._columns)
         X_ww = ww.concat_columns([X_ww, features])
 

--- a/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
+++ b/evalml/pipelines/components/transformers/preprocessing/transform_primitive_components.py
@@ -73,6 +73,17 @@ class _ExtractFeaturesWithTransformPrimitives(Transformer):
         es = self._make_entity_set(X_ww)
         features = ft.calculate_feature_matrix(features=self._features, entityset=es)
 
+        # Convert to object dtype so that pd.NA is converted to np.nan
+        # until sklearn imputer can handle pd.NA in release 1.1
+        # FT returns these as string types, currently there isn't much difference
+        # in terms of performance between object and string
+        # see https://pandas.pydata.org/docs/user_guide/text.html#text-data-types
+        # "Currently, the performance of object dtype arrays of strings
+        # "and arrays.StringArray are about the same."
+        features = features.astype(object, copy=False)
+        features.index = X_ww.index
+        features.ww.init(logical_types={col_: "categorical" for col_ in features})
+
         X_ww = X_ww.ww.drop(self._columns)
         X_ww = ww.concat_columns([X_ww, features])
 

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -167,25 +167,6 @@ def handle_component_class(component_class):
     return component_class
 
 
-def drop_natural_language_columns(X):
-    """Drops natural language columns from dataframes for the imputers.
-
-    Args:
-        X (pd.Dataframe): The dataframe that we want to impute on.
-
-    Returns:
-        pd.Dataframe: the dataframe with any natural language columns dropped.
-        list: list of all the columns that are considered natural language.
-    """
-    natural_language_columns = list(
-        X.ww.select(["NaturalLanguage"], return_schema=True).columns.keys(),
-    )
-    if natural_language_columns:
-        X = X.ww.copy()
-        X = X.ww.drop(columns=natural_language_columns)
-    return X, natural_language_columns
-
-
 def get_prediction_intevals_for_tree_regressors(
     X: pd.DataFrame,
     predictions: pd.Series,

--- a/evalml/pipelines/components/utils.py
+++ b/evalml/pipelines/components/utils.py
@@ -186,35 +186,6 @@ def drop_natural_language_columns(X):
     return X, natural_language_columns
 
 
-def set_boolean_columns_to_integer(X):
-    """Sets boolean columns to integer nullable for the imputer.
-
-    Args:
-        X (pd.Dataframe): The dataframe that we want to impute on.
-
-    Returns:
-        pd.Dataframe: the dataframe with any of its ww columns that are boolean set to integer nullable.
-    """
-    X = X.ww.copy()
-    original_X_schema = X.ww.schema.get_subset_schema(
-        subset_cols=list(
-            X.ww.select(
-                exclude=["Boolean", "BooleanNullable"],
-                return_schema=True,
-            ).columns,
-        ),
-    )
-    X_boolean_cols = list(
-        X.ww.select(
-            include=["Boolean", "BooleanNullable"],
-            return_schema=True,
-        ).columns,
-    )
-    new_ltypes_for_boolean_cols = {col: "IntegerNullable" for col in X_boolean_cols}
-    X.ww.init(schema=original_X_schema, logical_types=new_ltypes_for_boolean_cols)
-    return X
-
-
 def get_prediction_intevals_for_tree_regressors(
     X: pd.DataFrame,
     predictions: pd.Series,

--- a/evalml/tests/component_tests/test_featuretools.py
+++ b/evalml/tests/component_tests/test_featuretools.py
@@ -6,7 +6,13 @@ import pytest
 import woodwork as ww
 from featuretools.feature_base import IdentityFeature
 from pandas.testing import assert_frame_equal
-from woodwork.logical_types import Boolean, Categorical, Datetime, Double, Integer
+from woodwork.logical_types import (
+    Boolean,
+    Categorical,
+    Datetime,
+    Double,
+    Integer,
+)
 
 from evalml.demos import load_diabetes
 from evalml.pipelines.components import DFSTransformer

--- a/evalml/tests/component_tests/test_ft_transform_primitive_components.py
+++ b/evalml/tests/component_tests/test_ft_transform_primitive_components.py
@@ -50,11 +50,9 @@ def make_answer_email_fit_transform(df_with_url_and_email):
         ["gmail.com", "yahoo.com", "abalone.com", "hotmail.com", "email.org"],
         dtype="category",
     )
-    expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = ww.init_series(
-        pd.Series(
-            [True, True, False, True, True],
-        ),
-        logical_type="BooleanNullable",
+    expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = pd.Series(
+        [True, True, False, True, True],
+        dtype="category",
     )
     expected.ww.drop(["email"], inplace=True)
     return expected
@@ -95,11 +93,11 @@ def make_answer_email_fit_transform_missing_values(df_with_url_and_email):
     )
     expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = pd.Series(
         [None, None, False, True, True],
-        dtype="boolean",
+        dtype="category",
     )
     expected.ww["IS_FREE_EMAIL_DOMAIN(email_2)"] = pd.Series(
         [None, None, False, True, None],
-        dtype="boolean",
+        dtype="category",
     )
     return expected
 
@@ -143,7 +141,7 @@ def make_expected_logical_types_email_fit_transform():
     return {
         "categorical": ww.logical_types.Categorical(),
         "numeric": ww.logical_types.Double(),
-        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.BooleanNullable(),
+        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.Categorical(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": ww.logical_types.Categorical(),
         "integer": ww.logical_types.Integer(),
         "boolean": ww.logical_types.Boolean(),
@@ -172,8 +170,8 @@ def make_expected_logical_types_email_fit_transform_missing_values():
         "numeric": ww.logical_types.Double(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": ww.logical_types.Categorical(),
         "EMAIL_ADDRESS_TO_DOMAIN(email_2)": ww.logical_types.Categorical(),
-        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.BooleanNullable(),
-        "IS_FREE_EMAIL_DOMAIN(email_2)": ww.logical_types.BooleanNullable(),
+        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.Categorical(),
+        "IS_FREE_EMAIL_DOMAIN(email_2)": ww.logical_types.Categorical(),
         "integer": ww.logical_types.Integer(),
         "boolean": ww.logical_types.Boolean(),
         "nat_lang": ww.logical_types.NaturalLanguage(),

--- a/evalml/tests/component_tests/test_ft_transform_primitive_components.py
+++ b/evalml/tests/component_tests/test_ft_transform_primitive_components.py
@@ -50,9 +50,11 @@ def make_answer_email_fit_transform(df_with_url_and_email):
         ["gmail.com", "yahoo.com", "abalone.com", "hotmail.com", "email.org"],
         dtype="category",
     )
-    expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = pd.Series(
-        [True, True, False, True, True],
-        dtype="category",
+    expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = ww.init_series(
+        pd.Series(
+            [True, True, False, True, True],
+        ),
+        logical_type="BooleanNullable",
     )
     expected.ww.drop(["email"], inplace=True)
     return expected
@@ -93,11 +95,11 @@ def make_answer_email_fit_transform_missing_values(df_with_url_and_email):
     )
     expected.ww["IS_FREE_EMAIL_DOMAIN(email)"] = pd.Series(
         [None, None, False, True, True],
-        dtype="category",
+        dtype="boolean",
     )
     expected.ww["IS_FREE_EMAIL_DOMAIN(email_2)"] = pd.Series(
         [None, None, False, True, None],
-        dtype="category",
+        dtype="boolean",
     )
     return expected
 
@@ -141,7 +143,7 @@ def make_expected_logical_types_email_fit_transform():
     return {
         "categorical": ww.logical_types.Categorical(),
         "numeric": ww.logical_types.Double(),
-        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.Categorical(),
+        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.BooleanNullable(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": ww.logical_types.Categorical(),
         "integer": ww.logical_types.Integer(),
         "boolean": ww.logical_types.Boolean(),
@@ -170,8 +172,8 @@ def make_expected_logical_types_email_fit_transform_missing_values():
         "numeric": ww.logical_types.Double(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": ww.logical_types.Categorical(),
         "EMAIL_ADDRESS_TO_DOMAIN(email_2)": ww.logical_types.Categorical(),
-        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.Categorical(),
-        "IS_FREE_EMAIL_DOMAIN(email_2)": ww.logical_types.Categorical(),
+        "IS_FREE_EMAIL_DOMAIN(email)": ww.logical_types.BooleanNullable(),
+        "IS_FREE_EMAIL_DOMAIN(email_2)": ww.logical_types.BooleanNullable(),
         "integer": ww.logical_types.Integer(),
         "boolean": ww.logical_types.Boolean(),
         "nat_lang": ww.logical_types.NaturalLanguage(),

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -15,7 +15,10 @@ from woodwork.logical_types import (
 )
 
 from evalml.pipelines.components import Imputer
-from evalml.pipelines.components.transformers.imputers import KNNImputer, SimpleImputer
+from evalml.pipelines.components.transformers.imputers import (
+    KNNImputer,
+    SimpleImputer,
+)
 
 
 def test_invalid_strategy_parameters():

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -185,6 +185,7 @@ def test_categorical_and_numeric_input(imputer_test_data):
             "object col": pd.Series(["b", "b", "a", "c", "d"] * 4, dtype="category"),
             "float col": [0.1, 1.0, 0.0, -2.0, 5.0] * 4,
             "bool col": [True, False, False, True, True] * 4,
+            "bool col 2": [True, False, False, True, True] * 4,
             "natural language col": pd.Series(
                 ["cats are really great", "don't", "believe", "me?", "well..."] * 4,
                 dtype="string",

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -727,3 +727,6 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(
         assert {k: type(v) for k, v in transformed.ww.logical_types.items()} == {
             data: Double,
         }
+
+
+# --> add test for ww kept when passsed to child imputers

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -727,6 +727,3 @@ def test_imputer_woodwork_custom_overrides_returned_by_components(
         assert {k: type(v) for k, v in transformed.ww.logical_types.items()} == {
             data: Double,
         }
-
-
-# --> add test for ww kept when passsed to child imputers

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -643,7 +643,7 @@ def test_simple_imputer_all_bools_at_fit_and_transform():
         },
     )
 
-    imp = SimpleImputer()
+    imp = SimpleImputer(impute_strategy="most_frequent")
     imp.fit(X)
 
     X_imputed = imp.transform(X)
@@ -659,7 +659,7 @@ def test_simple_imputer_all_bools_at_fit_and_transform_with_all_null_and_nl_cols
     X = imputer_test_data.ww[["all nan", "bool col", "natural language col"]]
     X_copy = X.ww.copy()
 
-    imp = SimpleImputer()
+    imp = SimpleImputer(impute_strategy="most_frequent")
     imp.fit(X)
 
     X_imputed = imp.transform(X)
@@ -683,7 +683,7 @@ def test_simple_imputer_all_bools_at_fit_with_nans_at_transform():
         },
     )
 
-    imp = SimpleImputer()
+    imp = SimpleImputer(impute_strategy="most_frequent")
     imp.fit(X_train)
 
     # X_test will be BooleanNullable which will be a problem when _component_obj isn't fit

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -627,21 +627,10 @@ def test_simple_imputer_boolean_nullable_valid_train_empty_test():
     assert isinstance(X_t.ww.logical_types["a"], BooleanNullable)
 
 
-def test_simple_imputer_all_bools_at_fit_and_transform():
+def test_simple_imputer_all_bools_at_fit_and_transform(imputer_test_data):
     """Confirms that the simple imputer can handle data with only the bool dtype
     which sklearn would error on."""
-    X = pd.DataFrame(
-        {
-            "bools1": pd.Series([True, False, True, True] * 20),
-            "bools2": pd.Series([True, False, True, False] * 20),
-        },
-    )
-    X.ww.init(
-        logical_types={
-            "bools1": "Boolean",
-            "bools2": "Boolean",
-        },
-    )
+    X = imputer_test_data.ww.select("boolean")
 
     imp = SimpleImputer(impute_strategy="most_frequent")
     imp.fit(X)
@@ -656,7 +645,9 @@ def test_simple_imputer_all_bools_at_fit_and_transform_with_all_null_and_nl_cols
     """Confirm that the simple imputer, which doesn't pass all null or natural language columns
     to sklearn works when the remaining columns are all teh bool dtype, which sklearn would error on.
     """
-    X = imputer_test_data.ww[["all nan", "bool col", "natural language col"]]
+    X = imputer_test_data.ww[
+        ["all nan", "bool col", "bool col 2", "natural language col"]
+    ]
     X_copy = X.ww.copy()
 
     imp = SimpleImputer(impute_strategy="most_frequent")
@@ -666,37 +657,22 @@ def test_simple_imputer_all_bools_at_fit_and_transform_with_all_null_and_nl_cols
     pd.testing.assert_frame_equal(X_copy.ww.drop("all nan"), X_imputed)
 
 
-def test_simple_imputer_all_bools_at_fit_with_nans_at_transform():
+def test_simple_imputer_all_bools_at_fit_with_nans_at_transform(imputer_test_data):
     """Confirm that the simple imputer can handle data whose dtype is different at transform
     when originally the data only had bool dtype columns."""
     # X_train will be only bool dtypes so the _component_obj won't be fit
-    X_train = pd.DataFrame(
-        {
-            "bools1": pd.Series([True, False, True, True] * 20),
-            "bools2": pd.Series([True, False, True, False] * 20),
-        },
-    )
-    X_train.ww.init(
-        logical_types={
-            "bools1": "Boolean",
-            "bools2": "Boolean",
-        },
-    )
+    X_train = imputer_test_data.ww.select("boolean")
 
     imp = SimpleImputer(impute_strategy="most_frequent")
     imp.fit(X_train)
 
     # X_test will be BooleanNullable which will be a problem when _component_obj isn't fit
-    X_test = pd.DataFrame(
-        {
-            "bools1": pd.Series([True, False, pd.NA, True] * 20),
-            "bools2": pd.Series([True, pd.NA, True, False] * 20),
-        },
-    )
+    X_test = X_train.copy()
+    X_test.iloc[-1] = np.nan
     X_test.ww.init(
         logical_types={
-            "bools1": "BooleanNullable",
-            "bools2": "BooleanNullable",
+            "bool col": "BooleanNullable",
+            "bool col 2": "BooleanNullable",
         },
     )
 

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -626,3 +626,39 @@ def test_simple_imputer_boolean_nullable_valid_train_empty_test():
     X_t = imp.transform(X_test)
     assert not X_t["a"].isna().any()
     assert isinstance(X_t.ww.logical_types["a"], BooleanNullable)
+
+
+def test_simple_imputer_all_bools_at_fit_with_nans_at_transform():
+    # X_train will be only bool dtypes so the _component_obj won't be fit
+    X_train = pd.DataFrame(
+        {
+            "bools1": pd.Series([True, False, True, True] * 20),
+            "bools2": pd.Series([True, False, True, False] * 20),
+        },
+    )
+    X_train.ww.init(
+        logical_types={
+            "bools1": "Boolean",
+            "bools2": "Boolean",
+        },
+    )
+
+    imp = SimpleImputer()
+    imp.fit(X_train)
+
+    # X_test will be BooleanNullable which will be a problem when _component_obj isn't fit
+    X_test = pd.DataFrame(
+        {
+            "bools1": pd.Series([True, False, pd.NA, True] * 20),
+            "bools2": pd.Series([True, pd.NA, True, False] * 20),
+        },
+    )
+    X_test.ww.init(
+        logical_types={
+            "bools1": "BooleanNullable",
+            "bools2": "BooleanNullable",
+        },
+    )
+
+    X_imputed = imp.transform(X_test)
+    assert not X_imputed.isna().any().any()

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -3,7 +3,6 @@ import pandas
 import pandas as pd
 import pytest
 import woodwork as ww
-import woodwork.exceptions
 from pandas.testing import assert_frame_equal
 from woodwork.logical_types import (
     Boolean,
@@ -628,7 +627,47 @@ def test_simple_imputer_boolean_nullable_valid_train_empty_test():
     assert isinstance(X_t.ww.logical_types["a"], BooleanNullable)
 
 
+def test_simple_imputer_all_bools_at_fit_and_transform():
+    """Confirms that the simple imputer can handle data with only the bool dtype
+    which sklearn would error on."""
+    X = pd.DataFrame(
+        {
+            "bools1": pd.Series([True, False, True, True] * 20),
+            "bools2": pd.Series([True, False, True, False] * 20),
+        },
+    )
+    X.ww.init(
+        logical_types={
+            "bools1": "Boolean",
+            "bools2": "Boolean",
+        },
+    )
+
+    imp = SimpleImputer()
+    imp.fit(X)
+
+    X_imputed = imp.transform(X)
+    pd.testing.assert_frame_equal(X, X_imputed)
+
+
+def test_simple_imputer_all_bools_at_fit_and_transform_with_all_null_and_nl_cols(
+    imputer_test_data,
+):
+    """Confirm that the simple imputer, which doesn't pass all null or natural language columns
+    to sklearn works when the remaining columns are all teh bool dtype, which sklearn would error on."""
+    X = imputer_test_data.ww[["all nan", "bool col", "natural language col"]]
+    X_copy = X.ww.copy()
+
+    imp = SimpleImputer()
+    imp.fit(X)
+
+    X_imputed = imp.transform(X)
+    pd.testing.assert_frame_equal(X_copy.ww.drop("all nan"), X_imputed)
+
+
 def test_simple_imputer_all_bools_at_fit_with_nans_at_transform():
+    """Confirm that the simple imputer can handle data whose dtype is different at transform
+    when originally the data only had bool dtype columns."""
     # X_train will be only bool dtypes so the _component_obj won't be fit
     X_train = pd.DataFrame(
         {

--- a/evalml/tests/component_tests/test_simple_imputer.py
+++ b/evalml/tests/component_tests/test_simple_imputer.py
@@ -654,7 +654,8 @@ def test_simple_imputer_all_bools_at_fit_and_transform_with_all_null_and_nl_cols
     imputer_test_data,
 ):
     """Confirm that the simple imputer, which doesn't pass all null or natural language columns
-    to sklearn works when the remaining columns are all teh bool dtype, which sklearn would error on."""
+    to sklearn works when the remaining columns are all teh bool dtype, which sklearn would error on.
+    """
     X = imputer_test_data.ww[["all nan", "bool col", "natural language col"]]
     X_copy = X.ww.copy()
 

--- a/evalml/tests/component_tests/test_target_imputer.py
+++ b/evalml/tests/component_tests/test_target_imputer.py
@@ -285,5 +285,4 @@ def test_target_imputer_doesnt_truncate_imputed_ints(impute_strategy):
         # Confirm floating points are present
         assert not (expected_y_t % 1 == 0).all()
 
-    for i in range(len(y_t)):
-        assert y_t.iloc[i] == expected_y_t.iloc[i]
+    assert_series_equal(y_t, expected_y_t, check_dtype=False)

--- a/evalml/tests/component_tests/test_target_imputer.py
+++ b/evalml/tests/component_tests/test_target_imputer.py
@@ -127,8 +127,8 @@ def test_target_imputer_all_bool_return_original(data_type, make_data_type):
 
 @pytest.mark.parametrize("data_type", ["pd", "ww"])
 def test_target_imputer_boolean_dtype(data_type, make_data_type):
-    y = pd.Series([True, np.nan, False, np.nan, True], dtype="category")
-    y_expected = pd.Series([True, True, False, True, True], dtype="category")
+    y = pd.Series([True, np.nan, False, np.nan, True], dtype="boolean")
+    y_expected = pd.Series([True, True, False, True, True], dtype="bool")
     y = make_data_type(data_type, y)
     imputer = TargetImputer()
     imputer.fit(None, y)
@@ -209,8 +209,8 @@ def test_target_imputer_with_none(y, y_expected):
             pd.Series(["b", "a", "a", "a"] * 4, dtype="category"),
         ),
         (
-            pd.Series([True, None, False, True], dtype="category"),
-            pd.Series([True, True, False, True], dtype="category"),
+            pd.Series([True, None, False, True], dtype="boolean"),
+            pd.Series([True, True, False, True], dtype="bool"),
         ),
         (
             pd.Series(["b", "a", "a", None] * 4),

--- a/evalml/tests/component_tests/test_time_series_imputer.py
+++ b/evalml/tests/component_tests/test_time_series_imputer.py
@@ -171,6 +171,7 @@ def test_categorical_and_numeric_input(imputer_test_data):
             "object col": pd.Series(["b", "b", "a", "c", "d"] * 4, dtype="category"),
             "float col": [0.1, 1.0, 0.0, -2.0, 5.0] * 4,
             "bool col": [True, False, False, True, True] * 4,
+            "bool col 2": [True, False, False, True, True] * 4,
             "natural language col": pd.Series(
                 ["cats are really great", "don't", "believe", "me?", "well..."] * 4,
                 dtype="string",

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -22,7 +22,6 @@ from evalml.pipelines.components.utils import (
     handle_float_categories_for_catboost,
     make_balancing_dictionary,
     scikit_learn_wrapped_estimator,
-    set_boolean_columns_to_integer,
 )
 from evalml.problem_types import ProblemTypes
 from evalml.utils.woodwork_utils import infer_feature_types
@@ -276,48 +275,6 @@ def test_drop_natural_languages():
         },
     )
     assert_frame_equal(X_expected, X_t)
-
-
-def test_set_boolean_columns_to_integer():
-    X = pd.DataFrame(
-        {
-            "bool with nan": pd.Series(
-                [True, pd.NA, False, pd.NA, False],
-                dtype="boolean",
-            ),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-            "natural language": pd.Series(["asdf", "fdsa", "a", "b", "c"]),
-        },
-    )
-    X_e = pd.DataFrame(
-        {
-            "bool with nan": pd.Series(
-                [True, pd.NA, False, pd.NA, False],
-                dtype="boolean",
-            ),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-        },
-    )
-    X_e = infer_feature_types(X_e)
-    X_e.ww.set_types(
-        logical_types={
-            "bool with nan": "IntegerNullable",
-            "bool no nan": "IntegerNullable",
-        },
-    )
-    X = infer_feature_types(X)
-    assert len(X.ww.select(["IntegerNullable"]) == 0)
-
-    X = set_boolean_columns_to_integer(X)
-
-    assert len(X.ww.select(["IntegerNullable"]).columns) == 2
-    assert len(X.ww.select(["IntegerNullable"]) == 5)
-
-    assert_frame_equal(
-        X.ww.select(["IntegerNullable"]),
-        X_e.ww.select(["IntegerNullable"]),
-        check_dtype=False,
-    )
 
 
 def test_handle_float_categories_for_catboost(categorical_floats_df):

--- a/evalml/tests/component_tests/test_utils.py
+++ b/evalml/tests/component_tests/test_utils.py
@@ -3,7 +3,6 @@ import inspect
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
 
 from evalml.exceptions import MissingComponentError
 from evalml.model_family import ModelFamily
@@ -16,7 +15,6 @@ from evalml.pipelines.components import ComponentBase, RandomForestClassifier
 from evalml.pipelines.components.utils import (
     _all_estimators,
     all_components,
-    drop_natural_language_columns,
     estimator_unable_to_handle_nans,
     handle_component_class,
     handle_float_categories_for_catboost,
@@ -24,7 +22,6 @@ from evalml.pipelines.components.utils import (
     scikit_learn_wrapped_estimator,
 )
 from evalml.problem_types import ProblemTypes
-from evalml.utils.woodwork_utils import infer_feature_types
 
 binary = pd.Series([0] * 800 + [1] * 200)
 multiclass = pd.Series([0] * 800 + [1] * 150 + [2] * 50)
@@ -242,39 +239,6 @@ def test_estimator_unable_to_handle_nans():
         match="`estimator_class` must have a `model_family` attribute.",
     ):
         estimator_unable_to_handle_nans("error")
-
-
-def test_drop_natural_languages():
-    X = pd.DataFrame(
-        {
-            "bool with nan": pd.Series(
-                [True, pd.NA, False, pd.NA, False],
-                dtype="boolean",
-            ),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-            "natural language": pd.Series(["asdf", "fdsa", "a", "b", "c"]),
-        },
-    )
-    X = infer_feature_types(X)
-    X.ww.set_types(
-        logical_types={
-            "natural language": "natural_language",
-        },
-    )
-    X_t, dropped_cols = drop_natural_language_columns(X)
-    expected_dropped = ["natural language"]
-    assert expected_dropped == dropped_cols
-    assert len(X_t.columns) == 2
-    X_expected = pd.DataFrame(
-        {
-            "bool with nan": pd.Series(
-                [True, pd.NA, False, pd.NA, False],
-                dtype="boolean",
-            ),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-        },
-    )
-    assert_frame_equal(X_expected, X_t)
 
 
 def test_handle_float_categories_for_catboost(categorical_floats_df):

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -2227,6 +2227,7 @@ def X_no_nans():
             "object col": ["b", "b", "a", "c", "d"] * 4,
             "float col": [0.1, 1.0, 0.0, -2.0, 5.0] * 4,
             "bool col": [True, False, False, True, True] * 4,
+            "bool col 2": [True, False, False, True, True] * 4,
             "natural language col": pd.Series(
                 ["cats are really great", "don't", "believe", "me?", "well..."] * 4,
                 dtype="string",
@@ -2241,6 +2242,7 @@ def X_no_nans():
             "object col": "categorical",
             "float col": "double",
             "bool col": "boolean",
+            "bool col 2": "boolean",
             "natural language col": "NaturalLanguage",
         },
     )

--- a/evalml/tests/integration_tests/test_data_checks_and_actions_integration.py
+++ b/evalml/tests/integration_tests/test_data_checks_and_actions_integration.py
@@ -222,7 +222,7 @@ def test_data_checks_impute_cols(problem_type):
         expected_pipeline_class = BinaryClassificationPipeline
         y_expected = ww.init_series(
             pd.Series([0, 1, 1, 1, 1]),
-            logical_type="Double",
+            logical_type="Integer",
         )
 
     elif problem_type == "multiclass":
@@ -231,7 +231,7 @@ def test_data_checks_impute_cols(problem_type):
         expected_pipeline_class = MulticlassClassificationPipeline
         y_expected = ww.init_series(
             pd.Series([0, 1, 2, 2, 2]),
-            logical_type="Double",
+            logical_type="Integer",
         )
 
     else:

--- a/evalml/tests/integration_tests/test_data_checks_and_actions_integration.py
+++ b/evalml/tests/integration_tests/test_data_checks_and_actions_integration.py
@@ -20,7 +20,11 @@ from evalml.pipelines import (
     TimeSeriesRegressionPipeline,
     TimeSeriesRegularizer,
 )
-from evalml.pipelines.components import DropColumns, DropRowsTransformer, TargetImputer
+from evalml.pipelines.components import (
+    DropColumns,
+    DropRowsTransformer,
+    TargetImputer,
+)
 from evalml.pipelines.components.transformers.imputers.per_column_imputer import (
     PerColumnImputer,
 )
@@ -218,7 +222,7 @@ def test_data_checks_impute_cols(problem_type):
         expected_pipeline_class = BinaryClassificationPipeline
         y_expected = ww.init_series(
             pd.Series([0, 1, 1, 1, 1]),
-            logical_type="Integer",
+            logical_type="Double",
         )
 
     elif problem_type == "multiclass":
@@ -227,7 +231,7 @@ def test_data_checks_impute_cols(problem_type):
         expected_pipeline_class = MulticlassClassificationPipeline
         y_expected = ww.init_series(
             pd.Series([0, 1, 2, 2, 2]),
-            logical_type="Integer",
+            logical_type="Double",
         )
 
     else:

--- a/evalml/tests/pipeline_tests/test_component_graph.py
+++ b/evalml/tests/pipeline_tests/test_component_graph.py
@@ -8,7 +8,14 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
-from woodwork.logical_types import Boolean, Categorical, Double, EmailAddress, Integer
+from woodwork.logical_types import (
+    Boolean,
+    BooleanNullable,
+    Categorical,
+    Double,
+    EmailAddress,
+    Integer,
+)
 
 from evalml.demos import load_diabetes
 from evalml.exceptions import (
@@ -2677,7 +2684,7 @@ def test_get_component_input_logical_types():
         "numeric": Integer(),
         "cat": Categorical(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": Categorical(),
-        "IS_FREE_EMAIL_DOMAIN(email)": Categorical(),
+        "IS_FREE_EMAIL_DOMAIN(email)": BooleanNullable(),
     }
     assert graph1.last_component_input_logical_types == {
         "numeric": Integer(),
@@ -2685,7 +2692,7 @@ def test_get_component_input_logical_types():
         "cat_b": Boolean(),
         "cat_c": Boolean(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)_gmail.com": Boolean(),
-        "IS_FREE_EMAIL_DOMAIN(email)_1.0": Boolean(),
+        "IS_FREE_EMAIL_DOMAIN(email)": BooleanNullable(),
     }
 
     ensemble = ComponentGraph(
@@ -2717,7 +2724,7 @@ def test_get_component_input_logical_types():
         "cat": Categorical(),
         "numeric": Integer(),
         "EMAIL_ADDRESS_TO_DOMAIN(email)": Categorical(),
-        "IS_FREE_EMAIL_DOMAIN(email)": Categorical(),
+        "IS_FREE_EMAIL_DOMAIN(email)": BooleanNullable(),
     }
 
     no_estimator = ComponentGraph(

--- a/evalml/tests/utils_tests/test_gen_utils.py
+++ b/evalml/tests/utils_tests/test_gen_utils.py
@@ -23,7 +23,6 @@ from evalml.utils.gen_utils import (
     get_random_seed,
     get_time_index,
     import_or_raise,
-    is_categorical_actually_boolean,
     jupyter_check,
     pad_with_nans,
     save_plot,
@@ -876,20 +875,6 @@ def test_year_start_separated_by_gap():
         test,
         {"time_index": "time_index", "gap": 2},
     )
-
-
-def test_is_categorical_actually_boolean():
-    X = pd.DataFrame(
-        {
-            "categorical": ["a", "b", "c"],
-            "boolean_categorical": [True, False, None],
-            "boolean": [True, False, True],
-        },
-    )
-
-    assert not is_categorical_actually_boolean(X, "categorical")
-    assert is_categorical_actually_boolean(X, "boolean_categorical")
-    assert not is_categorical_actually_boolean(X, "boolean")
 
 
 @pytest.mark.parametrize("X_num_time_columns", [0, 1, 2, 3])

--- a/evalml/tests/utils_tests/test_nullable_type_utils.py
+++ b/evalml/tests/utils_tests/test_nullable_type_utils.py
@@ -199,7 +199,6 @@ def test_downcast_nullable_y_replaces_nullable_types(
     nullable_ltype,
     has_nans,
 ):
-    # --> remove this comment
     y = nullable_type_target(ltype=nullable_ltype, has_nans=has_nans)
 
     y_d = _downcast_nullable_y(

--- a/evalml/utils/gen_utils.py
+++ b/evalml/utils/gen_utils.py
@@ -49,26 +49,6 @@ def import_or_raise(library, error_msg=None, warning=False):
             raise Exception(msg)
 
 
-def is_categorical_actually_boolean(df, df_col):
-    """Function to identify columns of a dataframe that contain True, False and null type.
-
-    The function is intended to be applied to columns that are identified as Categorical
-    by the Imputer/SimpleImputer.
-
-    Args:
-        df (pandas.DataFrame): Pandas dataframe with data.
-        df_col (str): The column to identify as basically a nullable Boolean.
-
-    Returns:
-        bool: Whether the column contains True, False and a null type.
-
-    """
-    unique_vals = df[df_col].unique()
-    return {True, False}.issubset(set(unique_vals)) and any(
-        isinstance(x, bool) for x in unique_vals
-    )
-
-
 def convert_to_seconds(input_str):
     """Converts a string describing a length of time to its length in seconds.
 


### PR DESCRIPTION
Related to https://github.com/alteryx/evalml/issues/3999 (Note - will not yet close this issue, as this PR does not remove the nullable type logic; it only refactors the unnecessary logic)

Refactors the following imputers
- imputer.py 
- simple_imputer.py
- time_series_imputer.py 
- target_imputer.py
- knn_imputer.py