### PR TITLE
Make LightGBM not verbose

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,6 +10,7 @@ Release Notes
     * Fixes
     * Changes
     * Documentation Changes
+        * Removed LightGBM's excessive amount of warnings :pr:`4308`
     * Testing Changes
 
 .. warning::

--- a/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
+++ b/evalml/pipelines/components/estimators/classifiers/lightgbm_classifier.py
@@ -108,6 +108,7 @@ class LightGBMClassifier(Estimator):
             "n_jobs": n_jobs,
             "bagging_freq": bagging_freq,
             "bagging_fraction": bagging_fraction,
+            "verbose": -1,
         }
         parameters.update(kwargs)
         lg_parameters = copy.copy(parameters)

--- a/evalml/tests/component_tests/test_components.py
+++ b/evalml/tests/component_tests/test_components.py
@@ -492,6 +492,7 @@ def test_describe_component():
             "n_jobs": -1,
             "bagging_fraction": 0.9,
             "bagging_freq": 0,
+            "verbose": -1,
         },
     }
     assert lg_regressor.describe(return_dict=True) == {


### PR DESCRIPTION
### Pull Request Description
Closes #4307

Whenever you run `automl.search()`, LightGBM really likes to say the same warning over and over again.

For example, in the start page of the documentation for EvalML even if you set `verbose=False`:
<img width="243" alt="Screen Shot 2023-09-14 at 11 56 37 AM" src="https://github.com/alteryx/evalml/assets/56745347/94efbd4e-4998-422f-bce0-77111ef89cef">

the output has this:

<img width="920" alt="Screen Shot 2023-09-14 at 11 44 09 AM" src="https://github.com/alteryx/evalml/assets/56745347/0c4dd4c3-ea70-4e09-97fb-2da4aacf9551">
This continues for like 70 more lines.

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
