### PR TITLE
Add cap to seasonal period to include decomposition

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
     * Fixes
         * Fixed usage of codecov after uploader deprecation :pr:`4144`
     * Changes
+        * Capped size of seasonal period used for determining whether to include STLDecomposer in pipelines :pr:`4147`
     * Documentation Changes
     * Testing Changes
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -241,7 +241,7 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
                 y,
                 rel_max_order=order,
             )
-            if seasonal_period is not None:
+            if seasonal_period is not None and seasonal_period <= 1000:
                 components.append(STLDecomposer)
     return components
 

--- a/evalml/pipelines/utils.py
+++ b/evalml/pipelines/utils.py
@@ -72,6 +72,8 @@ from evalml.utils import get_time_index, infer_feature_types
 from evalml.utils.cli_utils import get_evalml_black_config
 from evalml.utils.gen_utils import contains_all_ts_parameters
 
+DECOMPOSER_PERIOD_CAP = 1000
+
 
 def _get_label_encoder(X, y, problem_type, estimator_class, sampler_name=None):
     component = []
@@ -241,7 +243,7 @@ def _get_decomposer(X, y, problem_type, estimator_class, sampler_name=None):
                 y,
                 rel_max_order=order,
             )
-            if seasonal_period is not None and seasonal_period <= 1000:
+            if seasonal_period is not None and seasonal_period <= DECOMPOSER_PERIOD_CAP:
                 components.append(STLDecomposer)
     return components
 

--- a/evalml/tests/pipeline_tests/test_pipeline_utils.py
+++ b/evalml/tests/pipeline_tests/test_pipeline_utils.py
@@ -218,6 +218,7 @@ def test_make_pipeline(
         ("YS", 6, True),
         ("Q", 4, True),
         ("Q", 2, False),
+        ("D", 1500, False),
         (None, None, False),
     ],
 )


### PR DESCRIPTION
Closes #4146 

Justification for this change can be found in the issue directly. I ran performance tests, there were no changes as all our test datasets have a period of <1000.