### PR TITLE
Pin scikit-learn

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -28,7 +28,7 @@ outputs:
         - pandas >=1.5.0, <2.0.0
         - dask >=2022.2.0, !=2022.10.1
         - scipy >=1.5.0
-        - scikit-learn >=1.2.2
+        - scikit-learn >=1.2.2, <1.3.0
         - scikit-optimize >=0.9.0
         - statsmodels >=0.12.2
         - colorama >=0.4.4

--- a/core-requirements.txt
+++ b/core-requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.21.0
 pandas>=1.5.0, <2.0.0
 scipy>=1.5.0
-scikit-learn>=1.2.1
+scikit-learn>=1.2.1, <1.3.0
 scikit-optimize>=0.9.0
 pyzmq>=20.0.0
 colorama>=0.4.4

--- a/evalml/pipelines/components/estimators/classifiers/decision_tree_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/decision_tree_classifier.py
@@ -14,17 +14,15 @@ class DecisionTreeClassifier(Estimator):
         criterion ({"gini", "entropy"}): The function to measure the quality of a split.
             Supported criteria are "gini" for the Gini impurity and "entropy" for the information gain.
             Defaults to "gini".
-        max_features (int, float or {"auto", "sqrt", "log2"}): The number of features to consider when looking for the best split:
+        max_features (int, float or {"sqrt", "log2"}): The number of features to consider when looking for the best split:
 
             - If int, then consider max_features features at each split.
             - If float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.
-            - If "auto", then max_features=sqrt(n_features).
             - If "sqrt", then max_features=sqrt(n_features).
             - If "log2", then max_features=log2(n_features).
             - If None, then max_features = n_features.
 
             The search for a split does not stop until at least one valid partition of the node samples is found, even if it requires to effectively inspect more than max_features features.
-            Defaults to "auto".
         max_depth (int): The maximum depth of the tree. Defaults to 6.
         min_samples_split (int or float): The minimum number of samples required to split an internal node:
 
@@ -40,12 +38,12 @@ class DecisionTreeClassifier(Estimator):
     name = "Decision Tree Classifier"
     hyperparameter_ranges = {
         "criterion": ["gini", "entropy"],
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }
     """{
         "criterion": ["gini", "entropy"],
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }"""
     model_family = ModelFamily.DECISION_TREE
