### PR TITLE
release

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,13 +2,25 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.82.0 Nov 3, 2023**
+    * Enhancements
         * Changed target name/series ID divider and added ability to return series ID column with predictions :pr:`4357`
     * Fixes
     * Changes
         * Pinned networkx version below 3.2 for Python version compatibility :pr:`4351`
     * Documentation Changes
         * Added multiseries time series section to user guide in documentation :pr:`4355`
-      * Updated release guide to include an FAQ section about fixing github actions :pr:`4346`
+        * Updated release guide to include an FAQ section about fixing github actions :pr:`4346`
     * Testing Changes
 
 .. warning::

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.81.1"
+__version__ = "0.82.0"


### PR DESCRIPTION
## v0.82.0 Nov. 3, 2023

Enhancements
 * Changed target name/series ID divider and added ability to return series ID column with predictions #4357

Fixes

Changes
 * Pinned networkx version below 3.2 for Python version compatibility #4351

Documentation Changes
 * Added multiseries time series section to user guide in documentation #4355
 * Updated release guide to include an FAQ section about fixing github actions #4346

Testing Changes

Breaking Changes

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
