### PR TITLE
Remove nullable handlings where possible from sklearn 1.2.2 upgrade 

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Fixes
     * Changes
         * Added Oversampler nullable type incompatibility in X :pr:`4068`
+        * Removed nullable handling from objective functions, ``roc_curve``, and ``correlation_matrix`` :pr:`4072`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/model_understanding/metrics.py
+++ b/evalml/model_understanding/metrics.py
@@ -9,31 +9,9 @@ from sklearn.metrics import precision_recall_curve as sklearn_precision_recall_c
 from sklearn.metrics import roc_curve as sklearn_roc_curve
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.utils.multiclass import unique_labels
-from woodwork.logical_types import BooleanNullable, IntegerNullable
 
 from evalml.exceptions import NoPositiveLabelException
 from evalml.utils import import_or_raise, infer_feature_types, jupyter_check
-
-
-def _convert_ww_series_to_np_array(ww_series):
-    """Helper function to properly convert IntegerNullable/BooleanNullable Woodwork series to numpy arrays.
-
-    Args:
-        ww_series: Woodwork init-ed series possibly containing IntegerNullable or BooleanNullable datatype
-
-    Returns:
-        numpy.ndarray: The values of ww_series but in an array.
-    """
-    np_series = ww_series.to_numpy()
-    if isinstance(ww_series.ww.logical_type, BooleanNullable):
-        np_series = np_series.astype("bool")
-    if isinstance(ww_series.ww.logical_type, IntegerNullable):
-        try:
-            np_series = np_series.astype("int64")
-        except TypeError:
-            np_series = ww_series.astype(float).to_numpy()
-
-    return np_series
 
 
 def confusion_matrix(y_true, y_predicted, normalize_method="true"):
@@ -269,6 +247,7 @@ def roc_curve(y_true, y_pred_proba):
 
     Args:
         y_true (pd.Series or np.ndarray): True labels.
+        # --> also pd dataframe for multiclass
         y_pred_proba (pd.Series or np.ndarray): Predictions from a classifier, before thresholding has been applied.
 
     Returns:
@@ -279,28 +258,35 @@ def roc_curve(y_true, y_pred_proba):
                   * `threshold`: Threshold values used to produce each pair of true/false positive rates.
                   * `auc_score`: The area under the ROC curve.
     """
+    # Pull in data and convert to numpy arrays -
     y_true_ww = infer_feature_types(y_true)
-    y_true_np = _convert_ww_series_to_np_array(y_true_ww)
-    y_pred_proba = infer_feature_types(y_pred_proba).to_numpy()
+    y_pred_proba = infer_feature_types(y_pred_proba)
+    # If preds are 1d, turn it sideways to turn it 2d?
+    # --> check if series
+    if isinstance(y_pred_proba, pd.Series):
+        y_pred_proba = pd.DataFrame(y_pred_proba)
+    # If preds are 2d with two columns then only select the second column - for a binary situation
+    elif y_pred_proba.shape[1] == 2:
+        y_pred_proba = pd.DataFrame(y_pred_proba.iloc[:, 1])
 
-    if len(y_pred_proba.shape) == 1:
-        y_pred_proba = y_pred_proba.reshape(-1, 1)
-    if y_pred_proba.shape[1] == 2:
-        y_pred_proba = y_pred_proba[:, 1].reshape(-1, 1)
-    nan_indices = np.logical_or(pd.isna(y_true_np), np.isnan(y_pred_proba).any(axis=1))
-    y_true_np = y_true_np[~nan_indices]
+    y_true_nan_map = pd.isna(y_true_ww)
+    y_pred_nan_map = pd.isna(y_pred_proba).any(axis=1)
+    nan_indices = np.logical_or(y_true_nan_map, y_pred_nan_map)
+    y_true_ww = y_true_ww[~nan_indices]
     y_pred_proba = y_pred_proba[~nan_indices]
 
     lb = LabelBinarizer()
-    lb.fit(y_true_np)
-    y_one_hot_true = lb.transform(y_true_np)
+    lb.fit(y_true_ww)
+    # --> confirm this doesn't need to be woodwork inited
+    y_one_hot_true = pd.DataFrame(lb.transform(y_true_ww))
     n_classes = y_one_hot_true.shape[1]
 
     curve_data = []
     for i in range(n_classes):
+        # --> change to loc if name matters and will always be ints?
         fpr_rates, tpr_rates, thresholds = sklearn_roc_curve(
-            y_one_hot_true[:, i],
-            y_pred_proba[:, i],
+            y_one_hot_true.iloc[:, i],
+            y_pred_proba.iloc[:, i],
         )
         auc_score = sklearn_auc(fpr_rates, tpr_rates)
         curve_data.append(

--- a/evalml/model_understanding/metrics.py
+++ b/evalml/model_understanding/metrics.py
@@ -292,7 +292,7 @@ def roc_curve(y_true, y_pred_proba):
     y_pred_proba = y_pred_proba[~nan_indices]
 
     lb = LabelBinarizer()
-    lb.fit(np.unique(y_true_np))
+    lb.fit(y_true_np)
     y_one_hot_true = lb.transform(y_true_np)
     n_classes = y_one_hot_true.shape[1]
 

--- a/evalml/model_understanding/metrics.py
+++ b/evalml/model_understanding/metrics.py
@@ -48,11 +48,9 @@ def confusion_matrix(y_true, y_predicted, normalize_method="true"):
         pd.DataFrame: Confusion matrix. The column header represents the predicted labels while row header represents the actual labels.
     """
     y_true_ww = infer_feature_types(y_true)
