### PR TITLE
updated upload-artifact@v2 to v3

### DIFF
--- a/.github/workflows/linux_integration_tests.yaml
+++ b/.github/workflows/linux_integration_tests.yaml
@@ -48,7 +48,7 @@ jobs:
           source test_python/bin/activate
           make ${{matrix.command}}
       - name: Upload pytest duration artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-duration-report
           path: test-reports/${{matrix.command}}-junit.xml

--- a/.github/workflows/linux_unit_tests_with_latest_deps.yaml
+++ b/.github/workflows/linux_unit_tests_with_latest_deps.yaml
@@ -67,7 +67,7 @@ jobs:
           source test_python/bin/activate
           make ${{matrix.command}}
       - name: Upload pytest duration artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-duration-report
           path: test-reports/${{matrix.command}}-junit.xml


### PR DESCRIPTION
### Pull Request Description
gets rid of the warnings that happen during some actions because of node12 being deprecated 

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
