### PR TITLE
Add `get_prediction_intervals()` at the pipeline level

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Add nullable type incompatibility properties to the components that need them :pr:`4031`
         * Add ``get_evalml_requirements_file`` :pr:`4034`
         * Pipelines with DFS Transformers will run fast permutation importance if DFS features pre-exist :pr:`4037`
+        * Add get_prediction_intervals() at the pipeline level :pr:`4052`
     * Fixes
         * Remove nullable types handling for ``OverSampler`` :pr:`4064`
     * Changes

--- a/docs/source/user_guide/timeseries.ipynb
+++ b/docs/source/user_guide/timeseries.ipynb
@@ -953,10 +953,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_transform = pl.transform_all_but_final(\n",
-    "    X_forecast_dates, y_forecast, X_train=X, y_train=y\n",
+    "res = pl.get_prediction_intervals(\n",
+    "    X=pd.DataFrame(X_forecast_dates), y=y_forecast, X_train=X, y_train=y\n",
     ")\n",
-    "res = pl.estimator.get_prediction_intervals(X=X_transform, y=y_forecast)\n",
     "display(res)"
    ]
   },

--- a/evalml/pipelines/components/estimators/estimator.py
+++ b/evalml/pipelines/components/estimators/estimator.py
@@ -152,6 +152,7 @@ class Estimator(ComponentBase):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted regressor.
 
@@ -164,6 +165,7 @@ class Estimator(ComponentBase):
             y (pd.Series): Target data. Ignored.
             coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Optional list of predictions to use. If None, will generate predictions using `X`.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.
@@ -178,7 +180,8 @@ class Estimator(ComponentBase):
         if coverage is None:
             coverage = [0.95]
         X, _ = self._manage_woodwork(X, y)
-        predictions = self._component_obj.predict(X)
+        if predictions is None:
+            predictions = self._component_obj.predict(X)
 
         prediction_interval_result = {}
         for conf_int in coverage:

--- a/evalml/pipelines/components/estimators/regressors/arima_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/arima_regressor.py
@@ -319,6 +319,7 @@ class ARIMARegressor(Estimator):
         X: pd.DataFrame,
         y: pd.Series = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted ARIMARegressor.
 
@@ -327,6 +328,7 @@ class ARIMARegressor(Estimator):
             y (pd.Series): Target data. Optional.
             coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Not used for ARIMA regressor.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.

--- a/evalml/pipelines/components/estimators/regressors/et_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/et_regressor.py
@@ -116,7 +116,7 @@ class ExtraTreesRegressor(Estimator):
         X, _ = self._manage_woodwork(X, y)
         X = X.ww.select(exclude="Datetime")
 