-    y_true_np = _convert_ww_series_to_np_array(y_true_ww)
     y_predicted = infer_feature_types(y_predicted)
-    y_predicted = y_predicted.to_numpy()
-    labels = unique_labels(y_true_np, y_predicted)
-    conf_mat = sklearn_confusion_matrix(y_true_np, y_predicted)
+    labels = unique_labels(y_true_ww, y_predicted)
+    conf_mat = sklearn_confusion_matrix(y_true_ww, y_predicted)
     conf_mat = pd.DataFrame(conf_mat, index=labels, columns=labels)
     if normalize_method is not None:
         return normalize_confusion_matrix(conf_mat, normalize_method=normalize_method)

--- a/evalml/objectives/objective_base.py
+++ b/evalml/objectives/objective_base.py
@@ -5,16 +5,13 @@ import numpy as np
 import pandas as pd
 
 from evalml.problem_types import handle_problem_types
-from evalml.utils import _downcast_nullable_y, classproperty
+from evalml.utils import classproperty
 
 
 class ObjectiveBase(ABC):
     """Base class for all objectives."""
 
     problem_types = None
-    # Referring to the pandas nullable dtypes; not just woodwork logical types
-    _integer_nullable_incompatible = False
-    _boolean_nullable_incompatible = False
 
     @property
     @classmethod
@@ -202,24 +199,3 @@ class ObjectiveBase(ABC):
     def is_defined_for_problem_type(cls, problem_type):
         """Returns whether or not an objective is defined for a problem type."""
         return handle_problem_types(problem_type) in cls.problem_types
-
-    def _handle_nullable_types(self, y_true):
-        """Transforms y_true to remove any incompatible nullable types according to an objective function's needs.
-
-        Args:
-            y_true (pd.Series): Actual class labels of length [n_samples].
-                May contain nullable types.
-
-        Returns:
-            y_true with any incompatible nullable types downcasted to compatible equivalents.
-        """
-        # Do not pass numpy inputs into downcasting util, because they can
-        # never have nullable pandas dtypes.
-        if isinstance(y_true, pd.Series):
-            return _downcast_nullable_y(
-                y_true,
-                handle_boolean_nullable=self._boolean_nullable_incompatible,
-                handle_integer_nullable=self._integer_nullable_incompatible,
-            )
-
-        return y_true

--- a/evalml/objectives/standard_metrics.py
+++ b/evalml/objectives/standard_metrics.py
@@ -838,9 +838,9 @@ class MAPE(TimeSeriesRegressionObjective):
                 "targets contain the value 0.",
             )
         if isinstance(y_true, pd.Series):
-            y_true = y_true.values
+            y_true = y_true.to_numpy()
         if isinstance(y_predicted, pd.Series):
-            y_predicted = y_predicted.values
+            y_predicted = y_predicted.to_numpy()
         scaled_difference = (y_true - y_predicted) / y_true
         return np.abs(scaled_difference).mean() * 100
 

