### PR TITLE
Dont allow knn as boolean impute strategy

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Release Notes
         * Unpinned ``networkx`` and updated minimum version :pr:`4035`
         * Increased ``scikit-learn`` version to 1.2.2 :pr:`4064`
         * Capped max ``holidays`` version to 0.21 :pr:`4064`
+        * Stop allowing ``knn`` as a boolean impute strategy :pr:`4058`
     * Documentation Changes
     * Testing Changes
         * Use ``release.yaml`` for performance tests on merge to main :pr:`4007`

--- a/evalml/pipelines/components/transformers/imputers/imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/imputer.py
@@ -25,18 +25,18 @@ class Imputer(Transformer):
     hyperparameter_ranges = {
         "categorical_impute_strategy": ["most_frequent"],
         "numeric_impute_strategy": ["mean", "median", "most_frequent", "knn"],
-        "boolean_impute_strategy": ["most_frequent", "knn"],
+        "boolean_impute_strategy": ["most_frequent"],
     }
     """{
         "categorical_impute_strategy": ["most_frequent"],
         "numeric_impute_strategy": ["mean", "median", "most_frequent", "knn"],
-        "boolean_impute_strategy": ["most_frequent", "knn"]
+        "boolean_impute_strategy": ["most_frequent"]
     }"""
     _valid_categorical_impute_strategies = set(["most_frequent", "constant"])
     _valid_numeric_impute_strategies = set(
         ["mean", "median", "most_frequent", "constant", "knn"],
     )
-    _valid_boolean_impute_strategies = set(["most_frequent", "constant", "knn"])
+    _valid_boolean_impute_strategies = set(["most_frequent", "constant"])
 
     def __init__(
         self,
@@ -76,17 +76,11 @@ class Imputer(Transformer):
             fill_value=categorical_fill_value,
             **kwargs,
         )
