### PR TITLE
Release v0.84.0

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,6 +2,20 @@ Release Notes
 -------------
 **Future Releases**
     * Enhancements
+    * Fixes
+    * Changes
+    * Documentation Changes
+    * Testing Changes
+
+.. warning::
+
+    **Breaking Changes**
+        * Dropped support for Python 3.8 :pr:`4414`
+        * Removed vowpalwabbit :pr:`4427`
+
+
+**v0.84.0 Jun 6, 2024**
+    * Enhancements
         * Reformatted files with updated black version :pr:`4395`
     * Fixes
         * Fixed token issues related to pypi release github action failing :pr:`4446`

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -10,8 +10,6 @@ Release Notes
 .. warning::
 
     **Breaking Changes**
-        * Dropped support for Python 3.8 :pr:`4414`
-        * Removed vowpalwabbit :pr:`4427`
 
 
 **v0.84.0 Jun 6, 2024**

--- a/evalml/__init__.py
+++ b/evalml/__init__.py
@@ -24,4 +24,4 @@ with warnings.catch_warnings():
 warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-__version__ = "0.83.0"
+__version__ = "0.84.0"


### PR DESCRIPTION
### Pull Request Description
Note: the earlier v0.84.0 failed because of a pypi token error, which prevented this update from going live on pypi. That release has been yanked and replaced by this one, which includes a fix to that pypi error.

# v0.84.0 Jun. 4, 2024
### Enhancements
- Reformatted files with updated black version #4395
### Fixes
- Fixed token issues related to pypi release github action failing :pr:`4446`
### Changes
- Dropped support for Python 3.8 #4414
- Removed vowpalwabbit #4427
- Uncapped holidays #4428
- Unpinned kaleido #4423
- Unpinned shap and scipy #4436
- Unpinned most pinned dependencies under project.optional-dependencies #4431
### Documentation Changes
### Testing Changes
- Added ability to run airflow tests in Python 3.9 #4391
- Removed iterative test from airflow runs #4424
- Updated GH actions to improve handling of potentially unsafe variables #4417
- Fixed install test #4423
### Breaking Changes
- Dropped support for Python 3.8 #4414
- Removed vowpalwabbit #4427

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
