### PR TITLE
release_v0.83.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,18 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+
+
+**v0.83.0 Feb 2, 2024**
+    * Enhancements
         * Added support for additional estimators for multiseries datasets :pr:`4385`
     * Fixes
         * Fixed bug in `_downcast_nullable_y` causing woodwork initialization issues :pr:`4369`

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -23,4 +23,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.82.0"
+__version__ = "0.83.0"


### PR DESCRIPTION
### Pull Request Description
# v0.83.0 Feb. 2, 2024
### Enhancements
- Added support for additional estimators for multiseries datasets #4385
### Fixes
- Fixed bug in `_downcast_nullable_y` causing woodwork initialization issues #4369
- Fixed multiseries prediction interval labels #4377
### Changes
- Pinned scipy version to under 1.12.0 #4380
### Documentation Changes
### Testing Changes
### Breaking Changes

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
