### PR TITLE
Release v0.75.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,11 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-        * Fixed bug where resetting the holdout data indices would cause time series ``predict_in_sample`` to be wrong :pr:`4161`
     * Changes
-        * Changed per-pipeline timings to store as a float :pr:`4160`
-        * Update Dask install commands in ``pyproject.toml`` :pr:`4164`
-        * Capped `IPython` version to < 8.12.1 for readthedocs and plotly compatibility :pr:`3987`
     * Documentation Changes
     * Testing Changes
 
@@ -15,6 +11,14 @@ Release Notes
 
     **Breaking Changes**
 
+
+**v0.75.0 May. 01, 2023**
+    * Fixes
+        * Fixed bug where resetting the holdout data indices would cause time series ``predict_in_sample`` to be wrong :pr:`4161`
+    * Changes
+        * Changed per-pipeline timings to store as a float :pr:`4160`
+        * Update Dask install commands in ``pyproject.toml`` :pr:`4164`
+        * Capped `IPython` version to < 8.12.1 for readthedocs and plotly compatibility :pr:`3987`
 
 **v0.74.0 Apr. 18, 2023**
     * Enhancements

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.74.0"
+__version__ = "0.75.0"


### PR DESCRIPTION
# v0.75.0 May. 1, 2023
### Fixes
- Fixed bug where resetting the holdout data indices would cause time series ``predict_in_sample`` to be wrong #4161
### Changes
- Changed per-pipeline timings to store as a float #4160
- Update Dask install commands in ``pyproject.toml`` #4164
- Capped `IPython` version to < 8.12.1 for readthedocs and plotly compatibility #3987
