### PR TITLE
Handle new oversampler nullable type incompatibility in X

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Added Oversampler nullable type incompatibility in X :pr:`4068`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -1,5 +1,4 @@
 """SMOTE Oversampler component. Will automatically select whether to use SMOTE, SMOTEN, or SMOTENC based on inputs to the component."""
-
 from evalml.pipelines.components.transformers.samplers.base_sampler import BaseSampler
 from evalml.pipelines.components.utils import make_balancing_dictionary
 from evalml.utils import import_or_raise
@@ -25,6 +24,9 @@ class Oversampler(BaseSampler):
     name = "Oversampler"
     hyperparameter_ranges = {}
     _can_be_used_for_fast_partial_dependence = False
+
+    # Incompatibility https://github.com/alteryx/evalml/issues/3974
+    # TODO: Remove when support is added https://github.com/alteryx/evalml/issues/4067
     _boolean_nullable_incompatibilities = ["X"]
     _integer_nullable_incompatibilities = ["X"]
 

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -82,23 +82,6 @@ class Oversampler(BaseSampler):
         super().fit(X, y)
         return self
 
-    def transform(self, X, y=None):
-        """Transforms the input data by Oversampling the data.
-
-        Args:
-            X (pd.DataFrame): Training features.
-            y (pd.Series): Target.
-
-        Returns:
-            pd.DataFrame, pd.Series: Transformed features and target.
-        """
-        X_ww, y_ww = self._prepare_data(X, y)
-        original_schema = X_ww.ww.schema
-        X_d, y_d = self._handle_nullable_types(X_ww, y_ww)
-        X_t, y_t = super().transform(X_d, y_d)
-        X_t.ww.init(schema=original_schema)
-        return X_t, y_t
-
     def _get_best_oversampler(self, X):
         cat_cols = X.ww.select(["category", "boolean"]).columns
         if len(cat_cols) == X.shape[1]:

--- a/evalml/pipelines/components/transformers/samplers/oversampler.py
+++ b/evalml/pipelines/components/transformers/samplers/oversampler.py
@@ -25,7 +25,6 @@ class Oversampler(BaseSampler):
     name = "Oversampler"
     hyperparameter_ranges = {}
     _can_be_used_for_fast_partial_dependence = False
-    # --> need to make follow up evalml ticket to remove this eventually
     _boolean_nullable_incompatibilities = ["X"]
     _integer_nullable_incompatibilities = ["X"]
 

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -529,6 +529,8 @@ def test_oversampler_nullable_type_incompatibility(
         evalml_oversampler = Oversampler(sampling_ratio=0.5)
         X, y = evalml_oversampler._handle_nullable_types(X, y)
 
+    # We have to convert to `object` dtype with categorical columns
+    # because of the sklearn bug described by the test below this one
     X["categorical col"] = X["categorical col"].astype("object")
 
     im_oversampler.fit_resample(X, y)
@@ -548,10 +550,10 @@ def test_oversampler_category_dtype_incompatibility(
     nullable_type_test_data,
     handle_incompatibility,
 ):
-    """Testing that the nullable type incompatibility that caused us to add handling for Oversampler
-    is still present in imblearn's SMOTE oversamplers. If this test is causing the test suite to fail
-    because the code below no longer raises the expected ValueError, we should confirm that the nullable
-    types now work for our use case and remove the nullable type handling logic from Oversampler.
+    """Testing that the sklearn error the SMOTENC oversampler produces with categorical columns
+    is still present. If this test is causing the test suite to fail because the code
+    below no longer raises the expected ValueError, we should confirm that the issue with categorical
+    columns is truly gone and remove the logic to convert categorical columns to the object dtype.
     """
     X = nullable_type_test_data(has_nans=False)
     X = X.ww[["categorical col", "bool col"]]

--- a/evalml/tests/component_tests/test_oversampler.py
+++ b/evalml/tests/component_tests/test_oversampler.py
@@ -1,5 +1,4 @@
 import copy
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -451,7 +450,6 @@ def test_oversampler_handle_nullable_types(
     X = nullable_type_test_data(has_nans=False)
     # Oversampler can only handle numeric and boolean columns
     X = X.ww.select(include=["numeric", "Boolean", "BooleanNullable", "category"])
-    original_schema = X.ww.schema
     y = nullable_type_target(ltype=nullable_y_ltype, has_nans=False)
 
     oversampler = Oversampler(sampling_ratio=0.5)
@@ -461,30 +459,6 @@ def test_oversampler_handle_nullable_types(
     # Confirm oversampling happened by checking the length increased
     assert len(X_t) > len(X)
     assert len(y_t) > len(y)
-
-    # Confirm the original types are maintained
-    assert original_schema == X_t.ww.schema
-
-
-@patch(
-    "evalml.pipelines.components.component_base.ComponentBase._handle_nullable_types",
-)
-def test_oversampler_calls_handle_nullable_types(
-    mock_handle_nullable_types,
-    X_y_binary,
-):
-    X, y = X_y_binary
-
-    oversampler = Oversampler()
-
-    assert not mock_handle_nullable_types.called
-    mock_handle_nullable_types.return_value = X, y
-
-    oversampler.fit(X, y)
-    assert not mock_handle_nullable_types.called
-
-    oversampler.transform(X, y)
-    assert mock_handle_nullable_types.called
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
closes https://github.com/alteryx/evalml/issues/3974

This incompatibility only shows up when string categorical columns are present with the nullable pandas dtypes, but I chose not to add a special `_handle_nullable_types` implementation since it's dataset dependent vs the time series imputer that needed a different handling but that would be applied to any dataset. This is a bit of a gray area, though, so I'm open to changing it.