### PR TITLE
MismatchedSeriesLength Datacheck

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,7 +19,6 @@ Release Notes
     * Enhancements
         * Added support for prediction intervals for VARMAX regressor :pr:`4267`
         * Integrated multiseries time series into AutoMLSearch :pr:`4270`
-        * Extended TimeSeriesImputer to handle multiple series :pr:`4291`
     * Fixes
         * Fixed error when stacking data with no exogenous variables :pr:`4275`
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
     * Enhancements
         * Added support for prediction intervals for VARMAX regressor :pr:`4267`
         * Integrated multiseries time series into AutoMLSearch :pr:`4270`
-        * Added new datacheck to check for mismatched series length in multiseries :pr:`4296`
+        * Added datacheck to check for mismatched series length in multiseries :pr:`4296`
     * Fixes
         * Fixed error when stacking data with no exogenous variables :pr:`4275`
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes
     * Enhancements
         * Added support for prediction intervals for VARMAX regressor :pr:`4267`
         * Integrated multiseries time series into AutoMLSearch :pr:`4270`
+        * Added new datacheck to check for mismatched series length in multiseries :pr:`4296`
     * Fixes
         * Fixed error when stacking data with no exogenous variables :pr:`4275`
     * Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,8 @@ Release Notes
 **Future Releases**
     * Enhancements
         * Extended STLDecomposer to Support Multiseries :pr:`4253`
+        * Extended TimeSeriesImputer to handle multiseries :pr:`4291`
+        * Added datacheck to check for mismatched series length in multiseries :pr:`4296`
     * Fixes
     * Changes
     * Documentation Changes
@@ -17,7 +19,6 @@ Release Notes
     * Enhancements
         * Added support for prediction intervals for VARMAX regressor :pr:`4267`
         * Integrated multiseries time series into AutoMLSearch :pr:`4270`
-        * Added datacheck to check for mismatched series length in multiseries :pr:`4296`
     * Fixes
         * Fixed error when stacking data with no exogenous variables :pr:`4275`
     * Changes

--- a/evalml/data_checks/__init__.py
+++ b/evalml/data_checks/__init__.py
@@ -32,3 +32,6 @@ from evalml.data_checks.target_distribution_data_check import (
 from evalml.data_checks.datetime_format_data_check import DateTimeFormatDataCheck
 from evalml.data_checks.ts_parameters_data_check import TimeSeriesParametersDataCheck
 from evalml.data_checks.ts_splitting_data_check import TimeSeriesSplittingDataCheck
+from evalml.data_checks.mismatched_series_length_data_check import (
+    MismatchedSeriesLengthDataCheck,
+)

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -145,3 +145,8 @@ class DataCheckMessageCode(Enum):
 
     MISMATCHED_SERIES_LENGTH = "mismatched_series_length"
     """Message code for when one or more unique series in a multiseries dataset is of a different length than the others"""
+
+    MULTISERIES_TIMESERIES_SERIES_ID_NOT_IN_COL = (
+        "multiseries_timeseries_series_id_not_in_col"
+    )
+    """Message code for when given series_id is not in the dataset"""

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -146,7 +146,5 @@ class DataCheckMessageCode(Enum):
     MISMATCHED_SERIES_LENGTH = "mismatched_series_length"
     """Message code for when one or more unique series in a multiseries dataset is of a different length than the others"""
 
-    MULTISERIES_TIMESERIES_SERIES_ID_NOT_IN_COL = (
-        "multiseries_timeseries_series_id_not_in_col"
-    )
-    """Message code for when given series_id is not in the dataset"""
+    INVALID_SERIES_ID_COL = "INVALID_SERIES_ID_COL"
+    """Message code for when given series_id is invalid"""

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -142,3 +142,6 @@ class DataCheckMessageCode(Enum):
         "timeseries_target_not_compatible_with_split"
     )
     """Message code when any training and validation split of the time series target doesn't contain all classes."""
+
+    MISMATCHED_SERIES_LENGTH = "mismatched_series_length"
+    """Message code for when one or more unique series in a multiseries dataset is of a different length than the others"""

--- a/evalml/data_checks/data_check_message_code.py
+++ b/evalml/data_checks/data_check_message_code.py
@@ -146,5 +146,5 @@ class DataCheckMessageCode(Enum):
     MISMATCHED_SERIES_LENGTH = "mismatched_series_length"
     """Message code for when one or more unique series in a multiseries dataset is of a different length than the others"""
 
-    INVALID_SERIES_ID_COL = "INVALID_SERIES_ID_COL"
+    INVALID_SERIES_ID_COL = "invalid_series_id_col"
     """Message code for when given series_id is invalid"""