-        if boolean_impute_strategy == "knn":
-            self._boolean_imputer = KNNImputer(
-                number_neighbors=1,
-                **kwargs,
-            )
-        else:
-            self._boolean_imputer = SimpleImputer(
-                impute_strategy=boolean_impute_strategy,
-                fill_value=boolean_fill_value,
-                **kwargs,
-            )
+        self._boolean_imputer = SimpleImputer(
+            impute_strategy=boolean_impute_strategy,
+            fill_value=boolean_fill_value,
+            **kwargs,
+        )
         if numeric_impute_strategy == "knn":
             self._numeric_imputer = KNNImputer(
                 number_neighbors=3,

--- a/evalml/pipelines/components/transformers/imputers/knn_imputer.py
+++ b/evalml/pipelines/components/transformers/imputers/knn_imputer.py
@@ -91,12 +91,8 @@ class KNNImputer(Transformer):
 
         X_schema = X.ww.schema
 
-        X_bool_nullable_cols = X_schema._filter_cols(include=["BooleanNullable"])
         X_int_nullable_cols = X_schema._filter_cols(include=["IntegerNullable"])
-        new_ltypes_for_nullable_cols = {col: "Boolean" for col in X_bool_nullable_cols}
-        new_ltypes_for_nullable_cols.update(
-            {col: "Double" for col in X_int_nullable_cols},
-        )
+        new_ltypes_for_nullable_cols = {col: "Double" for col in X_int_nullable_cols}
 
         # Add back in natural language columns, unchanged
         if len(natural_language_cols) > 0:

--- a/evalml/tests/component_tests/test_imputer.py
+++ b/evalml/tests/component_tests/test_imputer.py
@@ -70,7 +70,7 @@ def test_imputer_init(
     expected_hyperparameters = {
         "categorical_impute_strategy": ["most_frequent"],
         "numeric_impute_strategy": ["mean", "median", "most_frequent", "knn"],
-        "boolean_impute_strategy": ["most_frequent", "knn"],
+        "boolean_impute_strategy": ["most_frequent"],
     }
     assert imputer.name == "Imputer"
     assert imputer.parameters == expected_parameters
@@ -78,25 +78,22 @@ def test_imputer_init(
 
 
 @pytest.mark.parametrize("categorical_impute_strategy", ["most_frequent", "constant"])
-def test_knn_as_input(categorical_impute_strategy):
+@pytest.mark.parametrize("boolean_impute_strategy", ["most_frequent", "constant"])
+def test_knn_as_input(boolean_impute_strategy, categorical_impute_strategy):
     imputer = Imputer(
         categorical_impute_strategy=categorical_impute_strategy,
         numeric_impute_strategy="knn",
-        boolean_impute_strategy="knn",
+        boolean_impute_strategy=boolean_impute_strategy,
     )
     assert isinstance(imputer._categorical_imputer, SimpleImputer)
     assert isinstance(imputer._numeric_imputer, KNNImputer)
-    assert isinstance(imputer._boolean_imputer, KNNImputer)
+    assert isinstance(imputer._boolean_imputer, SimpleImputer)
 
     expected_numeric_parameters = {
         "number_neighbors": 3,
     }
-    expected_boolean_parameters = {
-        "number_neighbors": 1,
-    }
 
     assert imputer._numeric_imputer.parameters == expected_numeric_parameters
-    assert imputer._boolean_imputer.parameters == expected_boolean_parameters
 
 
 def test_numeric_only_input(imputer_test_data):

--- a/evalml/tests/component_tests/test_knn_imputer.py
+++ b/evalml/tests/component_tests/test_knn_imputer.py
@@ -1,12 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
-import woodwork as ww
 from pandas.testing import assert_frame_equal
 from sklearn.impute import KNNImputer as Sk_KNNImputer
 
 from evalml.pipelines.components.transformers.imputers import KNNImputer
-from evalml.utils.woodwork_utils import infer_feature_types
 
 
 @pytest.mark.parametrize("n_neighbors", [1, 2, 5])
@@ -27,72 +25,6 @@ def test_knn_output(n_neighbors):
     sk_knn = Sk_KNNImputer(n_neighbors=n_neighbors)
     knn = KNNImputer(n_neighbors)
     assert_frame_equal(pd.DataFrame(sk_knn.fit_transform(X)), knn.fit_transform(X))
-
-
-@pytest.mark.parametrize("data_type", ["pd", "ww"])
-def test_knn_imputer_all_bool_return_original(data_type, make_data_type):
-    X = pd.DataFrame([True, True, False, True, True], dtype=bool)
-    y = pd.Series([1, 0, 0, 1, 0])
-    X = make_data_type(data_type, X)
-    y = make_data_type(data_type, y)
-    X_expected_arr = pd.DataFrame([True, True, False, True, True], dtype=bool)
-    imputer = KNNImputer()
-    imputer.fit(X, y)
-    X_t = imputer.transform(X)
-    assert_frame_equal(X_expected_arr, X_t)
-
-    X = infer_feature_types(X)
-    assert_frame_equal(X.ww.types, X_t.ww.types)
-
-
-@pytest.mark.parametrize("data_type", ["pd", "ww"])
-def test_knn_imputer_boolean_dtype(data_type, make_data_type):
-    X = pd.DataFrame(
-        {
-            "some_nan": pd.Series([True, np.nan, False, np.nan, True], dtype="boolean"),
-        },
-    )
-    y = pd.Series([1, 0, 0, 1, 0])
-    X_expected_arr = pd.DataFrame(
-        {
-            "some_nan": pd.Series([True, True, False, True, True]),
-        },
-    )
-    X = make_data_type(data_type, X)
-    imputer = KNNImputer(number_neighbors=1)
-    X_t = imputer.fit_transform(X, y)
-
-    assert type(X_t.ww.logical_types["some_nan"]) == ww.logical_types.Boolean
-    assert_frame_equal(X_expected_arr, X_t)
-
-
-@pytest.mark.parametrize("data_type", ["pd", "ww"])
-def test_knn_imputer_multitype_with_one_bool(data_type, make_data_type):
-    X_multi = pd.DataFrame(
-        {
-            "bool with nan": pd.Series([True, np.nan, False, np.nan, False]),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-        },
-    )
-    X_multi.ww.init(logical_types={"bool with nan": "BooleanNullable"})
-    y = pd.Series([1, 0, 0, 1, 0])
-    X_multi_expected_arr = pd.DataFrame(
-        {
-            "bool with nan": pd.Series(
-                [True, True, False, True, False],
-                dtype=bool,
-            ),
-            "bool no nan": pd.Series([False, False, False, False, True], dtype=bool),
-        },
-    )
-    X_multi = make_data_type(data_type, X_multi)
-
-    imputer = KNNImputer(number_neighbors=1)
-    imputer.fit(X_multi, y)
-    X_multi_t = imputer.transform(X_multi)
-    assert_frame_equal(X_multi_expected_arr, X_multi_t)
-    for col in X_multi_t:
-        assert type(X_multi_t.ww.logical_types[col]) == ww.logical_types.Boolean
 
 
 @pytest.mark.parametrize("df_composition", ["full_df", "single_column"])
@@ -135,3 +67,21 @@ def test_knn_imputer_ignores_natural_language(
         assert_frame_equal(result, X_df)
     elif df_composition == "single_column":
         assert_frame_equal(result, X_df)
+
+
+def test_knn_imputer_maintains_woodwork_types(imputer_test_data):
+    X = imputer_test_data.ww.select("numeric")
+    int_nullable_cols = X.ww.select("IntegerNullable").columns.to_list()
+    unchanged_schema = X.ww.drop(int_nullable_cols).ww.schema
+    y = pd.Series([x for x in range(X.shape[1])])
+
+    imputer = KNNImputer(number_neighbors=3)
+
+    imputer.fit(X, y)
+    result = imputer.transform(X, y)
+    assert unchanged_schema == result.ww.drop(int_nullable_cols).ww.schema
+    assert {
+        str(ltype)
+        for col, ltype in result.ww.logical_types.items()
+        if col in int_nullable_cols
+    } == {"Double"}

--- a/evalml/tests/pipeline_tests/test_pipelines.py
+++ b/evalml/tests/pipeline_tests/test_pipelines.py
@@ -2613,7 +2613,7 @@ def test_get_hyperparameter_ranges():
                 categories=("most_frequent", "mean"),
                 prior=None,
             ),
-            "boolean_impute_strategy": ["most_frequent", "knn"],
+            "boolean_impute_strategy": ["most_frequent"],
         },
         "Random Forest Classifier": {
             "n_estimators": Integer(


### PR DESCRIPTION
closes #4057 

Removes "knn" from `boolean_impute_strategy` in the `Imputer` component and stops accounting for boolean data in the `KNNImputer` component. 