### PR TITLE
Handle decomposer incompatibility

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
         * Remove unnecessary logic from imputer components prior to nullable type handling :pr:`4038`
         * Added calls to ``_handle_nullable_types`` in component fit, transform, and predict methods when needed :pr:`4046`
         * Remove existing nullable type handling across AutoMLSearch to just use new handling :pr:`4085`
+        * Handle nullable type incompatibility in ``Decomposer`` :pr:`4105`
     * Documentation Changes
     * Testing Changes
         * Updated graphviz installation in GitHub workflows to fix windows nightlies :pr:`4088`

--- a/evalml/pipelines/components/transformers/preprocessing/decomposer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/decomposer.py
@@ -34,6 +34,9 @@ class Decomposer(Transformer):
     modifies_target = True
     needs_fitting = True
     invalid_frequencies = []
+    # Incompatibility: https://github.com/alteryx/evalml/issues/4103
+    # TODO: Remove when support is added https://github.com/pandas-dev/pandas/issues/52127
+    _integer_nullable_incompatibilities = ["y"]
 
     def __init__(
         self,
@@ -148,6 +151,7 @@ class Decomposer(Transformer):
                 period is detected, returns None.
 
         """
+        X, y = cls._handle_nullable_types(cls, X, y)
 
         def _get_rel_max_from_acf(y):
             """Determines the relative maxima of the target's autocorrelation."""

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -519,9 +519,7 @@ def test_decomposer_determine_periodicity_nullable_type_incompatibility(
         trend_degree=trend_degree,
     )
 
-    # Multiply by 1000 so we can convert to Integer, truncating the rest of the value
-    # while still mainlining trend, period, etc
-    y = y * 1000
+    # Convert to Integer, truncating the rest of the value
     y = ww.init_series(y.astype(int), logical_type=nullable_ltype)
 
     if handle_incompatibility:
@@ -533,6 +531,9 @@ def test_decomposer_determine_periodicity_nullable_type_incompatibility(
 
     subtracted_floats = y - numpy_float_data
 
+    # Pandas will not recognize the np.NaN value in a Float64 subtracted_floats
+    # and will not drop that null value, so calling _handle_nullable_types ensures
+    # that we stay in float64 and properly drop the null value
     dropped_nans = subtracted_floats.dropna()
     assert len(dropped_nans) == len(y) - 1
 

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -526,16 +526,16 @@ def test_decomposer_determine_periodicity_nullable_type_incompatibility(
         dec = decomposer_child_class(degree=trend_degree, period=period)
         X, y = dec._handle_nullable_types(X, y)
 
-    numpy_float_data = pd.Series(range(len(y)), dtype="float64")
-    numpy_float_data.iloc[-1] = np.nan
-
-    subtracted_floats = y - numpy_float_data
+    # Introduce nans like we do in _detrend_on_fly by rolling y
+    moving_avg = 10
+    y_trend_estimate = y.rolling(moving_avg).mean().dropna()
+    subtracted_floats = y - y_trend_estimate
 
     # Pandas will not recognize the np.NaN value in a Float64 subtracted_floats
-    # and will not drop that null value, so calling _handle_nullable_types ensures
-    # that we stay in float64 and properly drop the null value
+    # and will not drop those null values, so calling _handle_nullable_types ensures
+    # that we stay in float64 and properly drop the null values
     dropped_nans = subtracted_floats.dropna()
-    assert len(dropped_nans) == len(y) - 1
+    assert len(dropped_nans) == len(y) - moving_avg + 1
 
 
 @pytest.mark.parametrize(

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -464,15 +464,10 @@ def test_decomposer_determine_periodicity(
     synthetic_data,
     generate_seasonal_data,
 ):
-    # --> failing for synthetic data when period is None and trend_degree is 1 - says the ac is 10??
     X, y = generate_seasonal_data(real_or_synthetic=synthetic_data)(
         period,
         trend_degree=trend_degree,
     )
-    if y_logical_type != "Double":
-        # Multiply by 1000 so we can convert to Integer, truncating the rest of the value
-        # while still mainlining trend, period, etc
-        y = y * 1000
     y = ww.init_series(y.astype(int), logical_type=y_logical_type)
 
     # Test that the seasonality can be determined if trend guess isn't spot on.

--- a/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
+++ b/evalml/tests/component_tests/decomposer_tests/test_decomposer.py
@@ -512,11 +512,10 @@ def test_decomposer_determine_periodicity_nullable_type_incompatibility(
     nullable_ltype,
     generate_seasonal_data,
 ):
-    # --> update
-    """Testing that the nullable type incompatibility that caused us to add handling for ARIMARegressor
-    is still present in sktime's AutoARIMA component. If this test is causing the test suite to fail
-    because the code below no longer raises the expected ValueError, we should confirm that the nullable
-    types now work for our use case and remove the nullable type handling logic from ARIMARegressor.
+    """Testing that the nullable type incompatibility that caused us to add handling for the Decomposer
+    is still present in pandas. If this test is causing the test suite to fail
+    because the code below no longer raises the expected AssertionError, we should confirm that the nullable
+    types now work for our use case and remove the nullable type handling logic from Decomposer.determine_periodicity.
     """
     trend_degree = 2
     period = 7


### PR DESCRIPTION
closes https://github.com/alteryx/evalml/issues/4103

This handles a small incompatibility in the Decomposer's `determine_periodicity` method where `float64` data containing nans when subtracted from `Int64` dtype data produces `Float64` dtype data with a `np.NaN` values that are not recognized by `dropna`, resulting in a periodicity of `None`. If we used `Float64` as a dtype in Woodwork, we'd also need to handle that here. `boolean` isn't an issue, because this is only used for regression problems.