--- a/evalml/data_checks/mismatched_series_length_data_check.py
+++ b/evalml/data_checks/mismatched_series_length_data_check.py
@@ -1,0 +1,112 @@
+"""Data check that checks if one or more unique series in a multiseres data is a different length than the others."""
+
+from evalml.data_checks import (
+    DataCheck,
+    DataCheckMessageCode,
+    DataCheckWarning,
+)
+
+
+class MismatchedSeriesLengthDataCheck(DataCheck):
+    """Check if one or more unique series in a multiseries dataset is of a different length than the others.
+
+    Args:
+        series_id (str): The name of the series_id column for the dataset.
+    """
+
+    def __init__(self, series_id):
+        if series_id is None:
+            raise ValueError(
+                "series_id must be set to the series_id column in the dataset and not None",
+            )
+        self.series_id = series_id
+
+    def validate(self, X, y=None):
+        """Check if one or more unique series in a multiseries dataset is of a different length than the other.
+
+        Currently works specifically on stacked data
+
+        Args:
+            X (pd.DataFrame, np.ndarray): The input features to check.
+            y (pd.Series): The target. Defaults to None. Ignored.
+
+        Returns:
+            dict: A dictionary of features with column name or index and their probability of being ID columns
+
+        Examples:
+            >>> import pandas as pd
+
+            For multiseries time series datasets, each seriesID should ideally have the same number of datetime entries as
+            each other. If they don't, then a warning will be raised denoting which seriesID have mismatched lengths
+
+            >>> X = pd.DataFrame(
+            ...     {
+            ...         "date": pd.date_range(start="1/1/2018", periods=20).repeat(5),
+            ...         "series_id": pd.Series(list(range(5)) * 20, dtype="str"),
+            ...         "feature_a": range(100),
+            ...         "feature_b": reversed(range(100)),
+            ...     },
+            ... )
+            >>> X = X.drop(labels=0, axis=0)
+            >>> mismatched_series_length_check = MismatchedSeriesLengthDataCheck("series_id")
+            >>> assert mismatched_series_length_check.validate(X) == [
+            ...     DataCheckWarning(
+            ...         message = "Series ID ['0'] do not match the majority length of the other series, which is 20",
+            ...         data_check_name = "MismatchedSeriesLengthDataCheck",
+            ...         message_code = "MISMATCHED_SERIES_LENGTH",
+            ...         details = {"series_id": ['0'], "majority_length": 20},
+            ...         action_options = []
+            ...     ).to_dict(),
+            ... ]
+        """
+        messages = []
+        if self.series_id not in X:
+            raise ValueError(
+                f"""series_id "{self.series_id}" doesn't match the series_id column of the dataset.""",
+            )
+
+        # gets all the number of entries per series_id
+        series_id_len = {}
+        for id in X[self.series_id].unique():
+            series_id_len[id] = len(X[X[self.series_id] == id])
+
+        # get the majority length
+        tracker = {}
+        for _, v in series_id_len.items():
+            if v not in tracker:
+                tracker[v] = 0
+            else:
+                tracker[v] += 1
+        majority_len = max(tracker, key=tracker.get)
+
+        # get the series_id's that aren't the majority length
+        not_majority = []
+        for id in series_id_len:
+            if series_id_len[id] != majority_len:
+                not_majority.append(id)
+
+        if len(not_majority) > 0 and len(not_majority) < len(series_id_len) - 1:
+            warning_msg = f"Series ID {not_majority} do not match the majority length of the other series, which is {majority_len}"
+            messages.append(
+                DataCheckWarning(
+                    message=warning_msg,
+                    data_check_name=self.name,
+                    message_code=DataCheckMessageCode.MISMATCHED_SERIES_LENGTH,
+                    details={
+                        "series_id": not_majority,
+                        "majority_length": majority_len,
+                    },
+                    action_options=[],
+                ).to_dict(),
+            )
+        elif len(not_majority) == len(series_id_len) - 1:
+            warning_msg = "All series ID have different lengths than each other"
+            messages.append(
+                DataCheckWarning(
+                    message=warning_msg,
+                    data_check_name=self.name,
+                    message_code=DataCheckMessageCode.MISMATCHED_SERIES_LENGTH,
+                    action_options=[],
+                ).to_dict(),
+            )
+        return messages

--- a/evalml/data_checks/mismatched_series_length_data_check.py
+++ b/evalml/data_checks/mismatched_series_length_data_check.py
@@ -49,14 +49,20 @@ class MismatchedSeriesLengthDataCheck(DataCheck):
             ... )
             >>> X = X.drop(labels=0, axis=0)
             >>> mismatched_series_length_check = MismatchedSeriesLengthDataCheck("series_id")
