### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,5 +18,4 @@ jobs:
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
         TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
-      with:
-        tag_name: ${{ github.event.release.tag_name }}
+        TAG_NAME: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,5 @@ jobs:
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
         TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      with:
+        tag_name: ${{ github.event.release.tag_name }}

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-         * Fixed bug related to pypi release #4330
+         * Fixed bug related to pypi release :pr:`4330`
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,7 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
-      * Fixed bug related to pypi release #4330
+         * Fixed bug related to pypi release #4330
     * Changes
     * Documentation Changes
     * Testing Changes

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,6 +3,7 @@ Release Notes
 **Future Releases**
     * Enhancements
     * Fixes
+      * Fixed bug related to pypi release #4330
     * Changes
     * Documentation Changes
     * Testing Changes


### PR DESCRIPTION
### Pull Request Description
Closes #4331

$GITHUB_REF is empty so trying to use 
`$ {{ github.event.release.tag_name }}`

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