@@ -66,7 +64,7 @@ class DecisionTreeClassifier(Estimator):
     def __init__(
         self,
         criterion="gini",
-        max_features="auto",
+        max_features="sqrt",
         max_depth=6,
         min_samples_split=2,
         min_weight_fraction_leaf=0.0,

--- a/evalml/pipelines/components/estimators/classifiers/et_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/et_classifier.py
@@ -12,17 +12,15 @@ class ExtraTreesClassifier(Estimator):
 
     Args:
         n_estimators (float): The number of trees in the forest. Defaults to 100.
-        max_features (int, float or {"auto", "sqrt", "log2"}): The number of features to consider when looking for the best split:
+        max_features (int, float or {"sqrt", "log2"}): The number of features to consider when looking for the best split:
 
             - If int, then consider max_features features at each split.
             - If float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.
-            - If "auto", then max_features=sqrt(n_features).
             - If "sqrt", then max_features=sqrt(n_features).
             - If "log2", then max_features=log2(n_features).
             - If None, then max_features = n_features.
 
             The search for a split does not stop until at least one valid partition of the node samples is found, even if it requires to effectively inspect more than max_features features.
-            Defaults to "auto".
         max_depth (int): The maximum depth of the tree. Defaults to 6.
         min_samples_split (int or float): The minimum number of samples required to split an internal node:
 
@@ -39,12 +37,12 @@ class ExtraTreesClassifier(Estimator):
     name = "Extra Trees Classifier"
     hyperparameter_ranges = {
         "n_estimators": Integer(10, 1000),
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }
     """{
         "n_estimators": Integer(10, 1000),
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }
     """
@@ -66,7 +64,7 @@ class ExtraTreesClassifier(Estimator):
     def __init__(
         self,
         n_estimators=100,
-        max_features="auto",
+        max_features="sqrt",
         max_depth=6,
         min_samples_split=2,
         min_weight_fraction_leaf=0.0,

--- a/evalml/pipelines/components/estimators/regressors/decision_tree_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/decision_tree_regressor.py
@@ -18,11 +18,10 @@ class DecisionTreeRegressor(Estimator):
                 - "friedman_mse", which uses mean squared error with Friedman"s improvement score for potential splits
                 - "absolute_error" for the mean absolute error, which minimizes the L1 loss using the median of each terminal node,
                 - "poisson" which uses reduction in Poisson deviance to find splits.
-        max_features (int, float or {"auto", "sqrt", "log2"}): The number of features to consider when looking for the best split:
+        max_features (int, float or {"sqrt", "log2"}): The number of features to consider when looking for the best split:
 
             - If int, then consider max_features features at each split.
             - If float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.
-            - If "auto", then max_features=sqrt(n_features).
             - If "sqrt", then max_features=sqrt(n_features).
             - If "log2", then max_features=log2(n_features).
             - If None, then max_features = n_features.
@@ -43,12 +42,12 @@ class DecisionTreeRegressor(Estimator):
     name = "Decision Tree Regressor"
     hyperparameter_ranges = {
         "criterion": ["squared_error", "friedman_mse", "absolute_error"],
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }
     """{
         "criterion": ["squared_error", "friedman_mse", "absolute_error"],
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }"""
     model_family = ModelFamily.DECISION_TREE
@@ -65,7 +64,7 @@ class DecisionTreeRegressor(Estimator):
     def __init__(
         self,
         criterion="squared_error",
-        max_features="auto",
+        max_features="sqrt",
         max_depth=6,
         min_samples_split=2,
         min_weight_fraction_leaf=0.0,

--- a/evalml/pipelines/components/estimators/regressors/et_regressor.py
+++ b/evalml/pipelines/components/estimators/regressors/et_regressor.py
@@ -18,17 +18,15 @@ class ExtraTreesRegressor(Estimator):
 
     Args:
         n_estimators (float): The number of trees in the forest. Defaults to 100.
-        max_features (int, float or {"auto", "sqrt", "log2"}): The number of features to consider when looking for the best split:
+        max_features (int, float or {"sqrt", "log2"}): The number of features to consider when looking for the best split:
 
             - If int, then consider max_features features at each split.
             - If float, then max_features is a fraction and int(max_features * n_features) features are considered at each split.
-            - If "auto", then max_features=sqrt(n_features).
             - If "sqrt", then max_features=sqrt(n_features).
             - If "log2", then max_features=log2(n_features).
             - If None, then max_features = n_features.
 
             The search for a split does not stop until at least one valid partition of the node samples is found, even if it requires to effectively inspect more than max_features features.
-            Defaults to "auto".
         max_depth (int): The maximum depth of the tree. Defaults to 6.
         min_samples_split (int or float): The minimum number of samples required to split an internal node:
 
@@ -45,12 +43,12 @@ class ExtraTreesRegressor(Estimator):
     name = "Extra Trees Regressor"
     hyperparameter_ranges = {
         "n_estimators": Integer(10, 1000),
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }
     """{
         "n_estimators": Integer(10, 1000),
-        "max_features": ["auto", "sqrt", "log2"],
+        "max_features": ["sqrt", "log2"],
         "max_depth": Integer(4, 10),
     }"""
     model_family = ModelFamily.EXTRA_TREES
@@ -67,7 +65,7 @@ class ExtraTreesRegressor(Estimator):
     def __init__(
         self,
         n_estimators: int = 100,
-        max_features: str = "auto",
+        max_features: str = "sqrt",
         max_depth: int = 6,
         min_samples_split: int = 2,
         min_weight_fraction_leaf: float = 0.0,

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -29,7 +29,7 @@ scikit-optimize==0.9.0
 scipy==1.10.1
 seaborn==0.12.2
 shap==0.42.1
-sktime==0.20.1
+sktime==0.21.0
 statsmodels==0.14.0
 texttable==1.6.7
 tomli==2.0.1


### PR DESCRIPTION
Closes #4247 

The newest version of scikit-learn is incomatible with the version of imbalanced-learn that we're pinned to. Unfortunately, imbalanced-learn must remain pinned due to lack of nullable type handling, so we can't upgrade scikit-learn. Once imbalanced-learn fixes their nullable type issues, we should be able to unpin both.