-        if predictions is not None:
+        if predictions is None:
             predictions = self._component_obj.predict(X)
         estimators = self._component_obj.estimators_
         return get_prediction_intevals_for_tree_regressors(

--- a/evalml/pipelines/components/estimators/regressors/et_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/et_regressor.py
@@ -97,6 +97,7 @@ class ExtraTreesRegressor(Estimator):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted ExtraTreesRegressor.
 
@@ -105,6 +106,7 @@ class ExtraTreesRegressor(Estimator):
             y (pd.Series): Target data. Optional.
             coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Optional list of predictions to use. If None, will generate predictions using `X`.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.
@@ -114,7 +116,8 @@ class ExtraTreesRegressor(Estimator):
         X, _ = self._manage_woodwork(X, y)
         X = X.ww.select(exclude="Datetime")
 
-        predictions = self._component_obj.predict(X)
+        if predictions is not None:
+            predictions = self._component_obj.predict(X)
         estimators = self._component_obj.estimators_
         return get_prediction_intevals_for_tree_regressors(
             X,

--- a/evalml/pipelines/components/estimators/regressors/exponential_smoothing_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/exponential_smoothing_regressor.py
@@ -146,6 +146,7 @@ class ExponentialSmoothingRegressor(Estimator):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted ExponentialSmoothingRegressor.
 
@@ -156,6 +157,7 @@ class ExponentialSmoothingRegressor(Estimator):
             y (pd.Series): Target data. Optional.
             coverage (List[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Not used for Exponential Smoothing regressor.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.

--- a/evalml/pipelines/components/estimators/regressors/exponential_smoothing_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/exponential_smoothing_regressor.py
@@ -68,6 +68,7 @@ class ExponentialSmoothingRegressor(Estimator):
             "damped_trend": damped_trend,
             "seasonal": seasonal,
             "sp": sp,
+            "random_state": random_seed,
         }
         parameters.update(kwargs)
         smoothing_model_msg = (
@@ -174,6 +175,7 @@ class ExponentialSmoothingRegressor(Estimator):
             nsimulations=X.shape[0],
             repetitions=400,
             anchor="end",
+            random_state=self.parameters["random_state"],
         )
         prediction_interval_result = {}
         for conf_int in coverage:

--- a/evalml/pipelines/components/estimators/regressors/prophet_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/prophet_regressor.py
@@ -171,6 +171,7 @@ class ProphetRegressor(Estimator):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted ProphetRegressor.
 
@@ -179,6 +180,7 @@ class ProphetRegressor(Estimator):
             y (pd.Series): Target data. Ignored.
             coverage (List[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Not used for Prophet estimator.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.

--- a/evalml/pipelines/components/estimators/regressors/rf_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/rf_regressor.py
@@ -70,6 +70,7 @@ class RandomForestRegressor(Estimator):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted RandomForestRegressor.
 
@@ -78,6 +79,7 @@ class RandomForestRegressor(Estimator):
             y (pd.Series): Target data. Optional.
             coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Optional list of predictions to use. If None, will generate predictions using `X`.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.
@@ -87,7 +89,8 @@ class RandomForestRegressor(Estimator):
         X, _ = self._manage_woodwork(X, y)
         X = X.ww.select(exclude="Datetime")
 
-        predictions = self._component_obj.predict(X)
+        if predictions is None:
+            predictions = self._component_obj.predict(X)
         estimators = self._component_obj.estimators_
         return get_prediction_intevals_for_tree_regressors(
             X,

--- a/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/xgboost_regressor.py
@@ -115,6 +115,7 @@ class XGBoostRegressor(Estimator):
         X: pd.DataFrame,
         y: Optional[pd.Series] = None,
         coverage: List[float] = None,
+        predictions: pd.Series = None,
     ) -> Dict[str, pd.Series]:
         """Find the prediction intervals using the fitted ProphetRegressor.
 
@@ -123,6 +124,7 @@ class XGBoostRegressor(Estimator):
             y (pd.Series): Target data. Ignored.
             coverage (List[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
                 prediction interval should be calculated for.
+            predictions (pd.Series): Optional list of predictions to use. If None, will generate predictions using `X`.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.
@@ -132,6 +134,7 @@ class XGBoostRegressor(Estimator):
             X=X,
             y=y,
             coverage=coverage,
+            predictions=predictions,
         )
         return prediction_interval_result
 

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -11,6 +11,7 @@ NO_PREDS_PI_ESTIMATORS = [
     ModelFamily.ARIMA,
     ModelFamily.EXPONENTIAL_SMOOTHING,
     ModelFamily.PROPHET,
+    ModelFamily.EXTRA_TREES,
 ]
 
 

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -11,7 +11,6 @@ NO_PREDS_PI_ESTIMATORS = [
     ModelFamily.ARIMA,
     ModelFamily.EXPONENTIAL_SMOOTHING,
     ModelFamily.PROPHET,
-    ModelFamily.EXTRA_TREES,
 ]
 
 
@@ -206,12 +205,6 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             y_train=y_train,
         )
         if self.estimator.model_family in NO_PREDS_PI_ESTIMATORS:
-            predictions = self.predict_in_sample(
-                X=X,
-                y=y,
-                X_train=X_train,
-                y_train=y_train,
-            )
             pred_intervals = self.estimator.get_prediction_intervals(
                 X=estimator_input,
                 y=y,
@@ -219,10 +212,7 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             )
             trans_pred_intervals = {}
             for key, orig_pi_values in pred_intervals.items():
-                res_intervals = orig_pi_values - predictions
-                trans_pred_intervals[key] = (
-                    self.inverse_transform(res_intervals) + predictions
-                )
+                trans_pred_intervals[key] = self.inverse_transform(orig_pi_values)
             return trans_pred_intervals
         else:
             predictions = self.predict_in_sample(

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -7,12 +7,6 @@ from evalml.pipelines.time_series_pipeline_base import TimeSeriesPipelineBase
 from evalml.problem_types import ProblemTypes
 from evalml.utils.woodwork_utils import infer_feature_types
 
-NO_PREDS_PI_ESTIMATORS = [
-    ModelFamily.ARIMA,
-    ModelFamily.EXPONENTIAL_SMOOTHING,
-    ModelFamily.PROPHET,
-]
-
 
 class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
     """Pipeline base class for time series regression problems.
@@ -49,6 +43,13 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
     """
 
     problem_type = ProblemTypes.TIME_SERIES_REGRESSION
+
+    NO_PREDS_PI_ESTIMATORS = [
+        ModelFamily.ARIMA,
+        ModelFamily.EXPONENTIAL_SMOOTHING,
+        ModelFamily.PROPHET,
+    ]
+
     """ProblemTypes.TIME_SERIES_REGRESSION"""
 
     def fit(self, X, y):
@@ -204,7 +205,7 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             X_train=X_train,
             y_train=y_train,
         )
-        if self.estimator.model_family in NO_PREDS_PI_ESTIMATORS:
+        if self.estimator.model_family in self.NO_PREDS_PI_ESTIMATORS:
             pred_intervals = self.estimator.get_prediction_intervals(
                 X=estimator_input,
                 y=y,

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -180,10 +180,10 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
         Args:
             X (pd.DataFrame): Data of shape [n_samples, n_features].
             y (pd.Series): Target data. Ignored.
-            coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
-                prediction interval should be calculated for.
             X_train (pd.DataFrame, np.ndarray): Data the pipeline was trained on of shape [n_samples_train, n_features].
             y_train (pd.Series, np.ndarray): Targets used to train the pipeline of shape [n_samples_train].
+            coverage (list[float]): A list of floats between the values 0 and 1 that the upper and lower bounds of the
+                prediction interval should be calculated for.
 
         Returns:
             dict: Prediction intervals, keys are in the format {coverage}_lower or {coverage}_upper.

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -198,7 +198,11 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             X_train=X_train,
             y_train=y_train,
         )
-        pred_intervals = self.estimator.get_prediction_intervals(estimator_input, y)
+        pred_intervals = self.estimator.get_prediction_intervals(
+            X=estimator_input,
+            y=y,
+            coverage=coverage,
+        )
         if self.estimator.model_family not in [
             ModelFamily.ARIMA,
             ModelFamily.EXPONENTIAL_SMOOTHING,

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -206,6 +206,12 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             y_train=y_train,
         )
         if self.estimator.model_family in NO_PREDS_PI_ESTIMATORS:
+            predictions = self.predict_in_sample(
+                X=X,
+                y=y,
+                X_train=X_train,
+                y_train=y_train,
+            )
             pred_intervals = self.estimator.get_prediction_intervals(
                 X=estimator_input,
                 y=y,
@@ -213,7 +219,10 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             )
             trans_pred_intervals = {}
             for key, orig_pi_values in pred_intervals.items():
-                trans_pred_intervals[key] = self.inverse_transform(orig_pi_values)
+                res_intervals = orig_pi_values - predictions
+                trans_pred_intervals[key] = (
+                    self.inverse_transform(res_intervals) + predictions
+                )
             return trans_pred_intervals
         else:
             predictions = self.predict_in_sample(

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -203,7 +203,7 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
             y=y,
             coverage=coverage,
         )
-        if self.estimator.model_family not in [
+        if self.estimator.model_family in [
             ModelFamily.ARIMA,
             ModelFamily.EXPONENTIAL_SMOOTHING,
             ModelFamily.PROPHET,

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -197,14 +197,14 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
         Raises:
             MethodPropertyNotFoundError: If the estimator does not support Time Series Regression as a problem type.
         """
+        X, y = self._drop_time_index(X, y)
+        estimator_input = self.transform_all_but_final(
+            X,
+            y,
+            X_train=X_train,
+            y_train=y_train,
+        )
         if self.estimator.model_family in NO_PREDS_PI_ESTIMATORS:
-            X, y = self._drop_time_index(X, y)
-            estimator_input = self.transform_all_but_final(
-                X,
-                y,
-                X_train=X_train,
-                y_train=y_train,
-            )
             pred_intervals = self.estimator.get_prediction_intervals(
                 X=estimator_input,
                 y=y,

--- a/evalml/pipelines/time_series_regression_pipeline.py
+++ b/evalml/pipelines/time_series_regression_pipeline.py
@@ -184,6 +184,10 @@ class TimeSeriesRegressionPipeline(TimeSeriesPipelineBase):
         all predictions using a window size of 5. The lower and upper predictions are determined by taking the percent
         point (quantile) function of the lower tail probability at each bound multiplied by the rolling standard deviation.
 
+        Certain estimators (Extra Trees Estimator, XGBoost Estimator, Prophet Estimator, ARIMA, and
+        Exponential Smoothing estimator) utilize a different methodology to calculate prediction intervals.
+        See the docs for these estimators to learn more.
+
         Args:
             X (pd.DataFrame): Data of shape [n_samples, n_features].
             y (pd.Series): Target data. Ignored.

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1953,7 +1953,7 @@ def test_time_series_pipeline_get_prediction_intervals(
     )
 
     for key, pl_interval in pl_intervals.items():
-        if no_preds_pi_estimator is False:
+        if not no_preds_pi_estimator:
             assert_series_equal(est_intervals[key], pl_interval)
         else:
             est_interval = est_intervals[key]

--- a/evalml/tests/pipeline_tests/test_time_series_pipeline.py
+++ b/evalml/tests/pipeline_tests/test_time_series_pipeline.py
@@ -1861,3 +1861,101 @@ def test_dates_needed_for_prediction_range(
             prediction_start,
             prediction_end,
         )
+
+
+@pytest.mark.parametrize("add_decomposer", [True, False])
+@pytest.mark.parametrize("no_preds_pi_estimator", [True, False])
+def test_time_series_pipeline_get_prediction_intervals(
+    no_preds_pi_estimator,
+    add_decomposer,
+    ts_data_long,
+):
+    X, _, y = ts_data_long
+    component_graph = {
+        "Time Series Featurizer": ["Time Series Featurizer", "X", "y"],
+        "DateTime Featurizer": ["DateTime Featurizer", "Time Series Featurizer.x", "y"],
+        "Drop NaN Rows Transformer": [
+            "Drop NaN Rows Transformer",
+            "DateTime Featurizer.x",
+            "y",
+        ],
+        "Regressor": [
+            "Exponential Smoothing Regressor"
+            if no_preds_pi_estimator
+            else "Linear Regressor",
+            "Drop NaN Rows Transformer.x",
+            "Drop NaN Rows Transformer.y",
+        ],
+    }
+    if add_decomposer:
+        component_graph.update(
+            {
+                "STL Decomposer": ["STL Decomposer", "Time Series Featurizer.x", "y"],
+                "DateTime Featurizer": [
+                    "DateTime Featurizer",
+                    "STL Decomposer.x",
+                    "STL Decomposer.y",
+                ],
+                "Drop NaN Rows Transformer": [
+                    "Drop NaN Rows Transformer",
+                    "DateTime Featurizer.x",
+                    "STL Decomposer.y",
+                ],
+            },
+        )
+
+    pipeline = TimeSeriesRegressionPipeline(
+        component_graph=component_graph,
+        parameters={
+            "pipeline": {
+                "gap": 1,
+                "max_delay": 10,
+                "time_index": "date",
+                "forecast_horizon": 7,
+                "random_seed": 0,
+            },
+            "Time Series Featurizer": {
+                "max_delay": 2,
+                "gap": 1,
+                "forecast_horizon": 10,
+                "time_index": "date",
+            },
+        },
+    )
+    limit = int(np.floor(0.66 * len(X)))
+    X_train, y_train = X[:limit], y[:limit]
+    X_validation, y_validation = X[limit + 1 :], y[limit + 1 :]
+    pipeline.fit(X_train, y_train)
+
+    pl_intervals = pipeline.get_prediction_intervals(
+        X=X_validation,
+        y=y_validation,
+        X_train=X_train,
+        y_train=y_train,
+    )
+
+    predictions = pipeline.predict_in_sample(
+        X_validation,
+        y_validation,
+        X_train,
+        y_train,
+    )
+    features = pipeline.transform_all_but_final(
+        X_validation,
+        y_validation,
+        X_train,
+        y_train,
+    )
+    est_intervals = pipeline.estimator.get_prediction_intervals(
+        X=features,
+        y=y_validation,
+        predictions=predictions,
+    )
+
+    for key, pl_interval in pl_intervals.items():
+        if no_preds_pi_estimator is False:
+            assert_series_equal(est_intervals[key], pl_interval)
+        else:
+            est_interval = est_intervals[key]
+            inv_trans_interval = pipeline.inverse_transform(est_interval)
+            assert_series_equal(inv_trans_interval, pl_interval)


### PR DESCRIPTION
Resolves #4060 

Adds `get_prediction_intervals()` at the pipeline level, which runs `inverse_transform()` before returning results.