### PR TITLE
Release v0.81.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.81.0 Oct 3, 2023**
+    * Enhancements
         * Extended STLDecomposer to support multiseries :pr:`4253`
         * Extended TimeSeriesImputer to support multiseries :pr:`4291`
         * Added datacheck to check for mismatched series length in multiseries :pr:`4296`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,7 +12,7 @@ Release Notes
     **Breaking Changes**
 
 
-**v0.81.0 Oct 3, 2023**
+**v0.81.0 Oct 5, 2023**
     * Enhancements
         * Extended STLDecomposer to support multiseries :pr:`4253`
         * Extended TimeSeriesImputer to support multiseries :pr:`4291`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.80.0"
+__version__ = "0.81.0"


### PR DESCRIPTION
### Pull Request Description
    * Enhancements
        * Extended STLDecomposer to support multiseries :pr:`4253`
        * Extended TimeSeriesImputer to support multiseries :pr:`4291`
        * Added datacheck to check for mismatched series length in multiseries :pr:`4296`
        * Added STLDecomposer to multiseries pipelines :pr:`4299`
        * Extended DateTimeFormatCheck data check to support multiseries :pr:`4300`
        * Extended TimeSeriesRegularizer to support multiseries :pr:`4303`
    * Fixes
        * Fixed forecast period generation function for multiseries :pr:`4320`
        * Fixed bug in ``STLDecomposer.inverse_transform`` causing incorrect seasonality projections :pr:`4328`
    * Changes
        * Updated ``split_data`` to call ``split_multiseries_data`` when passed stacked multiseries data :pr:`4312`
        * Pinned pandas version under 2.1.0 :pr:`4315`
        * Increased minimum numpy version :pr:`4321`
    * Documentation Changes
        * Removed LightGBM's excessive amount of warnings :pr:`4308`
    * Testing Changes
        * Removed old performance testing workflow :pr:`4318`

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
