### PR TITLE
Increased minimum numpy version

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -24,7 +24,7 @@ outputs:
         - pip
         - setuptools ==58.0.4
       run:
-        - numpy >=1.21.0
+        - numpy >=1.22.0
         - pandas >=1.5.0, <2.1.0
         - dask >=2022.2.0, !=2022.10.1
         - scipy >=1.5.0

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,7 @@ Release Notes
     * Changes
         * Updated ``split_data`` to call ``split_multiseries_data`` when passed stacked multiseries data :pr:`4312`
         * Pinned pandas version under 2.1.0 :pr:`4315`
+        * Increased minimum numpy version :pr:`4321`
     * Documentation Changes
         * Removed LightGBM's excessive amount of warnings :pr:`4308`
     * Testing Changes

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -17,7 +17,7 @@ lime==0.2.0.1
 matplotlib==3.3.3
 networkx==2.6
 nlp-primitives==2.9.0
-numpy==1.21.0
+numpy==1.22.0
 packaging==23.0
 pandas==1.5.0
 plotly==5.0.0

--- a/evalml/tests/dependency_update_check/minimum_test_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_test_requirements.txt
@@ -21,7 +21,7 @@ matplotlib==3.3.3
 nbval==0.9.3
 networkx==2.6
 nlp-primitives==2.9.0
-numpy==1.21.0
+numpy==1.22.0
 packaging==23.0
 pandas==1.5.0
 plotly==5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["data science", "machine learning", "optimization", "automl"]
 license = {file = "LICENSE"}
 requires-python = ">=3.8,<4"
 dependencies = [
-    "numpy >= 1.21.0",
+    "numpy >= 1.22.0",
     "pandas >= 1.5.0, < 2.1.0",
     "scipy >= 1.5.0",
     "scikit-learn >= 1.3.0",


### PR DESCRIPTION
Currently, we are erroring out on install as numba requires numpy 1.22. This PR bumps up the minimum version of numpy to satisfy this.  

Resolves #4322