### PR TITLE
Fix deps checker including any package with `post` in the name

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -11,6 +11,7 @@ Release Notes
         * Added support for pandas 2 :pr:`4216`
         * Fixed bug where time series pipelines would fail due to MASE needing `y_train` when scoring :pr:`4258`
         * Update s3 bucket for docs image :pr:`4260`
+        * Fix deps checker including any package with post in the name :pr:`4268`
     * Changes
         * Unpinned sktime version :pr:`4214`
         * Bumped minimum lightgbm version to 4.0.0 for nullable type handling :pr:`4237`

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,6 +1,6 @@
 black==23.7.0
 catboost==1.2
-category-encoders==2.6.1
+category-encoders==2.5.1.post0
 click==8.1.6
 cloudpickle==2.2.1
 colorama==0.4.6

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,5 +1,6 @@
 black==23.7.0
 catboost==1.2
+category-encoders==2.6.1
 click==8.1.6
 cloudpickle==2.2.1
 colorama==0.4.6

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,6 +1,5 @@
 black==23.7.0
 catboost==1.2
-category-encoders==2.5.1.post0
 click==8.1.6
 cloudpickle==2.2.1
 colorama==0.4.6
@@ -23,7 +22,7 @@ packaging==23.1
 pandas==2.0.3
 plotly==5.15.0
 pmdarima==2.0.3
-pyzmq==25.1.0
+pyzmq==25.1.1
 scikit-learn==1.3.0
 scikit-optimize==0.9.0
 scipy==1.10.1

--- a/evalml/tests/dependency_update_check/make_deps_diff.sh
+++ b/evalml/tests/dependency_update_check/make_deps_diff.sh
@@ -1,4 +1,4 @@
 reqs_list=$(python -c "import os; from evalml.utils import get_evalml_pip_requirements; print('\n'.join(get_evalml_pip_requirements(os.getcwd())))")
-allow_list=$(echo ${reqs_list} | grep -oE "[a-zA-Z]+[a-zA-Z_\-]*" | paste -d "|" -s -)
+allow_list=$(echo ${reqs_list} | grep -oE "[a-zA-Z]+[a-zA-Z_\-]*" | grep -v "post" | paste -d "|" -s -)
 echo "Allow list: ${allow_list}"
 pip freeze | grep -v "evalml.git" | grep -E "${allow_list}" > "${DEPENDENCY_FILE_PATH}"

--- a/evalml/tests/dependency_update_check/make_deps_diff.sh
+++ b/evalml/tests/dependency_update_check/make_deps_diff.sh
@@ -1,4 +1,4 @@
 reqs_list=$(python -c "import os; from evalml.utils import get_evalml_pip_requirements; print('\n'.join(get_evalml_pip_requirements(os.getcwd())))")
-allow_list=$(echo ${reqs_list} | grep -oE "[a-zA-Z]+[a-zA-Z_\-]*" | grep -v "post" | paste -d "|" -s -)
+allow_list=$(echo ${reqs_list} | grep -oE "[a-zA-Z]+[a-zA-Z_\-]*" | grep -v "post" | tr "_" "-" | paste -d "|" -s -)
 echo "Allow list: ${allow_list}"
 pip freeze | grep -v "evalml.git" | grep -E "${allow_list}" > "${DEPENDENCY_FILE_PATH}"


### PR DESCRIPTION
Fixes issue with our automated dependency checker where we are including any package with `post` in the name/version number.

Resolves #4269 