--- a/evalml/tests/conftest.py
+++ b/evalml/tests/conftest.py
@@ -23,7 +23,6 @@ from woodwork.logical_types import (
 from evalml.demos import load_weather
 from evalml.model_family import ModelFamily
 from evalml.objectives import BinaryClassificationObjective
-from evalml.objectives.objective_base import ObjectiveBase
 from evalml.objectives.utils import get_core_objectives, get_non_core_objectives
 from evalml.pipelines import (
     BinaryClassificationPipeline,
@@ -2089,27 +2088,6 @@ def CustomClassificationObjectiveRanges(ranges):
             """Not implementing since mocked in our tests."""
 
     return CustomClassificationObjectiveRanges()
-
-
-def CustomObjective(
-    integer_nullable_incompatible=True,
-    boolean_nullable_incompatible=True,
-):
-    class CustomObjective(ObjectiveBase):
-        _integer_nullable_incompatible = integer_nullable_incompatible
-        _boolean_nullable_incompatible = boolean_nullable_incompatible
-
-        name = "my_objective"
-        greater_is_better = True
-        score_needs_proba = False
-        perfect_score = 1.0
-        is_bounded_like_percentage = True
-        expected_range = [0, 1]
-
-        def objective_function(self, y_true, y_predicted, X=None, sample_weight=None):
-            """Not implementing"""
-
-    return CustomObjective()
 
 
 def CustomComponent(

--- a/evalml/tests/model_understanding_tests/test_metrics.py
+++ b/evalml/tests/model_understanding_tests/test_metrics.py
@@ -78,6 +78,17 @@ def test_confusion_matrix(data_type, test_nullable, dtype, make_data_type):
         )
 
 
+def test_incom():
+    import pandas as pd
+    from sklearn.metrics import confusion_matrix
+
+    for dtype in ["Int64", "Float64", "boolean"]:
+        y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
+        y_predicted = pd.Series([0, 0, 1, 1, 0, 1, 1, 1, 1], dtype="int64")
+
+        confusion_matrix(y_true, y_predicted)
+
+
 @pytest.mark.parametrize("data_type", ["ww", "np", "pd"])
 def test_normalize_confusion_matrix(data_type, make_data_type):
     conf_mat = np.array([[2, 3, 0], [0, 1, 1], [1, 0, 2]])
@@ -634,3 +645,6 @@ def test_jupyter_graph_check(
         graph_roc_curve(y, y_pred_proba)
         assert len(graph_valid) == 0
         import_check.assert_called_with("ipywidgets", warning=True)
+
+
+# --> add another test with confusion matrix and nullable types?

--- a/evalml/tests/model_understanding_tests/test_metrics.py
+++ b/evalml/tests/model_understanding_tests/test_metrics.py
@@ -78,17 +78,6 @@ def test_confusion_matrix(data_type, test_nullable, dtype, make_data_type):
         )
 
 
-def test_incom():
-    import pandas as pd
-    from sklearn.metrics import confusion_matrix
-
-    for dtype in ["Int64", "Float64", "boolean"]:
-        y_true = pd.Series([1, 0, 0, 1, 0, 1, 1, 0, 1], dtype=dtype)
-        y_predicted = pd.Series([0, 0, 1, 1, 0, 1, 1, 1, 1], dtype="int64")
-
-        confusion_matrix(y_true, y_predicted)
-
-
 @pytest.mark.parametrize("data_type", ["ww", "np", "pd"])
 def test_normalize_confusion_matrix(data_type, make_data_type):
     conf_mat = np.array([[2, 3, 0], [0, 1, 1], [1, 0, 2]])
@@ -331,10 +320,7 @@ def test_graph_precision_recall_curve_title_addition(X_y_binary, go):
 @pytest.mark.parametrize("dtype", ["int", "bool"])
 @pytest.mark.parametrize("data_type", ["np", "pd", "ww"])
 def test_roc_curve_binary(test_nullable, dtype, data_type, make_data_type):
-    if dtype == "int":
-        y_true = np.array([1, 1, 0, 0])
-    elif dtype == "bool":
-        y_true = np.array([1, 1, 0, 0]).astype(bool)
+    y_true = np.array([1, 1, 0, 0], dtype=dtype)
     y_predict_proba = np.array([0.1, 0.4, 0.35, 0.8])
     y_true = make_data_type(data_type, y_true, nullable=test_nullable)
     y_predict_proba = make_data_type(data_type, y_predict_proba)
@@ -355,10 +341,10 @@ def test_roc_curve_binary(test_nullable, dtype, data_type, make_data_type):
     assert isinstance(roc_curve_data["tpr_rates"], np.ndarray)
     assert isinstance(roc_curve_data["thresholds"], np.ndarray)
 
-    y_true = np.array([1, 1, 0, 0])
+    y_true = np.array([1, 1, 0, 0], dtype=dtype)
     y_predict_proba = np.array([[0.9, 0.1], [0.6, 0.4], [0.65, 0.35], [0.2, 0.8]])
     y_predict_proba = make_data_type(data_type, y_predict_proba)
-    y_true = make_data_type(data_type, y_true)
+    y_true = make_data_type(data_type, y_true, nullable=test_nullable)
 
     roc_curve_data = roc_curve(y_true, y_predict_proba)[0]
     fpr_rates = roc_curve_data.get("fpr_rates")
@@ -645,6 +631,3 @@ def test_jupyter_graph_check(
         graph_roc_curve(y, y_pred_proba)
         assert len(graph_valid) == 0
         import_check.assert_called_with("ipywidgets", warning=True)
-
-
-# --> add another test with confusion matrix and nullable types?

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -230,4 +230,5 @@ def test_objectives_support_nullable_types(
         y_true = y_true.ww.replace({0: 10})
         y_pred = y_pred.replace({0: 10})
 
-    obj.score(y_true=y_true, y_predicted=y_pred, X=X)
+    score = obj.score(y_true=y_true, y_predicted=y_pred, X=X)
+    assert not pd.isna(score)

--- a/evalml/tests/objective_tests/test_objectives.py
+++ b/evalml/tests/objective_tests/test_objectives.py
@@ -197,7 +197,7 @@ def test_get_objectives_all_expected_ranges(obj):
 @pytest.mark.parametrize("obj", [obj for obj in _all_objectives_dict().values()])
 @pytest.mark.parametrize(
     "nullable_y_true_ltype",
-    ["BooleanNullable", "Integer", "AgeNullable"],
+    ["BooleanNullable", "IntegerNullable", "AgeNullable"],
 )
 def test_objectives_support_nullable_types(
     nullable_y_true_ltype,


### PR DESCRIPTION
closes #4021, closes #4020, closes #4018, closes #3992, closes #4019, closes #4054

Removes logic related to model understanding nullable type handling and Objective nullable type handling, since sklearn 1.2.2 allows us to fully support nullable types! 
