### PR TITLE
Extended time series regularizer to support multiseries

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
         * Extended TimeSeriesImputer to handle multiseries :pr:`4291`
         * Added datacheck to check for mismatched series length in multiseries :pr:`4296`
         * Added STLDecomposer to multiseries pipelines :pr:`4299`
+        * Extended TimeSeriesRegularizer to support multiseries :pr:`4303`
     * Fixes
     * Changes
     * Documentation Changes

--- a/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
@@ -24,6 +24,8 @@ class TimeSeriesRegularizer(Transformer):
     This Transformer should be used before the `TimeSeriesImputer` in order to impute the missing values that were
     added to X and y (if passed).
 
+    If used on multiseries dataset, works specifically on unstacked datasets.
+
     Args:
         time_index (string): Name of the column containing the datetime information used to order the data, required. Defaults to None.
         frequency_payload (tuple): Payload returned from Woodwork's infer_frequency function where debug is True. Defaults to None.

--- a/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
@@ -312,7 +312,7 @@ class TimeSeriesRegularizer(Transformer):
             cleaned_x.loc[
                 cleaned_x[self.time_index] == values["correct"]
             ] = to_replace.values
-            if y is not None:
+            if y is not None and isinstance(y, pd.Series):
                 cleaned_y.loc[cleaned_y[self.time_index] == values["correct"]] = y.iloc[
                     index
                 ]
@@ -323,5 +323,4 @@ class TimeSeriesRegularizer(Transformer):
             cleaned_y.ww.init()
 
         cleaned_x.ww.init()
-
         return cleaned_x, cleaned_y

--- a/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
+++ b/evalml/pipelines/components/transformers/preprocessing/time_series_regularizer.py
@@ -320,6 +320,10 @@ class TimeSeriesRegularizer(Transformer):
         if cleaned_y is not None:
             if isinstance(y, pd.Series):
                 cleaned_y = cleaned_y["target"]
+            elif isinstance(y, pd.DataFrame):
+                # remove date time column from unstacked y
+                cleaned_y = cleaned_y.drop(columns=self.time_index, axis=1)
+
             cleaned_y.ww.init()
 
         cleaned_x.ww.init()

--- a/evalml/tests/component_tests/test_time_series_regularizer.py
+++ b/evalml/tests/component_tests/test_time_series_regularizer.py
@@ -10,7 +10,7 @@ def get_df(dates):
     reg_X = pd.DataFrame()
 
     reg_X["dates"] = dates