-            >>> assert mismatched_series_length_check.validate(X) == [
-            ...     DataCheckWarning(
-            ...         message = "Series ID ['0'] do not match the majority length of the other series, which is 20",
-            ...         data_check_name = "MismatchedSeriesLengthDataCheck",
-            ...         message_code = "MISMATCHED_SERIES_LENGTH",
-            ...         details = {"series_id": ['0'], "majority_length": 20},
-            ...         action_options = []
-            ...     ).to_dict(),
+            >>> xd = [
+            ...      {
+            ...         "message": "Series ID ['0'] do not match the majority length of the other series, which is 20",
+            ...         "data_check_name": "MismatchedSeriesLengthDataCheck",
+            ...         "level": "warning",
+            ...         "details": {
+            ...             "columns": None,
+            ...             "rows": None,
+            ...             "series_id": ['0'],
+            ...             "majority_length": 20
+            ...         },
+            ...         "message_code": "MISMATCHED_SERIES_LENGTH",
+            ...         "action_options": [],
+            ...     }
             ... ]
         """
         messages = []

--- a/evalml/data_checks/mismatched_series_length_data_check.py
+++ b/evalml/data_checks/mismatched_series_length_data_check.py
@@ -28,11 +28,11 @@ class MismatchedSeriesLengthDataCheck(DataCheck):
         Currently works specifically on stacked data
 
         Args:
-            X (pd.DataFrame, np.ndarray): The input features to check.
+            X (pd.DataFrame, np.ndarray): The input features to check. Must have a series_id column.
             y (pd.Series): The target. Defaults to None. Ignored.
 
         Returns:
-            dict: A dictionary of features with column name or index and their probability of being ID columns
+            dict: Dictionary with DataCheckWarning if there are mismatch series length in the datasets
 
         Examples:
             >>> import pandas as pd

--- a/evalml/data_checks/mismatched_series_length_data_check.py
+++ b/evalml/data_checks/mismatched_series_length_data_check.py
@@ -1,5 +1,6 @@
 """Data check that checks if one or more unique series in a multiseres data is a different length than the others."""
 
+
 from evalml.data_checks import (
     DataCheck,
     DataCheckMessageCode,
@@ -49,7 +50,7 @@ class MismatchedSeriesLengthDataCheck(DataCheck):
             ... )
             >>> X = X.drop(labels=0, axis=0)
             >>> mismatched_series_length_check = MismatchedSeriesLengthDataCheck("series_id")
-            >>> xd = [
+            >>> assert mismatched_series_length_check.validate(X) == [
             ...      {
             ...         "message": "Series ID ['0'] do not match the majority length of the other series, which is 20",
             ...         "data_check_name": "MismatchedSeriesLengthDataCheck",
@@ -60,7 +61,7 @@ class MismatchedSeriesLengthDataCheck(DataCheck):
             ...             "series_id": ['0'],
             ...             "majority_length": 20
             ...         },
-            ...         "message_code": "MISMATCHED_SERIES_LENGTH",
+            ...         "code": "MISMATCHED_SERIES_LENGTH",
             ...         "action_options": [],
             ...     }
             ... ]

--- a/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
+++ b/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
@@ -1,6 +1,7 @@
 import pytest
 
 from evalml.data_checks import (
+    DataCheckError,
     DataCheckMessageCode,
     DataCheckWarning,
     MismatchedSeriesLengthDataCheck,
@@ -18,13 +19,23 @@ def test_mismatched_series_length_data_check_raises_value_error(
     ):
         MismatchedSeriesLengthDataCheck(None)
 
+
+def test_mistmatched_series_length_data_check_data_check_error(
+    multiseries_ts_data_stacked,
+):
     X, _ = multiseries_ts_data_stacked
     dc = MismatchedSeriesLengthDataCheck("not_series_id")
-    with pytest.raises(
-        ValueError,
-        match="""series_id "not_series_id" doesn't match the series_id column of the dataset.""",
-    ):
-        dc.validate(X)
+    messages = dc.validate(X)
+    assert len(messages) == 1
+    assert messages == [
+        DataCheckError(
+            message="""series_id 'not_series_id' does not match the series_id column of the dataset.""",
+            data_check_name=mismatch_series_length_dc_name,
+            message_code=DataCheckMessageCode.MULTISERIES_TIMESERIES_SERIES_ID_NOT_IN_COL,
+            details={"series_id": "not_series_id"},
+            action_options=[],
+        ).to_dict(),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
+++ b/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
@@ -1,0 +1,71 @@
+import pytest
+
+from evalml.data_checks import (
+    DataCheckMessageCode,
+    DataCheckWarning,
+    MismatchedSeriesLengthDataCheck,
+)
+
+mismatch_series_length_dc_name = MismatchedSeriesLengthDataCheck.name
+
+
+def test_mismatched_series_length_data_check_raises_value_error(
+    multiseries_ts_data_stacked,
+):
+    with pytest.raises(
+        ValueError,
+        match="series_id must be set to the series_id column in the dataset and not None",
+    ):
+        MismatchedSeriesLengthDataCheck(None)
+
+    X, _ = multiseries_ts_data_stacked
+    dc = MismatchedSeriesLengthDataCheck("not_series_id")
+    with pytest.raises(
+        ValueError,
+        match="""series_id "not_series_id" doesn't match the series_id column of the dataset.""",
+    ):
+        dc.validate(X)
+
+
+@pytest.mark.parametrize(
+    "num_drop, not_majority, majority_length",
+    [(1, ["0"], 20), (2, ["0", "1"], 20), (3, ["3", "4"], 19)],
+)
+def test_mismatched_series_length_data_check(
+    multiseries_ts_data_stacked,
+    num_drop,
+    not_majority,
+    majority_length,
+):
+    X, _ = multiseries_ts_data_stacked
+    for i in range(num_drop):
+        X = X.drop(labels=0, axis=0).reset_index(drop=True)
+    mismatch_series_length_dc = MismatchedSeriesLengthDataCheck("series_id")
+    messages = mismatch_series_length_dc.validate(X)
+    assert len(messages) == 1
+    assert messages == [
+        DataCheckWarning(
+            message=f"Series ID {not_majority} do not match the majority length of the other series, which is {majority_length}",
+            data_check_name=mismatch_series_length_dc_name,
+            message_code=DataCheckMessageCode.MISMATCHED_SERIES_LENGTH,
+            details={"series_id": not_majority, "majority_length": majority_length},
+            action_options=[],
+        ).to_dict(),
+    ]
+
+
+def test_mismatched_series_length_data_check_all(multiseries_ts_data_stacked):
+    rows_index = [0, 1, 2, 3, 5, 6, 7, 10, 11, 15]
+    X, _ = multiseries_ts_data_stacked
+    X = X.drop(rows_index).reset_index(drop=True)
+    mismatch_series_length_dc = MismatchedSeriesLengthDataCheck("series_id")
+    messages = mismatch_series_length_dc.validate(X)
+    assert len(messages) == 1
+    assert messages == [
+        DataCheckWarning(
+            message="All series ID have different lengths than each other",
+            data_check_name=mismatch_series_length_dc_name,
+            message_code=DataCheckMessageCode.MISMATCHED_SERIES_LENGTH,
+            action_options=[],
+        ).to_dict(),
+    ]

--- a/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
+++ b/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
@@ -80,3 +80,11 @@ def test_mismatched_series_length_data_check_all(multiseries_ts_data_stacked):
             action_options=[],
         ).to_dict(),
     ]
