### PR TITLE
Release v0.69.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.69.0 Mar. 15, 2023**
+    * Enhancements
         * Move black to regular dependency and use it for ``generate_pipeline_code`` :pr:`4005`
         * Implement ``generate_pipeline_example`` :pr:`4023`
         * Add new downcast utils for component-specific nullable type handling and begin implementation on objective and component base classes :pr:`4024`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -32,16 +32,11 @@ Release Notes
         * Capped max ``holidays`` version to 0.21 :pr:`4064`
         * Stop allowing ``knn`` as a boolean impute strategy :pr:`4058`
         * Capped ``nbsphinx`` at < 0.9.0 :pr:`4071`
-    * Documentation Changes
     * Testing Changes
         * Use ``release.yaml`` for performance tests on merge to main :pr:`4007`
         * Pin ``github-action-check-linked-issues`` at v1.4.5 :pr:`4042`
         * Updated tests to support Woodwork's object dtype inference for numeric columns :pr:`4066`
         * Updated ``TargetLeakageDataCheck`` tests to handle boolean targets properly :pr:`4066`
-
-.. warning::
-
-    **Breaking Changes**
 
 **v0.68.0 Feb. 15, 2023**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.68.0"
+__version__ = "0.69.0"


### PR DESCRIPTION
# v0.69.0 Mar. 15, 2023
### Enhancements
- Move black to regular dependency and use it for ``generate_pipeline_code`` #4005
- Implement ``generate_pipeline_example`` #4023
- Add new downcast utils for component-specific nullable type handling and begin implementation on objective and component base classes #4024
- Add nullable type incompatibility properties to the components that need them #4031
- Add ``get_evalml_requirements_file`` #4034
- Pipelines with DFS Transformers will run fast permutation importance if DFS features pre-exist #4037
- Add get_prediction_intervals() at the pipeline level #4052
### Fixes
- Fixed ``generate_pipeline_example`` erroring out for pipelines with a ``DFSTransformer`` #4059
- Remove nullable types handling for ``OverSampler`` #4064
### Changes
- Uncapped ``pmdarima`` and updated minimum version #4027
- Increase min catboost to 1.1.1 and xgboost to 1.7.0 to add nullable type support for those estimators #3996
- Unpinned ``networkx`` and updated minimum version #4035
- Increased ``scikit-learn`` version to 1.2.2 #4064
- Capped max ``holidays`` version to 0.21 #4064
- Stop allowing ``knn`` as a boolean impute strategy #4058
- Capped ``nbsphinx`` at < 0.9.0 #4071
### Testing Changes
- Use ``release.yaml`` for performance tests on merge to main #4007
- Pin ``github-action-check-linked-issues`` at v1.4.5 #4042
- Updated tests to support Woodwork's object dtype inference for numeric columns #4066
- Updated ``TargetLeakageDataCheck`` tests to handle boolean targets properly #4066