-    reg_X["ints"] = [int(i) for i in range(len(dates))]
+    reg_X["ints"] = list(range(len(dates)))
     reg_X["doubles"] = [i / 0.25 ** (i / 100) for i in range(len(dates))]
     reg_X["bools"] = [bool(min(1, i % 3)) for i in range(len(dates))]
     reg_X["cats"] = np.random.choice(
@@ -27,14 +27,14 @@ def get_unstacked_df(dates):
     reg_X = pd.DataFrame()
 
     reg_X["dates"] = dates
-    reg_X["feature_a_0"] = [int(i) for i in range(len(dates))]
-    reg_X["feature_a_1"] = [int(i) for i in range(len(dates), 0, -1)]
-    reg_X["feature_b_0"] = [int(i) for i in range(len(dates) * 2, 0, -2)]
-    reg_X["feature_b_1"] = [int(i) for i in range(0, len(dates) * 2, 2)]
+    reg_X["feature_a_0"] = list(range(len(dates)))
+    reg_X["feature_a_1"] = list(range(len(dates), 0, -1))
+    reg_X["feature_b_0"] = list(range(len(dates) * 2, 0, -2))
+    reg_X["feature_b_1"] = list(range(0, len(dates) * 2, 2))
 
     reg_y = pd.DataFrame()
-    reg_y["target_0"] = [int(i) for i in range(len(dates))]
-    reg_y["target_1"] = [int(i) for i in range(len(dates), 0, -1)]
+    reg_y["target_0"] = list(range(len(dates)))
+    reg_y["target_1"] = list(range(len(dates), 0, -1))
     return reg_X, reg_y
 
 
@@ -87,7 +87,7 @@ def assert_features_and_length_equal(
         )
 
 
-def check(is_multiseries, X, y, X_output, y_output, error_dict):
+def check_x_and_y_output(is_multiseries, X, y, X_output, y_output, error_dict):
     if is_multiseries:
         # put date column into the y dataframes for testing purposes
         y["dates"] = X["dates"]
@@ -322,7 +322,7 @@ def test_ts_regularizer_duplicate(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
 
     error_dict = ts_regularizer.error_dict
-    check(is_multiseries, X, y, X_output, y_output, error_dict)
+    check_x_and_y_output(is_multiseries, X, y, X_output, y_output, error_dict)
 
 
 @pytest.mark.parametrize("is_multiseries", [True, False])
@@ -359,7 +359,7 @@ def test_ts_regularizer_missing(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
 
     error_dict = ts_regularizer.error_dict
-    check(is_multiseries, X, y, X_output, y_output, error_dict)
+    check_x_and_y_output(is_multiseries, X, y, X_output, y_output, error_dict)
 
 
 @pytest.mark.parametrize("is_multiseries", [True, False])
@@ -398,7 +398,7 @@ def test_ts_regularizer_uneven(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
     error_dict = ts_regularizer.error_dict
 
-    check(is_multiseries, X, y, X_output, y_output, error_dict)
+    check_x_and_y_output(is_multiseries, X, y, X_output, y_output, error_dict)
     if not is_multiseries:
         if uneven_type == "beginning":
             assert X.iloc[0]["dates"] not in X_output["dates"]

--- a/evalml/tests/component_tests/test_time_series_regularizer.py
+++ b/evalml/tests/component_tests/test_time_series_regularizer.py
@@ -87,6 +87,36 @@ def assert_features_and_length_equal(
         )
 
 
+def check(is_multiseries, X, y, X_output, y_output, error_dict):
+    if is_multiseries:
+        # put date column into the y dataframes for testing purposes
+        y["dates"] = X["dates"]
+        y_output["dates"] = X_output["dates"]
+
+        assert_features_and_length_equal(
+            X,
+            y,
+            X_output,
+            y_output,
+            error_dict,
+            has_target=False,
+            check_dtype=False,
+        )
+
+        # the function only really checks what's passed into "X" so passed in "y" as X in order to have it check y
+        assert_features_and_length_equal(
+            y,
+            X,
+            y_output,
+            X_output,
+            error_dict,
+            has_target=False,
+            check_dtype=False,
+        )
+    else:
+        assert_features_and_length_equal(X, y, X_output, y_output, error_dict)
+
+
 def test_ts_regularizer_init():
     ts_regularizer = TimeSeriesRegularizer(time_index="dates")
 
@@ -292,33 +322,7 @@ def test_ts_regularizer_duplicate(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
 
     error_dict = ts_regularizer.error_dict
-    if is_multiseries:
-        # put date column into the y dataframes for testing purposes
-        y["dates"] = X["dates"]
-        y_output["dates"] = X_output["dates"]
-
-        assert_features_and_length_equal(
-            X,
-            y,
-            X_output,
-            y_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-
-        # the function only really checks what's passed into "X" so passed in "y" as X in order to have it check y
-        assert_features_and_length_equal(
-            y,
-            X,
-            y_output,
-            X_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-    else:
-        assert_features_and_length_equal(X, y, X_output, y_output, error_dict)
+    check(is_multiseries, X, y, X_output, y_output, error_dict)
 
 
 @pytest.mark.parametrize("is_multiseries", [True, False])
@@ -355,30 +359,7 @@ def test_ts_regularizer_missing(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
 
     error_dict = ts_regularizer.error_dict
-    if is_multiseries:
-        y["dates"] = X["dates"]
-        y_output["dates"] = X_output["dates"]
-
-        assert_features_and_length_equal(
-            X,
-            y,
-            X_output,
-            y_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-        assert_features_and_length_equal(
-            y,
-            X,
-            y_output,
-            X_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-    else:
-        assert_features_and_length_equal(X, y, X_output, y_output, error_dict)
+    check(is_multiseries, X, y, X_output, y_output, error_dict)
 
 
 @pytest.mark.parametrize("is_multiseries", [True, False])
@@ -417,29 +398,8 @@ def test_ts_regularizer_uneven(
     X_output, y_output = ts_regularizer.fit_transform(X, y)
     error_dict = ts_regularizer.error_dict
 
-    if is_multiseries:
-        y["dates"] = X["dates"]
-        y_output["dates"] = X_output["dates"]
-
-        assert_features_and_length_equal(
-            X,
-            y,
-            X_output,
-            y_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-        assert_features_and_length_equal(
-            y,
-            X,
-            y_output,
-            X_output,
-            error_dict,
-            has_target=False,
-            check_dtype=False,
-        )
-    else:
+    check(is_multiseries, X, y, X_output, y_output, error_dict)
+    if not is_multiseries:
         if uneven_type == "beginning":
             assert X.iloc[0]["dates"] not in X_output["dates"]
             assert X.iloc[1]["dates"] not in X_output["dates"]
@@ -448,4 +408,3 @@ def test_ts_regularizer_uneven(
         elif uneven_type == "end":
             assert X.iloc[-1]["dates"] not in X_output["dates"]
             assert y.iloc[-1] not in y_output.values
-        assert_features_and_length_equal(X, y, X_output, y_output, error_dict)

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -1,4 +1,4 @@
-black==23.7.0
+black==23.9.1
 catboost==1.2.1
 category-encoders==2.5.1.post0
 click==8.1.7


### PR DESCRIPTION
### Pull Request Description
Extended time series regularizer to support multiseries
Closes #4304

### Example of what this does
Let's say you have an unstacked X:
 
<img width="583" alt="Screen Shot 2023-09-12 at 12 21 07 PM" src="https://github.com/alteryx/evalml/assets/56745347/cfe9fbac-6e65-4168-bceb-44619ed210a4">

Where "2018-01-11", "2018-01-12" and "2018-01-16" are missing.


And you have an unstacked y:
<img width="400" alt="Screen Shot 2023-09-12 at 12 23 18 PM" src="https://github.com/alteryx/evalml/assets/56745347/74d6de2e-5684-4d0f-8a86-66b65314aea5">

Which is missing the values that correspond to the missing dates from X_unstacked (values jumps from 49 -> 60 and 74 -> 80).

If you call TimeSeriesRegularizer on X and y:
<img width="423" alt="Screen Shot 2023-09-12 at 12 25 37 PM" src="https://github.com/alteryx/evalml/assets/56745347/295f551c-36b9-4757-8ec9-e0c1e887b0cd">

y will now regularize into:

<img width="401" alt="Screen Shot 2023-09-13 at 12 39 02 PM" src="https://github.com/alteryx/evalml/assets/56745347/d4996b97-e110-4868-8371-8da782bf2758">

Works also for duplicate datetimes, extra datetimes, and misaligned datetimes.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
