### PR TITLE
xgboost 1.7.0 to 1.7.0.post0

### DIFF
--- a/.github/meta.yaml
+++ b/.github/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - matplotlib-base >=3.3.3
         - seaborn >=0.11.1
         - ipywidgets >=7.5
-        - xgboost >=1.7.0
+        - xgboost >=1.7.0.post0
         - catboost >=1.1.1
         - lightgbm >=4.0.0
         - lime >=0.2.0.1

--- a/evalml/tests/dependency_update_check/latest_dependency_versions.txt
+++ b/evalml/tests/dependency_update_check/latest_dependency_versions.txt
@@ -31,7 +31,7 @@ seaborn==0.13.0
 shap==0.44.0
 sktime==0.24.1
 statsmodels==0.14.1
-texttable==1.7.0
+texttable==1.7.0.post0
 tomli==2.0.1
 vowpalwabbit==9.9.0
 woodwork==0.27.0

--- a/evalml/tests/dependency_update_check/minimum_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_requirements.txt
@@ -34,4 +34,4 @@ texttable==1.6.2
 tomli==2.0.1
 vowpalwabbit==8.11.0
 woodwork[dask]==0.22.0
-xgboost==1.7.0
+xgboost==1.7.0.post0

--- a/evalml/tests/dependency_update_check/minimum_test_requirements.txt
+++ b/evalml/tests/dependency_update_check/minimum_test_requirements.txt
@@ -42,4 +42,4 @@ texttable==1.6.2
 tomli==2.0.1
 vowpalwabbit==8.11.0
 woodwork[dask]==0.22.0
-xgboost==1.7.0
+xgboost==1.7.0.post0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "plotly >= 5.0.0",
     "kaleido == 0.1.0",
     "ipywidgets >= 7.5",
-    "xgboost >= 1.7.0",
+    "xgboost >= 1.7.0.post0",
     "catboost >= 1.1.1",
     "lightgbm >= 4.0.0",
     "matplotlib >= 3.3.3",


### PR DESCRIPTION
### Pull Request Description
Github actions is being weird and doesn't know what xgboost 1.7.0 is. Apparently it is actually `1.7.0.post0` because of the reason below (not sure when this change was implemented but it's only causing errors for evalml now).

> Note. The source distribution of Python XGBoost 1.7.0 was defective (https://github.com/dmlc/xgboost/issues/8415). Since PyPI does not allow us to replace existing artifacts, we released 1.7.0.post0 version to upload the new source distribution. Everything in 1.7.0.post0 is identical to 1.7.0 otherwise.

https://github.com/dmlc/xgboost/releases/tag/v1.7.0

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