+
+
+def test_mismatched_series_length_data_check_no_mismatch(multiseries_ts_data_stacked):
+    X, _ = multiseries_ts_data_stacked
+    mismatch_series_length_dc = MismatchedSeriesLengthDataCheck("series_id")
+    messages = mismatch_series_length_dc.validate(X)
+    assert len(messages) == 0
+    assert messages == []

--- a/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
+++ b/evalml/tests/data_checks_tests/test_mismatched_series_length_data_check.py
@@ -29,9 +29,9 @@ def test_mistmatched_series_length_data_check_data_check_error(
     assert len(messages) == 1
     assert messages == [
         DataCheckError(
-            message="""series_id 'not_series_id' does not match the series_id column of the dataset.""",
+            message="""series_id 'not_series_id' is not in the dataset.""",
             data_check_name=mismatch_series_length_dc_name,
-            message_code=DataCheckMessageCode.MULTISERIES_TIMESERIES_SERIES_ID_NOT_IN_COL,
+            message_code=DataCheckMessageCode.INVALID_SERIES_ID_COL,
             details={"series_id": "not_series_id"},
             action_options=[],
         ).to_dict(),


### PR DESCRIPTION
### Pull Request Description

Closes #4297 
Adds mismatched series length datacheck

### Visual of what this PR does
Say there was a multiseries dataset with 5 unique series_id that each show up 20 times (so there are 100 entries in the dataset).
<img width="343" alt="image" src="https://github.com/alteryx/evalml/assets/56745347/91055fb7-b14d-4e1f-8411-e37ee635e90f">

Let's say the first row was dropped, meaning that series_id "0" only has 19 entries while the rest of the series_id have 20 entries.
<img width="341" alt="image" src="https://github.com/alteryx/evalml/assets/56745347/0a6db33e-8861-498d-b657-7bca46fdfa6c">

Using the mismatched series length datacheck, the validate function will return:
<img width="840" alt="image" src="https://github.com/alteryx/evalml/assets/56745347/c2878966-c772-4b73-b79e-84f9f2856ec3">




*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
