### PR TITLE
Release v0.79.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.79.0 Aug. 11, 2023**
+    * Enhancements
         * Updated regression metrics to handle multioutput dataframes as well as single output series :pr:`4233`
         * Added baseline regressor for multiseries time series problems :pr:`4246`
         * Added stacking and unstacking utility functions to work with multiseries data :pr:`4250`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.78.0"
+__version__ = "0.79.0"


### PR DESCRIPTION
* Enhancements
    * Updated regression metrics to handle multioutput dataframes as well as single output series :pr:`4233`
    * Added baseline regressor for multiseries time series problems :pr:`4246`
    * Added stacking and unstacking utility functions to work with multiseries data :pr:`4250`
    * Added multiseries regression pipeline class :pr:`4256`
    * Added multiseries VARMAX regressor :pr:`4238`
* Fixes
    * Added support for pandas 2 :pr:`4216`
    * Fixed bug where time series pipelines would fail due to MASE needing `y_train` when scoring :pr:`4258`
    * Update s3 bucket for docs image :pr:`4260`
    * Fix deps checker including any package with post in the name :pr:`4268`
* Changes
    * Unpinned sktime version :pr:`4214`
    * Bumped minimum lightgbm version to 4.0.0 for nullable type handling :pr:`4237`
    * Pinned scikit-learn version due to incompatibility with pinned imbalanced-learn :pr:`4248`
* Documentation Changes
* Testing Changes